### PR TITLE
[Enhancement] Define some default values uniformly

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -240,3 +240,332 @@ the first 8 digits are taken, which will be used as the annotations for pods.
 {{- end }}
 {{- end }}
 
+{{/*
+Get the value of the schedulerName field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.schedulerName" -}}
+{{- if .Values.starrocksFESpec.schedulerName -}}
+{{- .Values.starrocksFESpec.schedulerName -}}
+{{- else if .Values.starrocksCluster.componentValues.schedulerName -}}
+{{- .Values.starrocksCluster.componentValues.schedulerName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the schedulerName field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.schedulerName" -}}
+{{- if .Values.starrocksBeSpec.schedulerName -}}
+{{- .Values.starrocksBeSpec.schedulerName -}}
+{{- else if .Values.starrocksCluster.componentValues.schedulerName -}}
+{{- .Values.starrocksCluster.componentValues.schedulerName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the schedulerName field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.schedulerName" -}}
+{{- if .Values.starrocksCnSpec.schedulerName -}}
+{{- .Values.starrocksCnSpec.schedulerName -}}
+{{- else if .Values.starrocksCluster.componentValues.schedulerName -}}
+{{- .Values.starrocksCluster.componentValues.schedulerName -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the serviceAccount field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.serviceAccount" -}}
+{{- if .Values.starrocksFESpec.serviceAccount -}}
+{{- .Values.starrocksFESpec.serviceAccount -}}
+{{- else if .Values.starrocksCluster.componentValues.serviceAccount -}}
+{{- .Values.starrocksCluster.componentValues.serviceAccount -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the serviceAccount field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.serviceAccount" -}}
+{{- if .Values.starrocksBeSpec.serviceAccount -}}
+{{- .Values.starrocksBeSpec.serviceAccount -}}
+{{- else if .Values.starrocksCluster.componentValues.serviceAccount -}}
+{{- .Values.starrocksCluster.componentValues.serviceAccount -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the serviceAccount field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.serviceAccount" -}}
+{{- if .Values.starrocksCnSpec.serviceAccount -}}
+{{- .Values.starrocksCnSpec.serviceAccount -}}
+{{- else if .Values.starrocksCluster.componentValues.serviceAccount -}}
+{{- .Values.starrocksCluster.componentValues.serviceAccount -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the imagePullSecrets field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.imagePullSecrets" -}}
+{{- if .Values.starrocksFESpec.imagePullSecrets -}}
+{{- toYaml .Values.starrocksFESpec.imagePullSecrets -}}
+{{- else if .Values.starrocksCluster.componentValues.imagePullSecrets -}}
+{{- toYaml .Values.starrocksCluster.componentValues.imagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the imagePullSecrets field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.imagePullSecrets" -}}
+{{- if .Values.starrocksBeSpec.imagePullSecrets -}}
+{{- toYaml .Values.starrocksBeSpec.imagePullSecrets -}}
+{{- else if .Values.starrocksCluster.componentValues.imagePullSecrets -}}
+{{- toYaml .Values.starrocksCluster.componentValues.imagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the imagePullSecrets field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.imagePullSecrets" -}}
+{{- if .Values.starrocksCnSpec.imagePullSecrets -}}
+{{- toYaml .Values.starrocksCnSpec.imagePullSecrets -}}
+{{- else if .Values.starrocksCluster.componentValues.imagePullSecrets -}}
+{{- toYaml .Values.starrocksCluster.componentValues.imagePullSecrets -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the tolerations field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.tolerations" -}}
+{{- if .Values.starrocksFESpec.tolerations -}}
+{{- toYaml .Values.starrocksFESpec.tolerations -}}
+{{- else if .Values.starrocksCluster.componentValues.tolerations -}}
+{{- toYaml .Values.starrocksCluster.componentValues.tolerations -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the tolerations field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.tolerations" -}}
+{{- if .Values.starrocksBeSpec.tolerations -}}
+{{- toYaml .Values.starrocksBeSpec.tolerations -}}
+{{- else if .Values.starrocksCluster.componentValues.tolerations -}}
+{{- toYaml .Values.starrocksCluster.componentValues.tolerations -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the tolerations field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.tolerations" -}}
+{{- if .Values.starrocksCnSpec.tolerations -}}
+{{- toYaml .Values.starrocksCnSpec.tolerations -}}
+{{- else if .Values.starrocksCluster.componentValues.tolerations -}}
+{{- toYaml .Values.starrocksCluster.componentValues.tolerations -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the nodeSelector field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.nodeSelector" -}}
+{{- if .Values.starrocksFESpec.nodeSelector -}}
+{{- toYaml .Values.starrocksFESpec.nodeSelector -}}
+{{- else if .Values.starrocksCluster.componentValues.nodeSelector -}}
+{{- toYaml .Values.starrocksCluster.componentValues.nodeSelector -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the nodeSelector field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.nodeSelector" -}}
+{{- if .Values.starrocksBeSpec.nodeSelector -}}
+{{- toYaml .Values.starrocksBeSpec.nodeSelector -}}
+{{- else if .Values.starrocksCluster.componentValues.nodeSelector -}}
+{{- toYaml .Values.starrocksCluster.componentValues.nodeSelector -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the nodeSelector field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.nodeSelector" -}}
+{{- if .Values.starrocksCnSpec.nodeSelector -}}
+{{- toYaml .Values.starrocksCnSpec.nodeSelector -}}
+{{- else if .Values.starrocksCluster.componentValues.nodeSelector -}}
+{{- toYaml .Values.starrocksCluster.componentValues.nodeSelector -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the affinity field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.affinity" -}}
+{{- if .Values.starrocksFESpec.affinity -}}
+{{- toYaml .Values.starrocksFESpec.affinity -}}
+{{- else if .Values.starrocksCluster.componentValues.affinity -}}
+{{- toYaml .Values.starrocksCluster.componentValues.affinity -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the affinity field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.affinity" -}}
+{{- if .Values.starrocksBeSpec.affinity -}}
+{{- toYaml .Values.starrocksBeSpec.affinity -}}
+{{- else if .Values.starrocksCluster.componentValues.affinity -}}
+{{- toYaml .Values.starrocksCluster.componentValues.affinity -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the affinity field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.affinity" -}}
+{{- if .Values.starrocksCnSpec.affinity -}}
+{{- toYaml .Values.starrocksCnSpec.affinity -}}
+{{- else if .Values.starrocksCluster.componentValues.affinity -}}
+{{- toYaml .Values.starrocksCluster.componentValues.affinity -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the runAsNonRoot field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.runAsNonRoot" -}}
+{{- if .Values.starrocksFESpec.runAsNonRoot -}}
+{{- .Values.starrocksFESpec.runAsNonRoot -}}
+{{- else if .Values.starrocksCluster.componentValues.runAsNonRoot -}}
+{{- .Values.starrocksCluster.componentValues.runAsNonRoot -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the runAsNonRoot field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.runAsNonRoot" -}}
+{{- if .Values.starrocksBeSpec.runAsNonRoot -}}
+{{- .Values.starrocksBeSpec.runAsNonRoot -}}
+{{- else if .Values.starrocksCluster.componentValues.runAsNonRoot -}}
+{{- .Values.starrocksCluster.componentValues.runAsNonRoot -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of the runAsNonRoot field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.runAsNonRoot" -}}
+{{- if .Values.starrocksCnSpec.runAsNonRoot -}}
+{{- .Values.starrocksCnSpec.runAsNonRoot -}}
+{{- else if .Values.starrocksCluster.componentValues.runAsNonRoot -}}
+{{- .Values.starrocksCluster.componentValues.runAsNonRoot -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of hostAliases field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.hostAliases" -}}
+{{- if .Values.starrocksFESpec.hostAliases -}}
+{{- toYaml .Values.starrocksFESpec.hostAliases -}}
+{{- else if .Values.starrocksCluster.componentValues.hostAliases -}}
+{{- toYaml .Values.starrocksCluster.componentValues.hostAliases -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of hostAliases field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.hostAliases" -}}
+{{- if .Values.starrocksBeSpec.hostAliases -}}
+{{- toYaml .Values.starrocksBeSpec.hostAliases -}}
+{{- else if .Values.starrocksCluster.componentValues.hostAliases -}}
+{{- toYaml .Values.starrocksCluster.componentValues.hostAliases -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of hostAliases field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.hostAliases" -}}
+{{- if .Values.starrocksCnSpec.hostAliases -}}
+{{- toYaml .Values.starrocksCnSpec.hostAliases -}}
+{{- else if .Values.starrocksCluster.componentValues.hostAliases -}}
+{{- toYaml .Values.starrocksCluster.componentValues.hostAliases -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of tag field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.image.tag" -}}
+{{- if .Values.starrocksFESpec.image.tag -}}
+{{- .Values.starrocksFESpec.image.tag -}}
+{{- else if .Values.starrocksCluster.componentValues.image.tag -}}
+{{- .Values.starrocksCluster.componentValues.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of tag field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.image.tag" -}}
+{{- if .Values.starrocksBeSpec.image.tag -}}
+{{- .Values.starrocksBeSpec.image.tag -}}
+{{- else if .Values.starrocksCluster.componentValues.image.tag -}}
+{{- .Values.starrocksCluster.componentValues.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of tag field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.image.tag" -}}
+{{- if .Values.starrocksCnSpec.image.tag -}}
+{{- .Values.starrocksCnSpec.image.tag -}}
+{{- else if .Values.starrocksCluster.componentValues.image.tag -}}
+{{- .Values.starrocksCluster.componentValues.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of podLabels field in the starrocksFESpec
+*/}}
+{{- define "starrockscluster.fe.podLabels" -}}
+{{- if .Values.starrocksFESpec.podLabels -}}
+{{- toYaml .Values.starrocksFESpec.podLabels -}}
+{{- else if .Values.starrocksCluster.componentValues.podLabels -}}
+{{- toYaml .Values.starrocksCluster.componentValues.podLabels -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of podLabels field in the starrocksBeSpec
+*/}}
+{{- define "starrockscluster.be.podLabels" -}}
+{{- if .Values.starrocksBeSpec.podLabels -}}
+{{- toYaml .Values.starrocksBeSpec.podLabels -}}
+{{- else if .Values.starrocksCluster.componentValues.podLabels -}}
+{{- toYaml .Values.starrocksCluster.componentValues.podLabels -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the value of podLabels field in the starrocksCnSpec
+*/}}
+{{- define "starrockscluster.cn.podLabels" -}}
+{{- if .Values.starrocksCnSpec.podLabels -}}
+{{- toYaml .Values.starrocksCnSpec.podLabels -}}
+{{- else if .Values.starrocksCluster.componentValues.podLabels -}}
+{{- toYaml .Values.starrocksCluster.componentValues.podLabels -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   starRocksFeSpec:
-    image: "{{ .Values.starrocksFESpec.image.repository }}:{{ .Values.starrocksFESpec.image.tag }}"
+    image: "{{ .Values.starrocksFESpec.image.repository }}:{{ include "starrockscluster.fe.image.tag" . }}"
     replicas: {{ .Values.starrocksFESpec.replicas }}
     {{- /*
     support both resources and resource for backward compatibility
@@ -56,29 +56,29 @@ spec:
 {{- if .Values.starrocksFESpec.annotations }}
 {{ toYaml .Values.starrocksFESpec.annotations | indent 6 }}
 {{- end }}
-{{- if .Values.starrocksFESpec.imagePullSecrets }}
+    {{- if or .Values.starrocksFESpec.imagePullSecrets .Values.starrocksCluster.componentValues.imagePullSecrets }}
     imagePullSecrets:
-{{toYaml .Values.starrocksFESpec.imagePullSecrets | indent 4 }}
-{{- end }}
-{{- if .Values.starrocksFESpec.serviceAccount }}
-    serviceAccount: {{ .Values.starrocksFESpec.serviceAccount }}
-{{- end }}
-    runAsNonRoot: {{ .Values.starrocksFESpec.runAsNonRoot }}
-{{- if .Values.starrocksFESpec.nodeSelector }}
+      {{- include "starrockscluster.fe.imagePullSecrets" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksFESpec.serviceAccount .Values.starrocksCluster.componentValues.serviceAccount }}
+    serviceAccount: {{ include "starrockscluster.fe.serviceAccount" . }}
+    {{- end }}
+    runAsNonRoot: {{ include "starrockscluster.fe.runAsNonRoot" . }}
+    {{- if or .Values.starrocksFESpec.nodeSelector .Values.starrocksCluster.componentValues.nodeSelector }}
     nodeSelector:
-{{ toYaml .Values.starrocksFESpec.nodeSelector | indent 6 }}
-{{- end }}
-{{- if .Values.starrocksFESpec.podLabels }}
+      {{- include "starrockscluster.fe.nodeSelector" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksFESpec.podLabels .Values.starrocksCluster.componentValues.podLabels }}
     podLabels:
-{{toYaml .Values.starrocksFESpec.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.starrocksFESpec.hostAliases }}
+      {{- include "starrockscluster.fe.podLabels" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksFESpec.hostAliases .Values.starrocksCluster.componentValues.hostAliases }}
     hostAliases:
-{{toYaml .Values.starrocksFESpec.hostAliases | indent 4 }}
-{{- end }}
-{{- if .Values.starrocksFESpec.schedulerName }}
-    schedulerName: {{ .Values.starrocksFESpec.schedulerName }}
-{{- end }}
+      {{- include "starrockscluster.fe.hostAliases" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksFESpec.schedulerName .Values.starrocksCluster.componentValues.schedulerName }}
+    schedulerName: {{ include "starrockscluster.fe.schedulerName" . }}
+    {{- end }}
     feEnvVars:
       - name: TZ
         value: {{ .Values.timeZone }}
@@ -109,14 +109,14 @@ spec:
       {{- toYaml .Values.starrocksFESpec.feEnvVars | nindent 6 }}
       {{- end }}
       {{- end }}
-{{- if .Values.starrocksFESpec.affinity }}
+    {{- if or .Values.starrocksFESpec.affinity .Values.starrocksCluster.componentValues.affinity }}
     affinity:
-{{ toYaml .Values.starrocksFESpec.affinity | indent 6 }}
-{{- end }}
-{{- if .Values.starrocksFESpec.tolerations }}
+      {{- include "starrockscluster.fe.affinity" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksFESpec.tolerations .Values.starrocksCluster.componentValues.tolerations }}
     tolerations:
-{{toYaml .Values.starrocksFESpec.tolerations | indent 4 }}
-{{- end }}
+      {{- include "starrockscluster.fe.tolerations" . | nindent 6 }}
+    {{- end }}
     terminationGracePeriodSeconds: {{ .Values.starrocksFESpec.terminationGracePeriodSeconds }}
     {{- if .Values.starrocksFESpec.startupProbeFailureSeconds }}
     startupProbeFailureSeconds: {{ .Values.starrocksFESpec.startupProbeFailureSeconds }}
@@ -169,7 +169,7 @@ spec:
 
 {{- if .Values.starrocksCluster.enabledBe }}
   starRocksBeSpec:
-    image: "{{ .Values.starrocksBeSpec.image.repository }}:{{ .Values.starrocksBeSpec.image.tag }}"
+    image: "{{ .Values.starrocksBeSpec.image.repository }}:{{ include "starrockscluster.be.image.tag" . }}"
     replicas: {{ .Values.starrocksBeSpec.replicas }}
     {{- /*
     support both resources and resource for backward compatibility
@@ -213,33 +213,33 @@ spec:
 {{- if .Values.starrocksBeSpec.annotations }}
 {{ toYaml .Values.starrocksBeSpec.annotations | indent 6 }}
 {{- end }}
-{{- if .Values.starrocksBeSpec.imagePullSecrets }}
+    {{- if or .Values.starrocksBeSpec.imagePullSecrets .Values.starrocksCluster.componentValues.imagePullSecrets }}
     imagePullSecrets:
-{{toYaml .Values.starrocksBeSpec.imagePullSecrets | indent 4 }}
-{{- end }}
-{{- if .Values.starrocksBeSpec.serviceAccount }}
-    serviceAccount: {{ .Values.starrocksBeSpec.serviceAccount }}
-{{- end }}
-    runAsNonRoot: {{ .Values.starrocksBeSpec.runAsNonRoot }}
-{{- if .Values.starrocksBeSpec.capabilities }}
+      {{- include "starrockscluster.be.imagePullSecrets" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksBeSpec.serviceAccount .Values.starrocksCluster.componentValues.serviceAccount }}
+    serviceAccount: {{ include "starrockscluster.be.serviceAccount" . }}
+    {{- end }}
+    runAsNonRoot: {{ include "starrockscluster.be.runAsNonRoot" . }}
+    {{- if .Values.starrocksBeSpec.capabilities }}
     capabilities:
-{{toYaml .Values.starrocksBeSpec.capabilities | indent 6 }}
-{{- end }}
-{{- if .Values.starrocksBeSpec.podLabels }}
+      {{- toYaml .Values.starrocksBeSpec.capabilities | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksBeSpec.podLabels .Values.starrocksCluster.componentValues.podLabels }}
     podLabels:
-{{toYaml .Values.starrocksBeSpec.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.starrocksBeSpec.hostAliases }}
+      {{- include "starrockscluster.be.podLabels" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksBeSpec.hostAliases .Values.starrocksCluster.componentValues.hostAliases }}
     hostAliases:
-{{toYaml .Values.starrocksBeSpec.hostAliases | indent 4 }}
-{{- end }}
-{{- if .Values.starrocksBeSpec.schedulerName }}
-    schedulerName: {{ .Values.starrocksBeSpec.schedulerName }}
-{{- end }}
-{{- if .Values.starrocksBeSpec.nodeSelector }}
+      {{- include "starrockscluster.be.hostAliases" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksBeSpec.schedulerName .Values.starrocksCluster.componentValues.schedulerName }}
+    schedulerName: {{ include "starrockscluster.be.schedulerName" . }}
+    {{- end }}
+    {{- if or .Values.starrocksBeSpec.nodeSelector .Values.starrocksCluster.componentValues.nodeSelector }}
     nodeSelector:
-{{ toYaml .Values.starrocksBeSpec.nodeSelector | indent 6 }}
-{{- end }}
+      {{- include "starrockscluster.be.nodeSelector" . | nindent 6 }}
+    {{- end }}
     beEnvVars:
       - name: TZ
         value: {{ .Values.timeZone }}
@@ -270,14 +270,14 @@ spec:
       {{- toYaml .Values.starrocksBeSpec.beEnvVars | nindent 6 }}
       {{- end }}
       {{- end }}
-{{- if .Values.starrocksBeSpec.affinity }}
+    {{- if or .Values.starrocksBeSpec.affinity .Values.starrocksCluster.componentValues.affinity }}
     affinity:
-{{ toYaml .Values.starrocksBeSpec.affinity | indent 6 }}
-{{- end }}
-{{- if .Values.starrocksBeSpec.tolerations }}
+      {{- include "starrockscluster.be.affinity" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksBeSpec.tolerations .Values.starrocksCluster.componentValues.tolerations }}
     tolerations:
-{{toYaml .Values.starrocksBeSpec.tolerations | indent 4 }}
-{{- end }}
+      {{- include "starrockscluster.be.tolerations" . | nindent 6 }}
+    {{- end }}
     terminationGracePeriodSeconds: {{ .Values.starrocksBeSpec.terminationGracePeriodSeconds }}
     {{- if .Values.starrocksBeSpec.startupProbeFailureSeconds }}
     startupProbeFailureSeconds: {{ .Values.starrocksBeSpec.startupProbeFailureSeconds }}
@@ -330,29 +330,29 @@ spec:
   {{- end }}
 {{- if .Values.starrocksCluster.enabledCn }}
   starRocksCnSpec:
-    image: "{{ .Values.starrocksCnSpec.image.repository }}:{{ .Values.starrocksCnSpec.image.tag }}"
+    image: "{{ .Values.starrocksCnSpec.image.repository }}:{{ include "starrockscluster.cn.image.tag" . }}"
     {{- if .Values.starrocksCnSpec.replicas }}
     replicas: {{ .Values.starrocksCnSpec.replicas }}
     {{- end }}
-{{- if .Values.starrocksCnSpec.serviceAccount }}
-    serviceAccount: {{ .Values.starrocksCnSpec.serviceAccount }}
-{{- end }}
-    runAsNonRoot: {{ .Values.starrocksCnSpec.runAsNonRoot }}
-{{- if .Values.starrocksCnSpec.podLabels }}
+    {{- if or .Values.starrocksCnSpec.serviceAccount .Values.starrocksCluster.componentValues.serviceAccount }}
+    serviceAccount: {{ include "starrockscluster.cn.serviceAccount" . }}
+    {{- end }}
+    runAsNonRoot: {{ include "starrockscluster.cn.runAsNonRoot" . }}
+    {{- if or .Values.starrocksCnSpec.podLabels .Values.starrocksCluster.componentValues.podLabels }}
     podLabels:
-{{toYaml .Values.starrocksCnSpec.podLabels | indent 6 }}
-{{- end }}
-{{- if .Values.starrocksCnSpec.hostAliases }}
+      {{- include "starrockscluster.cn.podLabels" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksCnSpec.hostAliases .Values.starrocksCluster.componentValues.hostAliases }}
     hostAliases:
-{{toYaml .Values.starrocksCnSpec.hostAliases | indent 4 }}
-{{- end }}
-{{- if .Values.starrocksCnSpec.schedulerName }}
-    schedulerName: {{ .Values.starrocksCnSpec.schedulerName }}
-{{- end }}
-{{- if .Values.starrocksCnSpec.nodeSelector }}
+      {{- include "starrockscluster.cn.hostAliases" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksCnSpec.schedulerName .Values.starrocksCluster.componentValues.schedulerName }}
+    schedulerName: {{ include "starrockscluster.cn.schedulerName" . }}
+    {{- end }}
+    {{- if or .Values.starrocksCnSpec.nodeSelector .Values.starrocksCluster.componentValues.nodeSelector }}
     nodeSelector:
-{{ toYaml .Values.starrocksCnSpec.nodeSelector | indent 6 }}
-{{- end }}
+      {{- include "starrockscluster.cn.nodeSelector" . | nindent 6 }}
+    {{- end }}
     cnEnvVars:
       - name: TZ
         value: {{ .Values.timeZone }}
@@ -384,14 +384,14 @@ spec:
       {{- end }}
       {{- end }}
 
-{{- if .Values.starrocksCnSpec.affinity }}
+    {{- if or .Values.starrocksCnSpec.affinity .Values.starrocksCluster.componentValues.affinity }}
     affinity:
-{{ toYaml .Values.starrocksCnSpec.affinity | indent 6 }}
-{{- end }}
-{{- if .Values.starrocksCnSpec.tolerations }}
+      {{- include "starrockscluster.cn.affinity" . | nindent 6 }}
+    {{- end }}
+    {{- if or .Values.starrocksCnSpec.tolerations .Values.starrocksCluster.componentValues.tolerations }}
     tolerations:
-{{toYaml .Values.starrocksCnSpec.tolerations | indent 4 }}
-{{- end }}
+      {{- include "starrockscluster.cn.tolerations" . | nindent 6 }}
+    {{- end }}
     terminationGracePeriodSeconds: {{ .Values.starrocksCnSpec.terminationGracePeriodSeconds }}
     {{- if .Values.starrocksCnSpec.startupProbeFailureSeconds }}
     startupProbeFailureSeconds: {{ .Values.starrocksCnSpec.startupProbeFailureSeconds }}
@@ -448,10 +448,10 @@ spec:
 {{- if .Values.starrocksCnSpec.annotations }}
 {{ toYaml .Values.starrocksCnSpec.annotations | indent 6 }}
 {{- end }}
-{{- if .Values.starrocksCnSpec.imagePullSecrets }}
+    {{- if or .Values.starrocksCnSpec.imagePullSecrets .Values.starrocksCluster.componentValues.imagePullSecrets }}
     imagePullSecrets:
-{{toYaml .Values.starrocksCnSpec.imagePullSecrets | indent 4 }}
-{{- end }}
+      {{- include "starrockscluster.cn.imagePullSecrets" . | nindent 6 }}
+    {{- end }}
 {{- if .Values.starrocksCnSpec.secrets }}
     secrets:
     {{- range .Values.starrocksCnSpec.secrets }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -53,6 +53,53 @@ starrocksCluster:
   # specify the cn deploy or not.
   enabledBe: true
   enabledCn: false
+  # componentValues field is used to define values for all starrocks cluster components, including starrocksFESpec,
+  # starrocksBeSpec, starrocksCnSpec, not including starrocksFeProxySpec. So that you do not need to modify them in
+  # the following spec.
+  # Note:
+  #   1. the values in its own spec will take precedence over the values in this field.
+  componentValues:
+    image:
+      tag: "3.1-latest"
+    # hostAliases allows adding entries to /etc/hosts inside the containers.
+    hostAliases: []
+      # - ip: "127.0.0.1"
+      #   hostnames:
+      #   - "example.com"
+    # If runAsNonRoot is true, the container is run as non-root user.
+    # The userId will be set to 1000, and the groupID will be set to 1000.
+    runAsNonRoot: false
+    # schedulerName allows you to specify which scheduler will be used for your pods.
+    schedulerName: ""
+    # serviceAccount for access cloud service.
+    serviceAccount: ""
+    # imagePullSecrets allows you to use secrets to pull images for pods.
+    imagePullSecrets: []
+    # - name: "image-pull-secret"
+    # tolerations for pod scheduling to nodes with taints
+    # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    tolerations: []
+      # - key: "key"
+      #   operator: "Equal|Exists"
+      #   value: "value"
+      #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+    # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
+    # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+    nodeSelector: {}
+      # kubernetes.io/arch: amd64
+      # kubernetes.io/os: linux
+    # affinity for pod scheduling.
+    affinity: {}
+      # nodeAffinity:
+      #   requiredDuringSchedulingIgnoredDuringExecution:
+      #     nodeSelectorTerms:
+      #     - matchFields:
+      #       - key: metadata.name
+      #         operator: In
+      #         values:
+      #         - target-host-name
+    # the pod labels for user select or classify pods.
+    podLabels: {}
 
 # spec to deploy fe.
 starrocksFESpec:
@@ -61,7 +108,7 @@ starrocksFESpec:
   image:
     # image sliced by "repository:tag"
     repository: starrocks/fe-ubuntu
-    tag: 3.1-latest
+    tag: ""
   # add annotations for fe pods. For example, if you want to config monitor for datadog, you can config the annotations.
   annotations: {}
   # If runAsNonRoot is true, the container is run as non-root user.
@@ -223,7 +270,7 @@ starrocksCnSpec:
   image:
     # image sliced by "repository:tag"
     repository: starrocks/cn-ubuntu
-    tag: 3.1-latest
+    tag: ""
   # serviceAccount for cn access cloud service.
   serviceAccount: ""
   # add annotations for cn pods. example, if you want to config monitor for datadog, you can config the annotations.
@@ -400,7 +447,7 @@ starrocksBeSpec:
   image:
     # image sliced by "repository:tag"
     repository: starrocks/be-ubuntu
-    tag: 3.1-latest
+    tag: ""
   # serviceAccount for be access cloud service.
   serviceAccount: ""
   # add annotations for be pods. example, if you want to config monitor for datadog, you can config the annotations.

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -55,9 +55,10 @@ starrocksCluster:
   enabledCn: false
   # componentValues field is used to define values for all starrocks cluster components, including starrocksFESpec,
   # starrocksBeSpec, starrocksCnSpec, not including starrocksFeProxySpec. So that you do not need to modify them in
-  # the following spec.
+  # their own spec.
   # Note:
-  #   1. the values in its own spec will take precedence over the values in this field.
+  #   1. the values in their own spec will take precedence over the values in this field.
+  #   2. the values in their own spec will replace all the values in this field, not merge.
   componentValues:
     image:
       tag: "3.1-latest"

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -148,9 +148,10 @@ starrocks:
     enabledCn: false
     # componentValues field is used to define values for all starrocks cluster components, including starrocksFESpec,
     # starrocksBeSpec, starrocksCnSpec, not including starrocksFeProxySpec. So that you do not need to modify them in
-    # the following spec.
+    # their own spec.
     # Note:
-    #   1. the values in its own spec will take precedence over the values in this field.
+    #   1. the values in their own spec will take precedence over the values in this field.
+    #   2. the values in their own spec will replace all the values in this field, not merge.
     componentValues:
       image:
         tag: "3.1-latest"

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -146,6 +146,53 @@ starrocks:
     # specify the cn deploy or not.
     enabledBe: true
     enabledCn: false
+    # componentValues field is used to define values for all starrocks cluster components, including starrocksFESpec,
+    # starrocksBeSpec, starrocksCnSpec, not including starrocksFeProxySpec. So that you do not need to modify them in
+    # the following spec.
+    # Note:
+    #   1. the values in its own spec will take precedence over the values in this field.
+    componentValues:
+      image:
+        tag: "3.1-latest"
+      # hostAliases allows adding entries to /etc/hosts inside the containers.
+      hostAliases: []
+        # - ip: "127.0.0.1"
+        #   hostnames:
+        #   - "example.com"
+      # If runAsNonRoot is true, the container is run as non-root user.
+      # The userId will be set to 1000, and the groupID will be set to 1000.
+      runAsNonRoot: false
+      # schedulerName allows you to specify which scheduler will be used for your pods.
+      schedulerName: ""
+      # serviceAccount for access cloud service.
+      serviceAccount: ""
+      # imagePullSecrets allows you to use secrets to pull images for pods.
+      imagePullSecrets: []
+      # - name: "image-pull-secret"
+      # tolerations for pod scheduling to nodes with taints
+      # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+      tolerations: []
+        # - key: "key"
+        #   operator: "Equal|Exists"
+        #   value: "value"
+        #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+      # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
+      # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+      nodeSelector: {}
+        # kubernetes.io/arch: amd64
+        # kubernetes.io/os: linux
+      # affinity for pod scheduling.
+      affinity: {}
+        # nodeAffinity:
+        #   requiredDuringSchedulingIgnoredDuringExecution:
+        #     nodeSelectorTerms:
+        #     - matchFields:
+        #       - key: metadata.name
+        #         operator: In
+        #         values:
+        #         - target-host-name
+      # the pod labels for user select or classify pods.
+      podLabels: {}
   
   # spec to deploy fe.
   starrocksFESpec:
@@ -154,7 +201,7 @@ starrocks:
     image:
       # image sliced by "repository:tag"
       repository: starrocks/fe-ubuntu
-      tag: 3.1-latest
+      tag: ""
     # add annotations for fe pods. For example, if you want to config monitor for datadog, you can config the annotations.
     annotations: {}
     # If runAsNonRoot is true, the container is run as non-root user.
@@ -316,7 +363,7 @@ starrocks:
     image:
       # image sliced by "repository:tag"
       repository: starrocks/cn-ubuntu
-      tag: 3.1-latest
+      tag: ""
     # serviceAccount for cn access cloud service.
     serviceAccount: ""
     # add annotations for cn pods. example, if you want to config monitor for datadog, you can config the annotations.
@@ -493,7 +540,7 @@ starrocks:
     image:
       # image sliced by "repository:tag"
       repository: starrocks/be-ubuntu
-      tag: 3.1-latest
+      tag: ""
     # serviceAccount for be access cloud service.
     serviceAccount: ""
     # add annotations for be pods. example, if you want to config monitor for datadog, you can config the annotations.


### PR DESCRIPTION
# Description

In the individual spec definitions of the sub-components, there are indeed many fields with the same name, such as image, imagePullSecrets, nodeSelector, schedulerName. Generally, the contents of these fields are consistent in the individual spec definitions of the sub-components. 

Fixes: #424 

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
