### PR TITLE
[Enhancement] Allow user to add labels on serviceMonitor

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/servicemonitor.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/servicemonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ template "starrockscluster.namespace" . }}
   labels:
     cluster: {{ template "starrockscluster.name" . }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: http
@@ -35,6 +38,9 @@ metadata:
   namespace: {{ template "starrockscluster.namespace" . }}
   labels:
     cluster: {{ template "starrockscluster.name" . }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: webserver
@@ -66,6 +72,9 @@ metadata:
   namespace: {{ template "starrockscluster.namespace" . }}
   labels:
     cluster: {{ template "starrockscluster.name" . }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: webserver

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -36,11 +36,14 @@ datadog:
 # This configuration is used to integrate with external system Prometheus.
 metrics:
   serviceMonitor:
-    # Enable a prometheus ServiceMonitor
+    # Whether to expose metrics to Prometheus by ServiceMonitor.
     # Note: make sure the prometheus operator is installed in your cluster.
     # If prometheus is not installed by operator, you can add annotations on k8s service to expose metrics.
     # see https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/doc/integration/integration-prometheus-grafana.md#51-turn-on-the-prometheus-metrics-scrape-by-adding-annotations for more details.
     enabled: false
+    # Prometheus ServiceMonitor labels
+    labels: {}
+      # scraper: prometheus-operator
     # Prometheus ServiceMonitor interval
     interval: 15s
 

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -129,11 +129,14 @@ starrocks:
   # This configuration is used to integrate with external system Prometheus.
   metrics:
     serviceMonitor:
-      # Enable a prometheus ServiceMonitor
+      # Whether to expose metrics to Prometheus by ServiceMonitor.
       # Note: make sure the prometheus operator is installed in your cluster.
       # If prometheus is not installed by operator, you can add annotations on k8s service to expose metrics.
       # see https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/doc/integration/integration-prometheus-grafana.md#51-turn-on-the-prometheus-metrics-scrape-by-adding-annotations for more details.
       enabled: false
+      # Prometheus ServiceMonitor labels
+      labels: {}
+        # scraper: prometheus-operator
       # Prometheus ServiceMonitor interval
       interval: 15s
   


### PR DESCRIPTION
# Description

If there are multiple prometheus instances in k8s environment,  user need to add label to specify the concrete instance.

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
