### PR TITLE
[BugFix] Fix unknown field "spec.starRocksBeSpec.resources" error

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -123,45 +123,42 @@ be.conf: |
 Define a function to handle resource limits for fe
 */}}
 {{- define "starrockscluster.fe.resources" -}}
-resources:
-  requests:
-    {{- toYaml .Values.starrocksFESpec.resources.requests | nindent 4 }}
-  limits:
-  {{- range $key, $value := .Values.starrocksFESpec.resources.limits }}
-    {{- if ne (toString $value) "unlimited" }}
-    {{ $key }}: {{ $value }}
-    {{- end }}
+requests:
+  {{- toYaml .Values.starrocksFESpec.resources.requests | nindent 2 }}
+limits:
+{{- range $key, $value := .Values.starrocksFESpec.resources.limits }}
+  {{- if ne (toString $value) "unlimited" }}
+  {{ $key }}: {{ $value }}
   {{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*
 Define a function to handle resource limits for be
 */}}
 {{- define "starrockscluster.be.resources" -}}
-resources:
-  requests:
-    {{- toYaml .Values.starrocksBeSpec.resources.requests | nindent 4 }}
-  limits:
-  {{- range $key, $value := .Values.starrocksBeSpec.resources.limits }}
-    {{- if ne (toString $value) "unlimited" }}
-    {{ $key }}: {{ $value }}
-    {{- end }}
+requests:
+  {{- toYaml .Values.starrocksBeSpec.resources.requests | nindent 2 }}
+limits:
+{{- range $key, $value := .Values.starrocksBeSpec.resources.limits }}
+  {{- if ne (toString $value) "unlimited" }}
+  {{ $key }}: {{ $value }}
   {{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*
 Define a function to handle resource limits for cn
 */}}
 {{- define "starrockscluster.cn.resources" -}}
-resources:
-  requests:
-    {{- toYaml .Values.starrocksCnSpec.resources.requests | nindent 4 }}
-  limits:
-  {{- range $key, $value := .Values.starrocksCnSpec.resources.limits }}
-    {{- if ne (toString $value) "unlimited" }}
-    {{ $key }}: {{ $value }}
-    {{- end }}
+requests:
+  {{- toYaml .Values.starrocksCnSpec.resources.requests | nindent 2 }}
+limits:
+{{- range $key, $value := .Values.starrocksCnSpec.resources.limits }}
+  {{- if ne (toString $value) "unlimited" }}
+  {{ $key }}: {{ $value }}
   {{- end }}
+{{- end }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
# Description

when execute `helm upgrade`, helm report the following error:

```
W0130 19:07:13.003223   81804 warnings.go:70] unknown field "spec.starRocksBeSpec.resources"
W0130 19:07:13.003243   81804 warnings.go:70] unknown field "spec.starRocksCnSpec.resources"
W0130 19:07:13.003245   81804 warnings.go:70] unknown field "spec.starRocksFeSpec.resources"
```

This is because functions defined in `_helpers.tpl` has error, include `starrockscluster.fe.resources`, `starrockscluster.be.resources` and `starrockscluster.cn.resources`.

# Checklist

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
