### PR TITLE
Package operator binary into distroless image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.*
+Makefile
+OWNERS
+README.md
+
+api/
+build/
+deployments/
+githooks/
+assets/
+docs/
+githooks/
+docs/
+examples/
+githooks/
+vendor/
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,8 @@
-.*
-Makefile
-OWNERS
+.idea/
+.github/
+
 README.md
 
-api/
-build/
-deployments/
-githooks/
-assets/
-docs/
-githooks/
 docs/
 examples/
-githooks/
-vendor/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 
 # Run all the test cases before build.
 # TODO: uncomment this when this issue is resolved: https://github.com/StarRocks/starrocks-kubernetes-operator/issues/37
-#RUN go test ./... -v
+# RUN make test
 
 # Build the binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/sroperator cmd/main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,8 @@ FROM golang:1.19 as build
 WORKDIR /go/src/app
 COPY . .
 
-# Get dependancies
-RUN go mod download
-
 # Run all the test cases before build.
-# TODO: uncomment this when this issue is resolved: https://github.com/StarRocks/starrocks-kubernetes-operator/issues/37
-# RUN make test
+RUN make test
 
 # Build the binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/sroperator cmd/main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY . .
 # Get dependancies
 RUN go mod download
 
-# Run all the test cases before build
+# Run all the test cases before build.
+# TODO: uncomment this when this issue is resolved: https://github.com/StarRocks/starrocks-kubernetes-operator/issues/37
 #RUN go test ./... -v
 
 # Build the binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,23 @@
-FROM ubuntu:22.04
+# Docker file for building and packaing the operator.
+#
+# Run the following command from the root dir of the git repo:
+#   > DOCKER_BUILDKIT=1 docker build -t starrocks/operator:tag .
 
-ADD /bin/sroperator /sroperator
+FROM golang:1.19 as build
 
-CMD ["/sroperator"]
+WORKDIR /go/src/app
+COPY . .
+
+# Get dependancies
+RUN go mod download
+
+# Run all the test cases before build
+#RUN go test ./... -v
+
+# Build the binary
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/sroperator cmd/main.go
+
+FROM gcr.io/distroless/static-debian11
+
+COPY --from=build /app/sroperator /app/sroperator
+CMD ["/app/sroperator"]

--- a/README.md
+++ b/README.md
@@ -18,15 +18,25 @@ This Kubernetes Operator is able to deploy StarRocks' Front End (FE), Back End (
 ## （Optional) Build the operator images by yourself
 Get the official operator image from [here](https://hub.docker.com/r/starrocks/centos-operator/tags).
 
+### Build starrocks operator docker image
 Follow below instructions if you want to build your own image.
 
+```
+DOCKER_BUILDKIT=1 docker build -t starrocks-kubernetes-operator/operator:<tag> .
+```
+E.g.
 ```bash
-# under root directory, compile operator
-make build 
-# build docker image
-make docker IMG="xxx"
-# push image to docker hub
-make push IMG="xxx"
+DOCKER_BUILDKIT=1 docker build -t starrocks-kubernetes-operator/operator:latest .
+```
+
+### Publish starrocks operator docker image
+```
+docker push ghcr.io/OWNER/starrocks-kubernetes-operator/operator:latest
+```
+E.g. 
+Publish image to ghcr 
+```shell
+docker push ghcr.io/dengliu/starrocks-kubernetes-operator/operator:latest
 ```
 
 ## Install Operator in kubernetes


### PR DESCRIPTION
## Context
For micro-service k8s deployment, tt's preferred to use [distroless](https://github.com/GoogleContainerTools/distroless)  as it's much smaller in terms of size and has less vulnerabilities. 
(Ref: [centos vulnerability report ](https://snyk.io/test/docker/centos%3A7))

## Changes
- User [docker multi-stage build](https://docs.docker.com/build/building/multi-stage/) to build binary in a hermetic environment
- Package operator binary into distroless image
- Added instructions for building and publishing docker image
## Test
- Build the image with both distroless and centos and compares side-by-side
```
$ docker image ls
REPOSITORY                  TAG       IMAGE ID       CREATED        SIZE
starrocks/operator       centos   dd9ff6dc9389   5 seconds ago     253MB
starrocks/operator   distroless   976cfe591ce8   8 hours ago      51.4MB
```
- Demo to publish docker image to my personal repo
https://github.com/dengliu/starrocks-kubernetes-operator
https://github.com/users/dengliu/packages/container/package/starrocks-kubernetes-operator%2Foperator
![image](https://user-images.githubusercontent.com/5108773/216240524-35d44445-2355-4fcd-9dda-0e590de21947.png)


