### PR TITLE
Add imagePullSecrets and affinity fields for some helm charts

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         version: {{ $.Chart.Version }}
     spec:
       automountServiceAccountToken: true
+    {{- if .Values.starrocksOperator.imagePullSecrets }}
+      imagePullSecrets:
+    {{- toYaml .Values.starrocksOperator.imagePullSecrets | nindent 6 }}
+    {{- end }}
       containers:
       - command:
         - /sroperator
@@ -70,6 +74,10 @@ spec:
       {{- if .Values.starrocksOperator.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.starrocksOperator.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.starrocksOperator.affinity }}
+      affinity:
+        {{- toYaml .Values.starrocksOperator.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.starrocksOperator.tolerations }}
       tolerations:

--- a/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
@@ -42,9 +42,22 @@ starrocksOperator:
     requests:
       cpu: 500m
       memory: 400Mi
+  # imagePullSecrets allows you to use secrets to pull images for pods.
+  imagePullSecrets: [ ]
+  # - name: "image-pull-secret"
   # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}
+  # affinity for fe pod scheduling.
+  affinity: {}
+    # nodeAffinity:
+    #   requiredDuringSchedulingIgnoredDuringExecution:
+    #     nodeSelectorTerms:
+    #     - matchFields:
+    #       - key: metadata.name
+    #         operator: In
+    #         values:
+    #         - target-host-name
   tolerations: []
     # - key: "key"
     #   operator: "Equal|Exists"

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -7,6 +7,14 @@ metadata:
 spec:
   template:
     spec:
+  {{- if .Values.starrocksFESpec.imagePullSecrets }}
+      imagePullSecrets:
+  {{- toYaml .Values.starrocksFESpec.imagePullSecrets | nindent 6 }}
+  {{- end }}
+  {{- if .Values.starrocksFESpec.affinity }}
+      affinity:
+  {{- toYaml .Values.starrocksFESpec.affinity | nindent 8 }}
+  {{- end }}
       containers:
       - name: {{ template "starrockscluster.name" . }}-initpwd
         image: {{ .Values.starrocksFESpec.image.repository }}:{{ .Values.starrocksFESpec.image.tag }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -498,6 +498,10 @@ spec:
     {{- if .Values.starrocksFeProxySpec.image.repository }}
     image: "{{ .Values.starrocksFeProxySpec.image.repository }}:{{ .Values.starrocksFeProxySpec.image.tag }}"
     {{- end }}
+    {{- if .Values.starrocksFeProxySpec.imagePullSecrets }}
+    imagePullSecrets:
+    {{- toYaml .Values.starrocksFeProxySpec.imagePullSecrets | nindent 4 }}
+    {{- end }}
     replicas: {{ .Values.starrocksFeProxySpec.replicas }}
     resolver: {{ .Values.starrocksFeProxySpec.resolver }}
     {{- if .Values.starrocksFeProxySpec.resources }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -599,6 +599,9 @@ starrocksFeProxySpec:
       #   nodePort: 30080 # The range of valid ports is 30000-32767
       #   containerPort: 8080 # The port on the container to expose
       #   port: 8080 # The port to expose on the service
+  # imagePullSecrets allows you to use secrets for pulling images for your pods.
+  imagePullSecrets: [ ]
+  # - name: "image-pull-secret"
   # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -49,9 +49,22 @@ operator:
       requests:
         cpu: 500m
         memory: 400Mi
+    # imagePullSecrets allows you to use secrets to pull images for pods.
+    imagePullSecrets: [ ]
+    # - name: "image-pull-secret"
     # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector: {}
+    # affinity for fe pod scheduling.
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #     - matchFields:
+      #       - key: metadata.name
+      #         operator: In
+      #         values:
+      #         - target-host-name
     tolerations: []
       # - key: "key"
       #   operator: "Equal|Exists"
@@ -679,6 +692,9 @@ starrocks:
         #   nodePort: 30080 # The range of valid ports is 30000-32767
         #   containerPort: 8080 # The port on the container to expose
         #   port: 8080 # The port to expose on the service
+    # imagePullSecrets allows you to use secrets for pulling images for your pods.
+    imagePullSecrets: [ ]
+    # - name: "image-pull-secret"
     # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector: {}


### PR DESCRIPTION
# Description
Enhance the Helm charts with the following updates:
1.starrocksOperator add the imagePullSecrets and affinity fields.
2.fe-proxy add the imagePullSecrets field.
3.init-pwd job reuse the "FE" field, including both the affinity and imagePullSecrets fields.

# Related Issue(s)

# Checklist
- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
