### PR TITLE
Issue401/expose security capabilities

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -1035,6 +1035,24 @@ spec:
                       - name
                       type: object
                     type: array
+                  capabilities:
+                    description: refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
+                      grant certain privileges to a process without granting all the
+                      privileges of the root user
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                    type: object
                   configMapInfo:
                     description: the reference for configMap which store the config
                       info to start starrocks. e.g. be.conf, fe.conf, cn.conf.
@@ -2901,6 +2919,24 @@ spec:
                         type: string
                     required:
                     - maxReplicas
+                    type: object
+                  capabilities:
+                    description: refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
+                      grant certain privileges to a process without granting all the
+                      privileges of the root user
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
                     type: object
                   cnEnvVars:
                     description: cnEnvVars is a slice of environment variables that
@@ -5311,6 +5347,24 @@ spec:
                       type: string
                     description: annotation for pods. user can config monitor annotation
                       for collect to monitor system.
+                    type: object
+                  capabilities:
+                    description: refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
+                      grant certain privileges to a process without granting all the
+                      privileges of the root user
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
                     type: object
                   configMapInfo:
                     description: the reference for configMap which store the config

--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -1595,6 +1595,24 @@ spec:
                     required:
                     - maxReplicas
                     type: object
+                  capabilities:
+                    description: refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
+                      grant certain privileges to a process without granting all the
+                      privileges of the root user
+                    properties:
+                      add:
+                        description: Added capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                      drop:
+                        description: Removed capabilities
+                        items:
+                          description: Capability represent POSIX capabilities type
+                          type: string
+                        type: array
+                    type: object
                   configMapInfo:
                     description: the reference for configMap which store the config
                       info to start starrocks. e.g. be.conf, fe.conf, cn.conf.

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -467,6 +467,17 @@ spec:
                       - name
                       type: object
                     type: array
+                  capabilities:
+                    properties:
+                      add:
+                        items:
+                          type: string
+                        type: array
+                      drop:
+                        items:
+                          type: string
+                        type: array
+                    type: object
                   configMapInfo:
                     properties:
                       configMapName:
@@ -1315,6 +1326,17 @@ spec:
                         type: string
                     required:
                     - maxReplicas
+                    type: object
+                  capabilities:
+                    properties:
+                      add:
+                        items:
+                          type: string
+                        type: array
+                      drop:
+                        items:
+                          type: string
+                        type: array
                     type: object
                   cnEnvVars:
                     items:
@@ -2381,6 +2403,17 @@ spec:
                   annotations:
                     additionalProperties:
                       type: string
+                    type: object
+                  capabilities:
+                    properties:
+                      add:
+                        items:
+                          type: string
+                        type: array
+                      drop:
+                        items:
+                          type: string
+                        type: array
                     type: object
                   configMapInfo:
                     properties:

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -726,6 +726,17 @@ spec:
                     required:
                     - maxReplicas
                     type: object
+                  capabilities:
+                    properties:
+                      add:
+                        items:
+                          type: string
+                        type: array
+                      drop:
+                        items:
+                          type: string
+                        type: array
+                    type: object
                   configMapInfo:
                     properties:
                       configMapName:

--- a/pkg/apis/starrocks/v1/component_type.go
+++ b/pkg/apis/starrocks/v1/component_type.go
@@ -26,6 +26,11 @@ type StarRocksComponentSpec struct {
 	// default: nil
 	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty"`
 
+	// refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container
+	// grant certain privileges to a process without granting all the privileges of the root user
+	// +optional
+	Capabilities *corev1.Capabilities `json:"capabilities,omitempty"`
+
 	// the reference for configMap which allow users to mount any files to container.
 	// +optional
 	ConfigMaps []ConfigMapReference `json:"configMaps,omitempty"`
@@ -124,4 +129,8 @@ func (spec *StarRocksComponentSpec) GetTerminationGracePeriodSeconds() *int64 {
 		return &defaultSeconds
 	}
 	return spec.TerminationGracePeriodSeconds
+}
+
+func (spec *StarRocksComponentSpec) GetCapabilities() *corev1.Capabilities {
+	return spec.Capabilities
 }

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -72,6 +72,7 @@ type SpecInterface interface {
 	GetHostAliases() []corev1.HostAlias
 	GetRunAsNonRoot() (*int64, *int64)
 	GetTerminationGracePeriodSeconds() *int64
+	GetCapabilities() *corev1.Capabilities
 }
 
 var _ SpecInterface = &StarRocksFeSpec{}
@@ -191,6 +192,9 @@ func (spec *StarRocksFeProxySpec) GetRunAsNonRoot() (*int64, *int64) {
 func (spec *StarRocksFeProxySpec) GetTerminationGracePeriodSeconds() *int64 {
 	return nil
 }
+
+// fe proxy does not have field Capabilities
+func (spec *StarRocksFeProxySpec) GetCapabilities() *corev1.Capabilities { return nil }
 
 // Phase is defined under status, e.g.
 // 1. StarRocksClusterStatus.Phase represents the phase of starrocks cluster.

--- a/pkg/apis/starrocks/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/starrocks/v1/zz_generated.deepcopy.go
@@ -376,6 +376,11 @@ func (in *StarRocksComponentSpec) DeepCopyInto(out *StarRocksComponentSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Capabilities != nil {
+		in, out := &in.Capabilities, &out.Capabilities
+		*out = new(corev1.Capabilities)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ConfigMaps != nil {
 		in, out := &in.ConfigMaps, &out.ConfigMaps
 		*out = make([]ConfigMapReference, len(*in))

--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -294,5 +294,7 @@ func ContainerSecurityContext(spec v1.SpecInterface) *corev1.SecurityContext {
 		AllowPrivilegeEscalation: func() *bool { b := false; return &b }(),
 		// starrocks will create pid file, eg.g /opt/starrocks/fe/bin/fe.pid, so set it to false
 		ReadOnlyRootFilesystem: func() *bool { b := false; return &b }(),
+		// set additional Capabilities
+		Capabilities: spec.GetCapabilities(),
 	}
 }


### PR DESCRIPTION
This PR adds the function required by [Issue-401](https://github.com/StarRocks/starrocks-kubernetes-operator/issues/401). 

It expose `Capabilities` in `StarRocksComponentSpec` which is required for Datadog profiling integration. Some unit tests are added to verify it.

```
go test -mod=mod ./pkg/k8sutils/templates/pod/...
```

cc @yandongxiao 