### PR TITLE
[Bugfix] support k8s env which has no status.hostIP field

### DIFF
--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -227,12 +227,6 @@ func Envs(spec v1.SpecInterface, config map[string]interface{}, feExternalServic
 			},
 		},
 		{
-			Name: "HOST_IP",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
-			},
-		},
-		{
 			Name: "POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},

--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -15,7 +15,9 @@
 package pod
 
 import (
+	"os"
 	"strconv"
+	"strings"
 
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/common/hash"
@@ -206,8 +208,16 @@ func Envs(spec v1.SpecInterface, config map[string]interface{}, feExternalServic
 		keys[env.Name] = true
 	}
 
+	unsupport_envs := make(map[string]bool)
+	if unsupport_envs_str := os.Getenv("KUBE_STARROCKS_UNSUPPORTED_ENVS"); unsupport_envs_str != "" {
+		unsupport_envs_slice := strings.Split(unsupport_envs_str, ",")
+		for _, name := range unsupport_envs_slice {
+			unsupport_envs[name] = true
+		}
+	}
+
 	addEnv := func(envVar corev1.EnvVar) {
-		if !keys[envVar.Name] {
+		if !keys[envVar.Name] && !unsupport_envs[envVar.Name] {
 			keys[envVar.Name] = true
 			envs = append(envs, envVar)
 		}
@@ -224,6 +234,12 @@ func Envs(spec v1.SpecInterface, config map[string]interface{}, feExternalServic
 			Name: "POD_IP",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+			},
+		},
+		{
+			Name: "HOST_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
 			},
 		},
 		{

--- a/pkg/k8sutils/templates/pod/spec_test.go
+++ b/pkg/k8sutils/templates/pod/spec_test.go
@@ -506,12 +506,6 @@ func TestEnvs(t *testing.T) {
 			},
 		},
 		{
-			Name: "HOST_IP",
-			ValueFrom: &corev1.EnvVarSource{
-				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
-			},
-		},
-		{
 			Name: "POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},

--- a/pkg/k8sutils/templates/pod/spec_test.go
+++ b/pkg/k8sutils/templates/pod/spec_test.go
@@ -16,6 +16,7 @@ package pod
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -492,6 +493,25 @@ func TestLabels(t *testing.T) {
 }
 
 func TestEnvs(t *testing.T) {
+	envs_without_ip := []corev1.EnvVar{
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		},
+		{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+			},
+		},
+		{
+			Name:  "HOST_TYPE",
+			Value: "FQDN",
+		},
+	}
+
 	envs := []corev1.EnvVar{
 		{
 			Name: "POD_NAME",
@@ -530,9 +550,10 @@ func TestEnvs(t *testing.T) {
 		config      map[string]interface{}
 	}
 	tests := []struct {
-		name string
-		args args
-		want []corev1.EnvVar
+		name           string
+		args           args
+		want           []corev1.EnvVar
+		unsupport_envs string
 	}{
 		{
 			name: "test envs for fe",
@@ -551,6 +572,7 @@ func TestEnvs(t *testing.T) {
 					Value: service.ExternalServiceName("test", &v1.StarRocksFeSpec{}) + "." + "ns",
 				},
 			}...),
+			unsupport_envs: "",
 		},
 		{
 			name: "test envs for be",
@@ -573,6 +595,7 @@ func TestEnvs(t *testing.T) {
 					Value: fmt.Sprintf("%v", rutils.DefMap[rutils.QUERY_PORT]),
 				},
 			}...),
+			unsupport_envs: "",
 		},
 		{
 			name: "test envs for cn",
@@ -595,11 +618,39 @@ func TestEnvs(t *testing.T) {
 					Value: fmt.Sprintf("%v", rutils.DefMap[rutils.QUERY_PORT]),
 				},
 			}...),
+			unsupport_envs: "",
+		},
+		{
+			name: "test envs for be with unsupport envs",
+			args: args{
+				clusterName: "test",
+				namespace:   "ns",
+				spec:        &v1.StarRocksBeSpec{},
+			},
+			want: append(append([]corev1.EnvVar(nil), envs_without_ip...), []corev1.EnvVar{
+				{
+					Name:  v1.COMPONENT_NAME,
+					Value: v1.DEFAULT_BE,
+				},
+				{
+					Name:  v1.FE_SERVICE_NAME,
+					Value: service.ExternalServiceName("test", &v1.StarRocksFeSpec{}),
+				},
+				{
+					Name:  "FE_QUERY_PORT",
+					Value: fmt.Sprintf("%v", rutils.DefMap[rutils.QUERY_PORT]),
+				},
+			}...),
+			unsupport_envs: "HOST_IP,POD_IP",
 		},
 	}
 	for _, tt := range tests {
 		feExternalServiceName := service.ExternalServiceName("test", &v1.StarRocksFeSpec{})
 		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("KUBE_STARROCKS_UNSUPPORTED_ENVS", tt.unsupport_envs)
+			defer func() {
+				os.Setenv("KUBE_STARROCKS_UNSUPPORTED_ENVS", "")
+			}()
 			got := Envs(tt.args.spec, tt.args.config, feExternalServiceName, tt.args.namespace, nil)
 			if len(got) != len(tt.want) {
 				t.Errorf("Envs() = %v, want %v", got, tt.want)

--- a/pkg/k8sutils/templates/pod/spec_test.go
+++ b/pkg/k8sutils/templates/pod/spec_test.go
@@ -506,6 +506,12 @@ func TestEnvs(t *testing.T) {
 			},
 		},
 		{
+			Name: "HOST_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+			},
+		},
+		{
 			Name: "POD_NAMESPACE",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},


### PR DESCRIPTION
In some serverless k8s env ,there is no status.hostIP field, and we do not use hostIp in StarRocks， so remove it.