### PR TITLE
[BugFix] Add Service Labels to up metrics of Prometheus to support grafana dashboard

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/servicemonitor.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/servicemonitor.yaml
@@ -13,6 +13,11 @@ spec:
       interval: {{ . }}
       {{- end }}
       path: /metrics
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_endpoints_label_app_starrocks_ownerreference_name]
+          targetLabel: app_starrocks_ownerreference_name
+        - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+          targetLabel: app_kubernetes_io_component
   namespaceSelector:
     matchNames:
       - {{ template "starrockscluster.namespace" . }}
@@ -37,6 +42,11 @@ spec:
       interval: {{ . }}
       {{- end }}
       path: /metrics
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_endpoints_label_app_starrocks_ownerreference_name]
+          targetLabel: app_starrocks_ownerreference_name
+        - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+          targetLabel: app_kubernetes_io_component
   namespaceSelector:
     matchNames:
       - {{ template "starrockscluster.namespace" . }}
@@ -63,6 +73,11 @@ spec:
       interval: {{ . }}
       {{- end }}
       path: /metrics
+      relabelings:
+        - sourceLabels: [__meta_kubernetes_endpoints_label_app_starrocks_ownerreference_name]
+          targetLabel: app_starrocks_ownerreference_name
+        - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+          targetLabel: app_kubernetes_io_component
   namespaceSelector:
     matchNames:
       - {{ template "starrockscluster.namespace" . }}


### PR DESCRIPTION
# Description

When StarRocks metrics is scraped by ServiceMonitor, there will not have app_starrocks_ownerreference_name or app_kubernetes_io_component labels in `up` metrics. This will lead to grafana dashboard not working correctly.

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
