### PR TITLE
Support imagePullSecrets for init-pwd,operator and fe-proxy

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         version: {{ $.Chart.Version }}
     spec:
       automountServiceAccountToken: true
+    {{- if .Values.starrocksOperator.imagePullSecrets }}
+      imagePullSecrets:
+    {{- toYaml .Values.starrocksOperator.imagePullSecrets | nindent 6 }}
+    {{- end }}
       containers:
       - command:
         - /sroperator
@@ -70,6 +74,10 @@ spec:
       {{- if .Values.starrocksOperator.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.starrocksOperator.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.starrocksOperator.affinity }}
+      affinity:
+        {{- toYaml .Values.starrocksOperator.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.starrocksOperator.tolerations }}
       tolerations:

--- a/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
@@ -42,6 +42,9 @@ starrocksOperator:
     requests:
       cpu: 500m
       memory: 400Mi
+  # imagePullSecrets allows you to use secrets to pull images for pods.
+  imagePullSecrets: [ ]
+  # - name: "image-pull-secret"
   # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -6,6 +6,14 @@ metadata:
   namespace: {{ template "starrockscluster.namespace" . }}
 spec:
   template:
+  {{- if .Values.starrocksFESpec.imagePullSecrets }}
+  imagePullSecrets:
+  {{- toYaml .Values.starrocksFESpec.imagePullSecrets | nindent 6 }}
+  {{- end }}
+  {{- if .Values.starrocksFESpec.affinity }}
+  affinity:
+  {{- toYaml .Values.starrocksFESpec.affinity | nindent 8 }}
+  {{- end }}
     spec:
       containers:
       - name: {{ template "starrockscluster.name" . }}-initpwd

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -498,6 +498,10 @@ spec:
     {{- if .Values.starrocksFeProxySpec.image.repository }}
     image: "{{ .Values.starrocksFeProxySpec.image.repository }}:{{ .Values.starrocksFeProxySpec.image.tag }}"
     {{- end }}
+    {{- if .Values.starrocksFeProxySpec.imagePullSecrets }}
+    imagePullSecrets:
+    {{- toYaml .Values.starrocksFeProxySpec.imagePullSecrets | nindent 4 }}
+    {{- end }}
     replicas: {{ .Values.starrocksFeProxySpec.replicas }}
     resolver: {{ .Values.starrocksFeProxySpec.resolver }}
     {{- if .Values.starrocksFeProxySpec.resources }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -599,6 +599,9 @@ starrocksFeProxySpec:
       #   nodePort: 30080 # The range of valid ports is 30000-32767
       #   containerPort: 8080 # The port on the container to expose
       #   port: 8080 # The port to expose on the service
+  # imagePullSecrets allows you to use secrets for pulling images for your pods.
+  imagePullSecrets: [ ]
+  # - name: "image-pull-secret"
   # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -679,6 +679,9 @@ starrocks:
         #   nodePort: 30080 # The range of valid ports is 30000-32767
         #   containerPort: 8080 # The port on the container to expose
         #   port: 8080 # The port to expose on the service
+    # imagePullSecrets allows you to use secrets for pulling images for your pods.
+    imagePullSecrets: [ ]
+    # - name: "image-pull-secret"
     # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector: {}


### PR DESCRIPTION
# Description

The image for the components "operator" and "fe-proxy" may need to be pulled from a private registry. To achieve this, add the configuration item imagePullSecrets. 
Reuse the configurations for the "init-pwd" job from the "FE" component, including starrocksFESpec.affinity and starrocksFESpec.imagePullSecrets.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
