### PR TITLE
Modify the execution time of the job to only execute the job when executing 'helm install'. 

### DIFF
--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initPassword.enabled }}
+{{- if and .Values.initPassword.enabled .Release.IsInstall }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/templates/init-pwd/job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.initPassword.enabled }}
+{{- if and .Values.initPassword.enabled .Release.IsInstall }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Fix issue #183: Modify the execution time of the job to only execute the job when executing 'help install'. 