### PR TITLE
[Enhancement] disable FE scale to 1

### DIFF
--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -95,7 +95,7 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 	st := statefulset.MakeStatefulset(object.NewFromCluster(src), beSpec, podTemplateSpec)
 
 	// update the statefulset if feSpec be updated.
-	if err = k8sutils.ApplyStatefulSet(ctx, be.Client, &st, func(new *appv1.StatefulSet, actual *appv1.StatefulSet) bool {
+	if err = k8sutils.ApplyStatefulSet(ctx, be.Client, &st, true, func(new *appv1.StatefulSet, actual *appv1.StatefulSet) bool {
 		return rutils.StatefulSetDeepEqual(new, actual, false)
 	}); err != nil {
 		logger.Error(err, "apply statefulset failed")

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -148,13 +148,15 @@ func (cc *CnController) SyncCnSpec(ctx context.Context, object object.StarRocksO
 		return err
 	}
 	sts := statefulset.MakeStatefulset(object, cnSpec, *podTemplateSpec)
-	if err = k8sutils.ApplyStatefulSet(ctx, cc.k8sClient, &sts, func(expect *appv1.StatefulSet, actual *appv1.StatefulSet) bool {
-		if expect.Spec.Replicas == nil {
-			return rutils.StatefulSetDeepEqual(expect, actual, true)
-		} else {
-			return rutils.StatefulSetDeepEqual(expect, actual, false)
-		}
-	}); err != nil {
+	if err = k8sutils.ApplyStatefulSet(ctx, cc.k8sClient, &sts, true,
+		func(expect *appv1.StatefulSet, actual *appv1.StatefulSet) bool {
+			if expect.Spec.Replicas == nil {
+				return rutils.StatefulSetDeepEqual(expect, actual, true)
+			} else {
+				return rutils.StatefulSetDeepEqual(expect, actual, false)
+			}
+		},
+	); err != nil {
 		return err
 	}
 

--- a/pkg/subcontrollers/fe/fe_controller.go
+++ b/pkg/subcontrollers/fe/fe_controller.go
@@ -89,7 +89,7 @@ func (fc *FeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 	// first deploy statefulset for compatible v1.5, apply statefulset for update pod.
 	podTemplateSpec := fc.buildPodTemplate(src, config)
 	st := statefulset.MakeStatefulset(object, feSpec, podTemplateSpec)
-	if err = k8sutils.ApplyStatefulSet(ctx, fc.Client, &st, func(new *appv1.StatefulSet, actual *appv1.StatefulSet) bool {
+	if err = k8sutils.ApplyStatefulSet(ctx, fc.Client, &st, false, func(new *appv1.StatefulSet, actual *appv1.StatefulSet) bool {
 		return rutils.StatefulSetDeepEqual(new, actual, false)
 	}); err != nil {
 		logger.Error(err, "deploy statefulset failed")


### PR DESCRIPTION
If scale to 1, Operator will report an error. 

```
k get starrocksclusters.starrocks.com kube-starrocks
NAME             PHASE    FESTATUS   BESTATUS   CNSTATUS   FEPROXYSTATUS
kube-starrocks   failed   running               running

k get starrocksclusters.starrocks.com kube-starrocks -oyaml | grep reason
reason: 'error from FE controller: the replicas of statefulset kube-starrocks-fe can not be scaled to 1'
```