### PR TITLE
[Bugfix] remove chart function kube-starrocks.name

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/_helpers.tpl
@@ -9,6 +9,6 @@ The default service account name to use for the operator.
 {{- default .Release.Namespace .Values.starrocksOperator.namespaceOverride }}
 {{- end }}
 
-{{- define "kube-starrocks.name" -}}
+{{- define "operator.name" -}}
 {{- default .Chart.Name .Values.nameOverride -}}
 {{- end }}

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/clusterrole.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/clusterrole.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "kube-starrocks.name" . }}-operator
+  name: {{ template "operator.name" . }}-operator
   labels:
-    app: {{ template "kube-starrocks.name" . }}-operator
+    app: {{ template "operator.name" . }}-operator
 rules:
 - apiGroups:
   - apps

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/clusterrolebinding.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/clusterrolebinding.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "kube-starrocks.name" . }}-operator
+  name: {{ template "operator.name" . }}-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "kube-starrocks.name" . }}-operator
+  name: {{ template "operator.name" . }}-operator
 subjects:
 - kind: ServiceAccount
   name: {{ template  "operator.serviceAccountName" . }}

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -2,10 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "kube-starrocks.name" . }}-operator
+  name: {{ template "operator.name" . }}-operator
   namespace: {{ template "operator.namespace" . }}
   labels:
-    app: {{ template "kube-starrocks.name" . }}-operator
+    app: {{ template "operator.name" . }}-operator
   {{- if .Values.starrocksOperator.annotations }}
   annotations:
     {{- toYaml .Values.starrocksOperator.annotations | nindent 4 }}
@@ -13,7 +13,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "kube-starrocks.name" . }}-operator
+      app: {{ template "operator.name" . }}-operator
   replicas: {{ .Values.starrocksOperator.replicaCount }}
   template:
     metadata:
@@ -23,7 +23,7 @@ spec:
         {{- toYaml .Values.starrocksOperator.annotations | nindent 8 }}
       {{- end }}
       labels:
-        app: {{ template "kube-starrocks.name" . }}-operator
+        app: {{ template "operator.name" . }}-operator
         version: {{ $.Chart.Version }}
     spec:
       automountServiceAccountToken: true

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -1,11 +1,4 @@
 {{/*
-Expand the name of the chart.
-*/}}
-{{- define "kube-starrocks.name" -}}
-{{- default .Chart.Name .Values.nameOverride -}}
-{{- end }}
-
-{{/*
 Common labels
 */}}
 {{- define "starrockscluster.labels" -}}
@@ -18,7 +11,7 @@ initpassword secret name
 */}}
 
 {{- define "starrockscluster.initpassword.secret.name" -}}
-{{ default (print (include "kube-starrocks.name" .) "-credential") .Values.initPassword.passwordSecret }}
+{{ default (print (include "starrockscluster.name" .) "-credential") .Values.initPassword.passwordSecret }}
 {{- end }}
 
 {{/*
@@ -26,7 +19,7 @@ starrockscluster
 */}}
 
 {{- define "starrockscluster.name" -}}
-{{ default (include "kube-starrocks.name" .) .Values.starrocksCluster.name }}
+{{ default (default .Chart.Name .Values.nameOverride) .Values.starrocksCluster.name }}
 {{- end }}
 
 {{- define "starrockscluster.namespace" -}}
@@ -34,15 +27,15 @@ starrockscluster
 {{- end }}
 
 {{- define "starrockscluster.fe.name" -}}
-{{- print (include "kube-starrocks.name" .) "-fe" }}
+{{- print (include "starrockscluster.name" .) "-fe" }}
 {{- end }}
 
 {{- define "starrockscluster.cn.name" -}}
-{{- print (include "kube-starrocks.name" .) "-cn" }}
+{{- print (include "starrockscluster.name" .) "-cn" }}
 {{- end }}
 
 {{- define "starrockscluster.be.name" -}}
-{{- print (include "kube-starrocks.name" .) "-be" }}
+{{- print (include "starrockscluster.name" .) "-be" }}
 {{- end }}
 
 {{- define "starrockscluster.be.configmap.name" -}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/beconfigmap.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/beconfigmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template  "starrockscluster.be.configmap.name" . }}
   namespace: {{ template "starrockscluster.namespace" . }}
   labels:
-    cluster: {{ template "kube-starrocks.name" . }}
+    cluster: {{ template "starrockscluster.name" . }}
     app: "be"
 data:
 {{ include "starrocksclster.be.config" . | indent 2 }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/cnconfigmap.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/cnconfigmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "starrockscluster.cn.configmap.name" . }}
   namespace: {{ template "starrockscluster.namespace" . }}
   labels:
-    cluster: {{ template "kube-starrocks.name" . }}
+    cluster: {{ template "starrockscluster.name" . }}
     app: "cn"
 data:
 {{ include "starrockscluster.cn.config" . | indent 2 }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/feconfigmap.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/feconfigmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "starrockscluster.fe.configmap.name" . }}
   namespace: {{ template "starrockscluster.namespace" . }}
   labels:
-    cluster: {{ template "kube-starrocks.name" . }}
+    cluster: {{ template "starrockscluster.name" . }}
     app: "fe"
 data:
 {{ include "starrockscluster.fe.config" . | indent 2 }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -8,14 +8,14 @@ spec:
   template:
     spec:
       containers:
-      - name: {{ template "kube-starrocks.name" . }}-initpwd
+      - name: {{ template "starrockscluster.name" . }}-initpwd
         image: {{ .Values.starrocksFESpec.image.repository }}:{{ .Values.starrocksFESpec.image.tag }}
         imagePullPolicy: Always
         command:
         - /bin/bash
         args:
         - /opt/starrocks/fe_initpwd.sh
-        - {{ template "kube-starrocks.name" . }}-fe-0.{{ template "kube-starrocks.name" . }}-fe-search
+        - {{ template "starrockscluster.name" . }}-fe-0.{{ template "starrockscluster.name" . }}-fe-search
         - "9030"
         env:
         - name: INIT_PWD

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -41,7 +41,7 @@ metrics:
 
 # deploy a starrocks cluster
 starrocksCluster:
-  # the name of starrockscluster cluster, if not set, the chart name will be used.
+  # the name of starrockscluster cluster, if not set, the value of nameOverride fields will be used.
   name: ""
   # the namespace of starrockscluster cluster, if not set, the release namespace will be used.
   namespace: ""

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -113,7 +113,7 @@ starrocks:
   
   # deploy a starrocks cluster
   starrocksCluster:
-    # the name of starrockscluster cluster, if not set, the chart name will be used.
+    # the name of starrockscluster cluster, if not set, the value of nameOverride fields will be used.
     name: ""
     # the namespace of starrockscluster cluster, if not set, the release namespace will be used.
     namespace: ""


### PR DESCRIPTION
Fixes: #275 

If starrocks.initPassword.enabled is true, and the value of starrocks.starrocksCluster.name is set, it will cause an issue. When the value starrocks.starrocksCluster.name is set, the service hostname will follows while the hostname inside the initpwd still using the chart name.