### PR TITLE
[Enhancement] Eliminate the Helm warning caused by the different types of feEnvVars, beEnvVars, and cnEnvVars

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -156,9 +156,10 @@ starrocksFESpec:
   # Additional fe container environment variables.
   # See https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ for how to define environment variables.
   # Note: If you use slice to define environment variables, and if there are multiple values files, the values in the last values file will take effect.
-  #       If you use map to define environment variables, and if there are multiple values files, the values in the last values file will be merged.
+  #       If you use map to define environment variables, the values in the values files will be merged.
   #       You can only use one of slice and map to define environment variables.
-  feEnvVars: []
+  # In order to avoid different type of feEnvVars, we do not define the default value of feEnvVars, e.g. feEnvVars: [] or feEnvVars: {}.
+  #feEnvVars:
     # define environment variables by slice.
     # e.g. static environment variable:
     # - name: DEMO_GREETING
@@ -318,9 +319,10 @@ starrocksCnSpec:
   # Additional cn container environment variables.
   # See https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ for how to define environment variables.
   # Note: If you use slice to define environment variables, and if there are multiple values files, the values in the last values file will take effect.
-  #       If you use map to define environment variables, and if there are multiple values files, the values in the last values file will be merged.
+  #       If you use map to define environment variables, the values in the values files will be merged.
   #       You can only use one of slice and map to define environment variables.
-  cnEnvVars: []
+  # In order to avoid different type of cnEnvVars, we do not define the default value of cnEnvVars, e.g. cnEnvVars: [] or cnEnvVars: {}.
+  # cnEnvVars:
     # define environment variables by slice.
     # e.g. static environment variable:
     # - name: DEMO_GREETING
@@ -502,9 +504,10 @@ starrocksBeSpec:
   # Additional be container environment variables.
   # See https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ for how to define environment variables.
   # Note: If you use slice to define environment variables, and if there are multiple values files, the values in the last values file will take effect.
-  #       If you use map to define environment variables, and if there are multiple values files, the values in the last values file will be merged.
+  #       If you use map to define environment variables, the values in the values files will be merged.
   #       You can only use one of slice and map to define environment variables.
-  beEnvVars: []
+  # In order to avoid different type of beEnvVars, we do not define the default value of beEnvVars, e.g. beEnvVars: [] or beEnvVars: {}.
+  # beEnvVars:
     # define environment variables by slice.
     # e.g. static environment variable:
     # - name: DEMO_GREETING

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -127,10 +127,12 @@ starrocks:
       enabled: false
   
   # This configuration is used to integrate with external system Prometheus.
-  # You can enable the integration by setting the enabled to true.
   metrics:
     serviceMonitor:
       # Enable a prometheus ServiceMonitor
+      # Note: make sure the prometheus operator is installed in your cluster.
+      # If prometheus is not installed by operator, you can add annotations on k8s service to expose metrics.
+      # see https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/doc/integration/integration-prometheus-grafana.md#51-turn-on-the-prometheus-metrics-scrape-by-adding-annotations for more details.
       enabled: false
       # Prometheus ServiceMonitor interval
       interval: 15s
@@ -247,9 +249,10 @@ starrocks:
     # Additional fe container environment variables.
     # See https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ for how to define environment variables.
     # Note: If you use slice to define environment variables, and if there are multiple values files, the values in the last values file will take effect.
-    #       If you use map to define environment variables, and if there are multiple values files, the values in the last values file will be merged.
+    #       If you use map to define environment variables, the values in the values files will be merged.
     #       You can only use one of slice and map to define environment variables.
-    feEnvVars: []
+    # In order to avoid different type of feEnvVars, we do not define the default value of feEnvVars, e.g. feEnvVars: [] or feEnvVars: {}.
+    #feEnvVars:
       # define environment variables by slice.
       # e.g. static environment variable:
       # - name: DEMO_GREETING
@@ -409,9 +412,10 @@ starrocks:
     # Additional cn container environment variables.
     # See https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ for how to define environment variables.
     # Note: If you use slice to define environment variables, and if there are multiple values files, the values in the last values file will take effect.
-    #       If you use map to define environment variables, and if there are multiple values files, the values in the last values file will be merged.
+    #       If you use map to define environment variables, the values in the values files will be merged.
     #       You can only use one of slice and map to define environment variables.
-    cnEnvVars: []
+    # In order to avoid different type of cnEnvVars, we do not define the default value of cnEnvVars, e.g. cnEnvVars: [] or cnEnvVars: {}.
+    # cnEnvVars:
       # define environment variables by slice.
       # e.g. static environment variable:
       # - name: DEMO_GREETING
@@ -593,9 +597,10 @@ starrocks:
     # Additional be container environment variables.
     # See https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ for how to define environment variables.
     # Note: If you use slice to define environment variables, and if there are multiple values files, the values in the last values file will take effect.
-    #       If you use map to define environment variables, and if there are multiple values files, the values in the last values file will be merged.
+    #       If you use map to define environment variables, the values in the values files will be merged.
     #       You can only use one of slice and map to define environment variables.
-    beEnvVars: []
+    # In order to avoid different type of beEnvVars, we do not define the default value of beEnvVars, e.g. beEnvVars: [] or beEnvVars: {}.
+    # beEnvVars:
       # define environment variables by slice.
       # e.g. static environment variable:
       # - name: DEMO_GREETING


### PR DESCRIPTION
# Related Issue(s)

Fixes: #430 

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
