### PR TITLE
[Feature][issue-423] add datadog profiling to SR Helm

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -99,7 +99,7 @@ spec:
             name: {{ template "starrockscluster.initpassword.secret.name" . }}
             key: password
       {{- end }}
-      {{- if .Values.datadog.profiling.be }}
+      {{- if .Values.datadog.profiling.fe }}
       - name: ENABLE_DATADOG_PROFILE
         value: "true"
       - name: DD_PROFILING_ENABLED
@@ -247,9 +247,26 @@ spec:
     serviceAccount: {{ include "starrockscluster.be.serviceAccount" . }}
     {{- end }}
     runAsNonRoot: {{ include "starrockscluster.be.runAsNonRoot" . }}
-    {{- if .Values.starrocksBeSpec.capabilities }}
+    {{- if or .Values.starrocksBeSpec.capabilities .Values.datadog.profiling.be }}
     capabilities:
-      {{- toYaml .Values.starrocksBeSpec.capabilities | nindent 6 }}
+      {{- if or .Values.starrocksBeSpec.capabilities.add .Values.datadog.profiling.be }}
+      add:
+        {{- if .Values.starrocksBeSpec.capabilities.add }}
+        {{- toYaml .Values.starrocksBeSpec.capabilities.add | nindent 8 }}
+        {{- end }}
+        {{- if .Values.datadog.profiling.be }}
+        {{- if and .Values.starrocksBeSpec.capabilities.add (has "PERFMON" .Values.starrocksBeSpec.capabilities.add) | not }}
+        - PERFMON
+        {{- end }}
+        {{- if and .Values.starrocksBeSpec.capabilities.add (has "SYS_PTRACE" .Values.starrocksBeSpec.capabilities.add) | not }}
+        - SYS_PTRACE
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.starrocksBeSpec.capabilities.drop }}
+      drop:
+        {{- toYaml .Values.starrocksBeSpec.capabilities.drop | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- if or .Values.starrocksBeSpec.podLabels .Values.starrocksCluster.componentValues.podLabels .Values.datadog.profiling.be }}
     podLabels:
@@ -260,12 +277,6 @@ spec:
       admission.datadoghq.com/config.mode: service
       admission.datadoghq.com/enabled: "true"
       {{- end }}
-    {{- end }}
-    {{- if .Values.datadog.profiling.be }}
-    capabilities:
-      add:
-        - PERFMON
-        - SYS_PTRACE
     {{- end }}
     {{- if or .Values.starrocksBeSpec.hostAliases .Values.starrocksCluster.componentValues.hostAliases }}
     hostAliases:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -68,9 +68,15 @@ spec:
     nodeSelector:
       {{- include "starrockscluster.fe.nodeSelector" . | nindent 6 }}
     {{- end }}
-    {{- if or .Values.starrocksFESpec.podLabels .Values.starrocksCluster.componentValues.podLabels }}
+    {{- if or .Values.starrocksFESpec.podLabels .Values.starrocksCluster.componentValues.podLabels .Values.datadog.profiling.fe }}
     podLabels:
+      {{- if or .Values.starrocksFESpec.podLabels .Values.starrocksCluster.componentValues.podLabel }}
       {{- include "starrockscluster.fe.podLabels" . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.datadog.profiling.fe }}
+      admission.datadoghq.com/config.mode: service
+      admission.datadoghq.com/enabled: "true"
+      {{- end }}
     {{- end }}
     {{- if or .Values.starrocksFESpec.hostAliases .Values.starrocksCluster.componentValues.hostAliases }}
     hostAliases:
@@ -92,6 +98,26 @@ spec:
           secretKeyRef:
             name: {{ template "starrockscluster.initpassword.secret.name" . }}
             key: password
+      {{- end }}
+      {{- if .Values.datadog.profiling.be }}
+      - name: ENABLE_DATADOG_PROFILE
+        value: "true"
+      - name: DD_PROFILING_ENABLED
+        value: "true"
+      - name: DD_SERVICE
+        value: celostar-fe
+      - name: DD_ENV
+        value: "{{ .Values.datadog.profiling.env }}"
+      - name: DD_VERSION
+        value: "{{ include "starrockscluster.fe.image.tag" . }}"
+      - name: DD_PROFILING_DDPROF_ALLOC_ENABLED
+        value: "true"
+      - name: DD_PROFILING_DDPROF_ENABLED
+        value: "true"
+      - name: DD_PROFILING_DDPROF_LIVEHEAP_ENABLED
+        value: "true"
+      - name: DD_PROFILING_DIRECTALLOCATION_ENABLED
+        value: "true"
       {{- end }}
       {{- if .Values.starrocksFESpec.feEnvVars }}
       {{- /* if it is a map, we use range to iterate to merge environment variables */}}
@@ -225,9 +251,21 @@ spec:
     capabilities:
       {{- toYaml .Values.starrocksBeSpec.capabilities | nindent 6 }}
     {{- end }}
-    {{- if or .Values.starrocksBeSpec.podLabels .Values.starrocksCluster.componentValues.podLabels }}
+    {{- if or .Values.starrocksBeSpec.podLabels .Values.starrocksCluster.componentValues.podLabels .Values.datadog.profiling.be }}
     podLabels:
+      {{- if or .Values.starrocksBeSpec.podLabels .Values.starrocksCluster.componentValues.podLabels }}
       {{- include "starrockscluster.be.podLabels" . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.datadog.profiling.be }}
+      admission.datadoghq.com/config.mode: service
+      admission.datadoghq.com/enabled: "true"
+      {{- end }}
+    {{- end }}
+    {{- if .Values.datadog.profiling.be }}
+    capabilities:
+      add:
+        - PERFMON
+        - SYS_PTRACE
     {{- end }}
     {{- if or .Values.starrocksBeSpec.hostAliases .Values.starrocksCluster.componentValues.hostAliases }}
     hostAliases:
@@ -253,6 +291,18 @@ spec:
           secretKeyRef:
             name: {{ template "starrockscluster.initpassword.secret.name" . }}
             key: password
+      {{- end }}
+      {{- if .Values.datadog.profiling.be }}
+      - name: ENABLE_DATADOG_PROFILE
+        value: "true"
+      - name: DD_PROFILING_ENABLED
+        value: "true"
+      - name: DD_SERVICE
+        value: celostar-be
+      - name: DD_ENV
+        value: "{{ .Values.datadog.profiling.env }}"
+      - name: DD_VERSION
+        value: "{{ include "starrockscluster.be.image.tag" . }}"
       {{- end }}
       {{- if .Values.starrocksBeSpec.beEnvVars }}
       {{- /* if it is a map, we use range to iterate to merge environment variables */}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -399,9 +399,36 @@ spec:
     serviceAccount: {{ include "starrockscluster.cn.serviceAccount" . }}
     {{- end }}
     runAsNonRoot: {{ include "starrockscluster.cn.runAsNonRoot" . }}
-    {{- if or .Values.starrocksCnSpec.podLabels .Values.starrocksCluster.componentValues.podLabels }}
+    {{- if or .Values.starrocksCnSpec.capabilities .Values.datadog.profiling.cn }}
+    capabilities:
+      {{- if or .Values.starrocksCnSpec.capabilities.add .Values.datadog.profiling.cn }}
+      add:
+        {{- if .Values.starrocksCnSpec.capabilities.add }}
+        {{- toYaml .Values.starrocksCnSpec.capabilities.add | nindent 8 }}
+        {{- end }}
+        {{- if .Values.datadog.profiling.cn }}
+        {{- if and .Values.starrocksCnSpec.capabilities.add (has "PERFMON" .Values.starrocksCnSpec.capabilities.add) | not }}
+        - PERFMON
+        {{- end }}
+        {{- if and .Values.starrocksCnSpec.capabilities.add (has "SYS_PTRACE" .Values.starrocksCnSpec.capabilities.add) | not }}
+        - SYS_PTRACE
+        {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.starrocksCnSpec.capabilities.drop }}
+      drop:
+        {{- toYaml .Values.starrocksCnSpec.capabilities.drop | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- if or .Values.starrocksCnSpec.podLabels .Values.starrocksCluster.componentValues.podLabels .Values.datadog.profiling.cn }}
     podLabels:
+      {{- if or .Values.starrocksCnSpec.podLabels .Values.starrocksCluster.componentValues.podLabels }}
       {{- include "starrockscluster.cn.podLabels" . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.datadog.profiling.cn }}
+      admission.datadoghq.com/config.mode: service
+      admission.datadoghq.com/enabled: "true"
+      {{- end }}
     {{- end }}
     {{- if or .Values.starrocksCnSpec.hostAliases .Values.starrocksCluster.componentValues.hostAliases }}
     hostAliases:
@@ -427,6 +454,18 @@ spec:
           secretKeyRef:
             name: {{ template "starrockscluster.initpassword.secret.name" . }}
             key: password
+      {{- end }}
+      {{- if .Values.datadog.profiling.cn }}
+      - name: ENABLE_DATADOG_PROFILE
+        value: "true"
+      - name: DD_PROFILING_ENABLED
+        value: "true"
+      - name: DD_SERVICE
+        value: starrocks-cn
+      - name: DD_ENV
+        value: "{{ .Values.datadog.profiling.env }}"
+      - name: DD_VERSION
+        value: "{{ include "starrockscluster.cn.image.tag" . }}"
       {{- end }}
       {{- if .Values.starrocksCnSpec.cnEnvVars }}
       {{- /* if it is a map, we use range to iterate to merge environment variables */}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -105,7 +105,7 @@ spec:
       - name: DD_PROFILING_ENABLED
         value: "true"
       - name: DD_SERVICE
-        value: celostar-fe
+        value: starrocks-fe
       - name: DD_ENV
         value: "{{ .Values.datadog.profiling.env }}"
       - name: DD_VERSION
@@ -309,7 +309,7 @@ spec:
       - name: DD_PROFILING_ENABLED
         value: "true"
       - name: DD_SERVICE
-        value: celostar-be
+        value: starrocks-be
       - name: DD_ENV
         value: "{{ .Values.datadog.profiling.env }}"
       - name: DD_VERSION

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -35,6 +35,7 @@ datadog:
   profiling:
     fe: false # change to 'true' to enable profiling on FE pods;
     be: false # change to 'true' to enable profiling on BE pods;
+    cn: false # change to 'true' to enable profiling on CN pods;
     env: "starrocks-default" # the default value for DD_ENV;
 
 # This configuration is used to integrate with external system Prometheus.
@@ -286,6 +287,13 @@ starrocksCnSpec:
   # If runAsNonRoot is true, the container is run as non-root user.
   # The userId will be set to 1000, and the groupID will be set to 1000.
   runAsNonRoot: false
+  # add/drop capabilities for CN container.
+  capabilities: { }
+  #  add:
+  #    - PERFMON
+  #    - SYS_PTRACE
+  #  drop:
+  #    - SYS_ADMIN
   # specify the service name and port config and serviceType
   # the service type refer https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   service:
@@ -464,7 +472,7 @@ starrocksBeSpec:
   # If runAsNonRoot is true, the container is run as non-root user.
   # The userId will be set to 1000, and the groupID will be set to 1000.
   runAsNonRoot: false
-  # add/drop capabilities for BE container, DataDog profiling lib relies on it for example.
+  # add/drop capabilities for BE container.
   capabilities: {}
   #  add:
   #    - PERFMON

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -32,6 +32,10 @@ datadog:
     logConfig: '{}' # e.g. '{"app": "starrocks", "tags": ["aa", "bb"]}'
   metrics:
     enabled: false
+  profiling:
+    fe: false # change to 'true' to enable profiling on FE pods;
+    be: false # change to 'true' to enable profiling on BE pods;
+    env: "starrocks-default" # the default value for DD_ENV;
 
 # This configuration is used to integrate with external system Prometheus.
 metrics:

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -128,6 +128,7 @@ starrocks:
     profiling:
       fe: false # change to 'true' to enable profiling on FE pods;
       be: false # change to 'true' to enable profiling on BE pods;
+      cn: false # change to 'true' to enable profiling on CN pods;
       env: "starrocks-default" # the default value for DD_ENV;
   
   # This configuration is used to integrate with external system Prometheus.
@@ -379,6 +380,13 @@ starrocks:
     # If runAsNonRoot is true, the container is run as non-root user.
     # The userId will be set to 1000, and the groupID will be set to 1000.
     runAsNonRoot: false
+    # add/drop capabilities for CN container.
+    capabilities: { }
+    #  add:
+    #    - PERFMON
+    #    - SYS_PTRACE
+    #  drop:
+    #    - SYS_ADMIN
     # specify the service name and port config and serviceType
     # the service type refer https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     service:
@@ -557,7 +565,7 @@ starrocks:
     # If runAsNonRoot is true, the container is run as non-root user.
     # The userId will be set to 1000, and the groupID will be set to 1000.
     runAsNonRoot: false
-    # add/drop capabilities for BE container, DataDog profiling lib relies on it for example.
+    # add/drop capabilities for BE container.
     capabilities: {}
     #  add:
     #    - PERFMON

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -125,6 +125,10 @@ starrocks:
       logConfig: '{}' # e.g. '{"app": "starrocks", "tags": ["aa", "bb"]}'
     metrics:
       enabled: false
+    profiling:
+      fe: false # change to 'true' to enable profiling on FE pods;
+      be: false # change to 'true' to enable profiling on BE pods;
+      env: "starrocks-default" # the default value for DD_ENV;
   
   # This configuration is used to integrate with external system Prometheus.
   metrics:


### PR DESCRIPTION
# Description

Add datadog_profiling options in Helm chart to simplify the settings to enable dd profiling.

# Related Issue(s)

[Please list any related issues and link them here.](https://github.com/StarRocks/starrocks-kubernetes-operator/issues/423)

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).

-----Test Plan----
1. `helm lint`
2. `helm template` with settings on/off, and see the diff of `helm template starrocks .`
![Screenshot 2024-02-01 at 12 08 35 AM](https://github.com/StarRocks/starrocks-kubernetes-operator/assets/2017944/c3d51c36-91a4-455c-b845-a45355074460)
![Screenshot 2024-02-01 at 12 08 13 AM](https://github.com/StarRocks/starrocks-kubernetes-operator/assets/2017944/2746c580-de30-49a3-b4f5-20eb53433571)

3. apply the new `StarRocksCluster` yaml 

----Revision 2 Test Plan-------
1. turn on be/fe profiling, no difference compared with revision 1;
<img width="1305" alt="Screenshot 2024-02-01 at 2 03 29 PM" src="https://github.com/StarRocks/starrocks-kubernetes-operator/assets/2017944/75892987-47c7-4c1f-a27f-555fa7e8bb8f">

2. Add `starrocksBeSpec.capabilities` in values to confirm it's merged correctly
```
  capabilities:
    add:
      - PERFMON
      - SYS_PTRACE
    drop:
      - SYS_ADMIN
```
See output as below
 
<img width="1308" alt="Screenshot 2024-02-01 at 2 04 11 PM" src="https://github.com/StarRocks/starrocks-kubernetes-operator/assets/2017944/c7bfc08c-1107-4f49-b533-8c325fb9b915">

----revision 4 test plan-----
switch `  enabledBe/enabledCn: true/false`, plus with additional capabilities
```
  capabilities:
    add:
      - PERFMON
      - SYS_PTRACE
    drop:
      - SYS_ADMIN
```

The diff of helm template is shown as below:
<img width="1304" alt="Screenshot 2024-02-02 at 9 42 41 AM" src="https://github.com/StarRocks/starrocks-kubernetes-operator/assets/2017944/4adb8e5f-965f-4964-9164-cc45172ce039">

Dry-run
```
k apply -n xxxx -f ./issue-423.on.r3.yaml --dry-run="server"
configmap/kube-starrocks-cn-cm created (server dry run)
configmap/kube-starrocks-fe-cm created (server dry run)
starrockscluster.starrocks.com/kube-starrocks created (server dry run)
```
