### PR TITLE
[Enhancement] allow user to specify mount path

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -76,7 +76,11 @@ be.conf: |
 {{- end }}
 
 {{- define "starrockscluster.fe.meta.path" -}}
+{{- if .Values.starrocksFESpec.storageSpec.storageMountPath }}
+{{- print .Values.starrocksFESpec.storageSpec.storageMountPath }}
+{{- else }}
 {{- print "/opt/starrocks/fe/meta" }}
+{{- end }}
 {{- end }}
 
 {{- define "starrockscluster.fe.log.suffix" -}}
@@ -92,7 +96,11 @@ be.conf: |
 {{- end }}
 
 {{- define "starrockscluster.be.data.path" -}}
+{{- if .Values.starrocksBeSpec.storageSpec.storageMountPath }}
+{{- print .Values.starrocksBeSpec.storageSpec.storageMountPath }}
+{{- else }}
 {{- print "/opt/starrocks/be/storage" }}
+{{- end }}
 {{- end }}
 
 {{- define "starrockscluster.be.log.suffix" -}}
@@ -108,7 +116,11 @@ be.conf: |
 {{- end }}
 
 {{- define "starrockscluster.cn.data.path" -}}
+{{- if .Values.starrocksCnSpec.storageSpec.storageMountPath }}
+{{- print .Values.starrocksCnSpec.storageSpec.storageMountPath }}
+{{- else }}
 {{- print "/opt/starrocks/cn/storage" }}
+{{- end }}
 {{- end }}
 
 {{- define "starrockscluster.cn.log.suffix" -}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -205,7 +205,9 @@ starrocksFESpec:
     # the persistent volume size， default 10Gi.
     # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
     storageSize: 10Gi
-    # Setting this parameter can persist log storage.
+    # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/fe/meta.
+    storageMountPath: ""
+    # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/fe/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
     logStorageSize: 5Gi
   # mount other volumes if necessary.
@@ -395,7 +397,9 @@ starrocksCnSpec:
     storageClassName: ""
     # the storage size of persistent volume for data.
     storageSize: 1Ti
-    # the storage size of persistent volume for log.
+    # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
+    storageMountPath: ""
+    # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
     logStorageSize: 1Gi
   # mount other volumes if necessary.
@@ -549,8 +553,11 @@ starrocksBeSpec:
     # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
     # you must set name when you set storageClassName
     storageClassName: ""
+    # the storage size of persistent volume for data.
     storageSize: 1Ti
-    # Setting this parameter can persist log storage
+    # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/be/storage.
+    storageMountPath: ""
+    # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
     logStorageSize: 1Gi
   # mount other volumes if necessary.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -296,7 +296,9 @@ starrocks:
       # the persistent volume size， default 10Gi.
       # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
       storageSize: 10Gi
-      # Setting this parameter can persist log storage.
+      # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/fe/meta.
+      storageMountPath: ""
+      # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/fe/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
       logStorageSize: 5Gi
     # mount other volumes if necessary.
@@ -486,7 +488,9 @@ starrocks:
       storageClassName: ""
       # the storage size of persistent volume for data.
       storageSize: 1Ti
-      # the storage size of persistent volume for log.
+      # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
+      storageMountPath: ""
+      # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
       logStorageSize: 1Gi
     # mount other volumes if necessary.
@@ -640,8 +644,11 @@ starrocks:
       # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
       # you must set name when you set storageClassName
       storageClassName: ""
+      # the storage size of persistent volume for data.
       storageSize: 1Ti
-      # Setting this parameter can persist log storage
+      # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/be/storage.
+      storageMountPath: ""
+      # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
       logStorageSize: 1Gi
     # mount other volumes if necessary.


### PR DESCRIPTION
# Description

Backgroud information: https://github.com/StarRocks/starrocks-kubernetes-operator/issues/390#issuecomment-1918509571

In order to run StarRocks on a read-only file system, users need a volume to mount at `/opt/starrocks/fe` or `/opt/starrocks/be`.  But helm chart do not support to specify a mount path.

Fixes: #390 

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
