### PR TITLE
在部署starrocks时，增加初始化密码的能力。

### DIFF
--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
@@ -7,6 +7,7 @@ data:
   fe_initpwd.sh: |-
     #!/bin/bash
 
+<<<<<<< HEAD
     # ensure `mysql` command can be ended with 30 seconds
     # Change the root password during initial installation
     success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$3" 2>&1`
@@ -30,4 +31,26 @@ data:
 
     echo "Successfully modified password"
     exit 0
+=======
+    # ensure `mysql` command can be ended with 15 seconds
+    # Change the root password during initial installation
+    success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$3" 2>&1`
+
+    if [ $? != 0 ] ; then
+    echo $success
+    errcode=`echo $success | awk -F " " '{print $2}'`
+    echo $errcode
+
+    # Password error, believed to have been changed, exiting normally
+    if [ $errcode = '1045' ] ; then
+    exit 0
+    fi
+
+    # connect unsuccessful, abnormal exit
+    if [ $errcode = '2003' ]  ; then
+    exit 1
+    fi
+
+    fi
+>>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功
 

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
@@ -7,8 +7,6 @@ data:
   fe_initpwd.sh: |-
     #!/bin/bash
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     # ensure `mysql` command can be ended with 30 seconds
     # Change the root password during initial installation
     success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$3" 2>&1`
@@ -32,36 +30,4 @@ data:
 
     echo "Successfully modified password"
     exit 0
-=======
-    # ensure `mysql` command can be ended with 15 seconds
-=======
-    # ensure `mysql` command can be ended with 30 seconds
->>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
-    # Change the root password during initial installation
-    success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$3" 2>&1`
-  
-    if [ $? -ne 0 ] ; then
-      echo $success
-      errcode=`echo $success | awk -F " " '{print $2}'`
-      echo "error code: $errcode"
-
-      # Password error, believed to have been changed, exiting normally
-      if [[ $errcode = '1045' || $errcode = '1064' ]] ; then
-        echo "Password error, believed to have been changed, exiting normally"
-        exit 0
-      fi
-
-      # Other unsuccessful errors, abnormal exit
-      echo "Other unsuccessful errors, abnormal exit"
-      exit 1
-
-    fi
-
-<<<<<<< HEAD
-    fi
->>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功
-=======
-    echo "Successfully modified password"
-    exit 0
->>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
 

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: init-pwd-shell
+  namespace: {{ .Release.Namespace }}
+data:
+  fe_initpwd.sh: |-
+    #!/bin/bash
+
+    # ensure `mysql` command can be ended with 30 seconds
+    # Change the root password during initial installation
+    success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$3" 2>&1`
+  
+    if [ $? -ne 0 ] ; then
+      echo $success
+      errcode=`echo $success | awk -F " " '{print $2}'`
+      echo "error code: $errcode"
+
+      # Password error, believed to have been changed, exiting normally
+      if [[ $errcode = '1045' || $errcode = '1064' ]] ; then
+        echo "Password error, believed to have been changed, exiting normally"
+        exit 0
+      fi
+
+      # Other unsuccessful errors, abnormal exit
+      echo "Other unsuccessful errors, abnormal exit"
+      exit 1
+
+    fi
+
+    echo "Successfully modified password"
+    exit 0
+

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
@@ -8,6 +8,7 @@ data:
     #!/bin/bash
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     # ensure `mysql` command can be ended with 30 seconds
     # Change the root password during initial installation
     success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$3" 2>&1`
@@ -33,24 +34,34 @@ data:
     exit 0
 =======
     # ensure `mysql` command can be ended with 15 seconds
+=======
+    # ensure `mysql` command can be ended with 30 seconds
+>>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
     # Change the root password during initial installation
     success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$3" 2>&1`
+  
+    if [ $? -ne 0 ] ; then
+      echo $success
+      errcode=`echo $success | awk -F " " '{print $2}'`
+      echo "error code: $errcode"
 
-    if [ $? != 0 ] ; then
-    echo $success
-    errcode=`echo $success | awk -F " " '{print $2}'`
-    echo $errcode
+      # Password error, believed to have been changed, exiting normally
+      if [[ $errcode = '1045' || $errcode = '1064' ]] ; then
+        echo "Password error, believed to have been changed, exiting normally"
+        exit 0
+      fi
 
-    # Password error, believed to have been changed, exiting normally
-    if [ $errcode = '1045' ] ; then
-    exit 0
+      # Other unsuccessful errors, abnormal exit
+      echo "Other unsuccessful errors, abnormal exit"
+      exit 1
+
     fi
 
-    # connect unsuccessful, abnormal exit
-    if [ $errcode = '2003' ]  ; then
-    exit 1
-    fi
-
+<<<<<<< HEAD
     fi
 >>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功
+=======
+    echo "Successfully modified password"
+    exit 0
+>>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
 

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
@@ -10,8 +10,8 @@ data:
 
     # ensure `mysql` command can be ended with 30 seconds
     # Change the root password during initial installation
-    success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$3" 2>&1`
-  
+    init_pwd_sql="SET PASSWORD = PASSWORD('$INIT_PWD');"
+    success=`mysql --connect-timeout 30 -h $1 -P $2 -u root --skip-column-names --batch -e "$init_pwd_sql" 2>&1`
     if [ $? -ne 0 ] ; then
       echo $success
       errcode=`echo $success | awk -F " " '{print $2}'`

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.initPassword.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,3 +32,4 @@ data:
     echo "Successfully modified password"
     exit 0
 
+{{- end }}

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
@@ -4,8 +4,8 @@ kind: Secret
 metadata:
   name: {{ template "kube-starrocks.name" . }}-credential
   namespace: {{ .Release.Namespace }}
-stringData:
-  password: {{ .Values.initPassword.password }}
+data:
+  password: {{ .Values.initPassword.password | b64enc }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
@@ -26,10 +26,6 @@ spec:
         - /opt/starrocks/fe_initpwd.sh
         - {{ template "kube-starrocks.name" . }}-fe-0.{{ template "kube-starrocks.name" . }}-fe-search
         - "9030"
-<<<<<<< HEAD
-<<<<<<< HEAD:helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
-=======
->>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
         - "SET PASSWORD = PASSWORD(''$INIT_PWD'');"
         env:
         - name: INIT_PWD
@@ -37,12 +33,6 @@ spec:
             secretKeyRef:
               key: password
               name: {{ template "kube-starrocks.name" . }}-credential
-<<<<<<< HEAD
-=======
-        - "SET PASSWORD = PASSWORD('{{ .Values.initPassword.password }}');"
->>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功:helm-charts/charts/kube-starrocks/templates/init-pwd/initpwd.yaml
-=======
->>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
         volumeMounts:
         - mountPath: /opt/starrocks/fe_initpwd.sh
           name: fe-initpwd-shell
@@ -56,13 +46,6 @@ spec:
           name: init-pwd-shell
           optional: false
         name: fe-initpwd-shell
-<<<<<<< HEAD
-<<<<<<< HEAD:helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
-=======
-
->>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功:helm-charts/charts/kube-starrocks/templates/init-pwd/initpwd.yaml
-=======
->>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
       restartPolicy: OnFailure
   backoffLimit: 10
 {{- end }}

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
@@ -1,0 +1,51 @@
+
+{{- if .Values.initPassword.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kube-starrocks.name" . }}-credential
+  namespace: {{ .Release.Namespace }}
+stringData:
+  password: {{ .Values.initPassword.password }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: starrocks-initpwd
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{ template "kube-starrocks.name" . }}-initpwd
+        image: {{ .Values.starrocksFESpec.image.repository }}:{{ .Values.starrocksFESpec.image.tag }}
+        imagePullPolicy: Always
+        command:
+        - /bin/bash
+        args:
+        - /opt/starrocks/fe_initpwd.sh
+        - {{ template "kube-starrocks.name" . }}-fe-0.{{ template "kube-starrocks.name" . }}-fe-search
+        - "9030"
+        - "SET PASSWORD = PASSWORD(''$INIT_PWD'');"
+        env:
+        - name: INIT_PWD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: {{ template "kube-starrocks.name" . }}-credential
+        volumeMounts:
+        - mountPath: /opt/starrocks/fe_initpwd.sh
+          name: fe-initpwd-shell
+          subPath: fe_initpwd.sh
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+            - key: fe_initpwd.sh
+              path: fe_initpwd.sh
+          name: init-pwd-shell
+          optional: false
+        name: fe-initpwd-shell
+      restartPolicy: OnFailure
+  backoffLimit: 10
+{{- end }}

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
@@ -26,6 +26,7 @@ spec:
         - /opt/starrocks/fe_initpwd.sh
         - {{ template "kube-starrocks.name" . }}-fe-0.{{ template "kube-starrocks.name" . }}-fe-search
         - "9030"
+<<<<<<< HEAD:helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
         - "SET PASSWORD = PASSWORD(''$INIT_PWD'');"
         env:
         - name: INIT_PWD
@@ -33,6 +34,9 @@ spec:
             secretKeyRef:
               key: password
               name: {{ template "kube-starrocks.name" . }}-credential
+=======
+        - "SET PASSWORD = PASSWORD('{{ .Values.initPassword.password }}');"
+>>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功:helm-charts/charts/kube-starrocks/templates/init-pwd/initpwd.yaml
         volumeMounts:
         - mountPath: /opt/starrocks/fe_initpwd.sh
           name: fe-initpwd-shell
@@ -46,6 +50,10 @@ spec:
           name: init-pwd-shell
           optional: false
         name: fe-initpwd-shell
+<<<<<<< HEAD:helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+=======
+
+>>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功:helm-charts/charts/kube-starrocks/templates/init-pwd/initpwd.yaml
       restartPolicy: OnFailure
   backoffLimit: 10
 {{- end }}

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
@@ -25,7 +25,6 @@ spec:
         - /opt/starrocks/fe_initpwd.sh
         - {{ template "kube-starrocks.name" . }}-fe-0.{{ template "kube-starrocks.name" . }}-fe-search
         - "9030"
-        - "SET PASSWORD = PASSWORD(''$INIT_PWD'');"
         env:
         - name: INIT_PWD
           valueFrom:

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
@@ -1,4 +1,3 @@
-
 {{- if .Values.initPassword.enabled }}
 apiVersion: v1
 kind: Secret

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
@@ -26,7 +26,10 @@ spec:
         - /opt/starrocks/fe_initpwd.sh
         - {{ template "kube-starrocks.name" . }}-fe-0.{{ template "kube-starrocks.name" . }}-fe-search
         - "9030"
+<<<<<<< HEAD
 <<<<<<< HEAD:helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+=======
+>>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
         - "SET PASSWORD = PASSWORD(''$INIT_PWD'');"
         env:
         - name: INIT_PWD
@@ -34,9 +37,12 @@ spec:
             secretKeyRef:
               key: password
               name: {{ template "kube-starrocks.name" . }}-credential
+<<<<<<< HEAD
 =======
         - "SET PASSWORD = PASSWORD('{{ .Values.initPassword.password }}');"
 >>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功:helm-charts/charts/kube-starrocks/templates/init-pwd/initpwd.yaml
+=======
+>>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
         volumeMounts:
         - mountPath: /opt/starrocks/fe_initpwd.sh
           name: fe-initpwd-shell
@@ -50,10 +56,13 @@ spec:
           name: init-pwd-shell
           optional: false
         name: fe-initpwd-shell
+<<<<<<< HEAD
 <<<<<<< HEAD:helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
 =======
 
 >>>>>>> 2c3afa7... 在初始化密码时，增加状态判断能力，当链接不通时才进行重试，当发现时密码错误时，认为上一次尝试修改密码已成功:helm-charts/charts/kube-starrocks/templates/init-pwd/initpwd.yaml
+=======
+>>>>>>> 38a7399... 修改密码时，引用secret传入初始化密码，重新整理了脚本缩进，规范了部分写法
       restartPolicy: OnFailure
   backoffLimit: 10
 {{- end }}

--- a/helm-charts/charts/kube-starrocks/templates/starrocks/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/starrocks/starrockscluster.yaml
@@ -59,6 +59,14 @@ spec:
     feEnvVars:
 {{ toYaml .Values.starrocksFESpec.feEnvVars | indent 4 }}
 {{- end }}
+{{- if .Values.initPassword.enabled }}
+    feEnvVars: 
+      - name: "MYSQL_PWD"
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "kube-starrocks.name" . }}-credential
+            key: password
+{{- end }}
 {{- if .Values.starrocksFESpec.affinity }}
     affinity:
 {{ toYaml .Values.starrocksFESpec.affinity | indent 6 }}
@@ -148,6 +156,14 @@ spec:
     beEnvVars:
 {{ toYaml .Values.starrocksBeSpec.beEnvVars | indent 4 }}
 {{- end }}
+{{- if .Values.initPassword.enabled }}
+    beEnvVars: 
+      - name: "MYSQL_PWD"
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "kube-starrocks.name" . }}-credential
+            key: password
+{{- end }}
 {{- if .Values.starrocksBeSpec.affinity }}
     affinity:
 {{ toYaml .Values.starrocksBeSpec.affinity | indent 6 }}
@@ -214,6 +230,14 @@ spec:
 {{- if .Values.starrocksCnSpec.cnEnvVars }}
     cnEnvVars:
 {{ toYaml .Values.starrocksCnSpec.cnEnvVars | indent 4 }}
+{{- end }}
+{{- if .Values.initPassword.enabled }}
+    cnEnvVars: 
+      - name: "MYSQL_PWD"
+        valueFrom:
+          secretKeyRef:
+            name: {{ template "kube-starrocks.name" . }}-credential
+            key: password
 {{- end }}
 {{- if .Values.starrocksCnSpec.affinity }}
     affinity:

--- a/helm-charts/charts/kube-starrocks/templates/starrocks/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/starrocks/starrockscluster.yaml
@@ -57,7 +57,7 @@ spec:
 {{- end }}
 {{- if or .Values.starrocksFESpec.feEnvVars .Values.initPassword.enabled }}
     feEnvVars:
-{{- if .Values.initPassword.enabled }}
+{{- if and .Values.initPassword.enabled .Values.starrocksFESpec.feEnvVars | toJson | contains "MYSQL_PWD" | not }}
       - name: "MYSQL_PWD"
         valueFrom:
           secretKeyRef:
@@ -156,7 +156,7 @@ spec:
 {{- end }}
 {{- if or .Values.starrocksBeSpec.beEnvVars .Values.initPassword.enabled }}
     beEnvVars:
-{{- if .Values.initPassword.enabled }}
+{{- if and .Values.initPassword.enabled .Values.starrocksBeSpec.beEnvVars | toJson | contains "MYSQL_PWD" | not }}
       - name: "MYSQL_PWD"
         valueFrom:
           secretKeyRef:
@@ -233,7 +233,7 @@ spec:
 {{- end }}
 {{- if or .Values.starrocksCnSpec.cnEnvVars .Values.initPassword.enabled }}
     cnEnvVars:
-{{- if .Values.initPassword.enabled }}
+{{- if and .Values.initPassword.enabled .Values.starrocksCnSpec.cnEnvVars | toJson | contains "MYSQL_PWD" | not }}
       - name: "MYSQL_PWD"
         valueFrom:
           secretKeyRef:

--- a/helm-charts/charts/kube-starrocks/templates/starrocks/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/starrocks/starrockscluster.yaml
@@ -55,18 +55,20 @@ spec:
 {{- if .Values.starrocksFESpec.schedulerName }}
     schedulerName: {{ .Values.starrocksFESpec.schedulerName }}
 {{- end }}
-{{- if .Values.starrocksFESpec.feEnvVars }}
+{{- if or .Values.starrocksFESpec.feEnvVars .Values.initPassword.enabled }}
     feEnvVars:
-{{ toYaml .Values.starrocksFESpec.feEnvVars | indent 4 }}
-{{- end }}
 {{- if .Values.initPassword.enabled }}
-    feEnvVars: 
       - name: "MYSQL_PWD"
         valueFrom:
           secretKeyRef:
             name: {{ template "kube-starrocks.name" . }}-credential
             key: password
 {{- end }}
+{{- if .Values.starrocksFESpec.feEnvVars }}
+{{ toYaml .Values.starrocksFESpec.feEnvVars | indent 4 }}
+{{- end }}
+{{- end }}
+
 {{- if .Values.starrocksFESpec.affinity }}
     affinity:
 {{ toYaml .Values.starrocksFESpec.affinity | indent 6 }}
@@ -152,18 +154,20 @@ spec:
     nodeSelector:
 {{ toYaml .Values.starrocksBeSpec.nodeSelector | indent 6 }}
 {{- end }}
-{{- if .Values.starrocksBeSpec.beEnvVars }}
+{{- if or .Values.starrocksBeSpec.beEnvVars .Values.initPassword.enabled }}
     beEnvVars:
-{{ toYaml .Values.starrocksBeSpec.beEnvVars | indent 4 }}
-{{- end }}
 {{- if .Values.initPassword.enabled }}
-    beEnvVars: 
       - name: "MYSQL_PWD"
         valueFrom:
           secretKeyRef:
             name: {{ template "kube-starrocks.name" . }}-credential
             key: password
 {{- end }}
+{{- if .Values.starrocksBeSpec.beEnvVars }}
+{{ toYaml .Values.starrocksBeSpec.beEnvVars | indent 4 }}
+{{- end }}
+{{- end }}
+
 {{- if .Values.starrocksBeSpec.affinity }}
     affinity:
 {{ toYaml .Values.starrocksBeSpec.affinity | indent 6 }}
@@ -227,17 +231,18 @@ spec:
     nodeSelector:
 {{ toYaml .Values.starrocksCnSpec.nodeSelector | indent 6 }}
 {{- end }}
-{{- if .Values.starrocksCnSpec.cnEnvVars }}
+{{- if or .Values.starrocksCnSpec.cnEnvVars .Values.initPassword.enabled }}
     cnEnvVars:
-{{ toYaml .Values.starrocksCnSpec.cnEnvVars | indent 4 }}
-{{- end }}
 {{- if .Values.initPassword.enabled }}
-    cnEnvVars: 
       - name: "MYSQL_PWD"
         valueFrom:
           secretKeyRef:
             name: {{ template "kube-starrocks.name" . }}-credential
             key: password
+{{- end }}
+{{- if .Values.starrocksCnSpec.cnEnvVars }}
+{{ toYaml .Values.starrocksCnSpec.cnEnvVars | indent 4 }}
+{{- end }}
 {{- end }}
 {{- if .Values.starrocksCnSpec.affinity }}
     affinity:

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -14,6 +14,10 @@ global:
 
 # the starrockscluster crd' name.
 nameOverride: ""
+# the starrocks password
+initPassword:
+  enabled: false
+  password: ""
 
 starrocksOperator:
   enabled: true

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -14,7 +14,8 @@ global:
 
 # the starrockscluster crd' name.
 nameOverride: ""
-# the starrocks password
+# This configuration is used to modify the root password during initial deployment.
+# After deployment is completed, modify the password here and upgrade, does not modify the running root password
 initPassword:
   enabled: false
   password: ""


### PR DESCRIPTION
在部署starrocks时，增加配置初始化密码的能力。在部署时，可以设置：
```
initPassword: 
    enabled: true
    password: "password"
```
设置此参数后，部署时会提交一个job，尝试修改fe-0的密码，同时，fe、be、cn会自动添加环境变量：
```
      - name: "MYSQL_PWD"
        valueFrom:
          secretKeyRef:
            name: {{ template "kube-starrocks.name" . }}-credential
            key: password
```
按照以上配置完成starrocks的部署时，root账号的初始化密码会被修改为指定值。