### PR TITLE
[BugFix] Fix HPA deletion failed on GKE

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -247,11 +247,10 @@ func DeleteConfigMap(ctx context.Context, k8sClient client.Client, namespace, na
 	return k8sClient.Delete(ctx, &cm)
 }
 
-func DeleteAutoscaler(ctx context.Context, k8sClient client.Client, namespace, name string) error {
+func DeleteAutoscaler(ctx context.Context, k8sClient client.Client, namespace, name string, version srapi.AutoScalerVersion) error {
 	logger := logr.FromContextOrDiscard(ctx)
 	logger.Info("delete autoscaler from kubernetes", "name", name)
 
-	var version srapi.AutoScalerVersion
 	hpaObject := version.CreateEmptyHPA(KUBE_MAJOR_VERSION, KUBE_MINOR_VERSION)
 	if err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, hpaObject); apierrors.IsNotFound(err) {
 		return nil


### PR DESCRIPTION
# Description

Fixes: #420 

the root cause is In GKE environment, the Minor version is not a number, like v1.27.3-gke.100.
```
Server Version: version.Info{Major:"1", Minor:"27", GitVersion:"v1.27.3-gke.100", GitCommit:"6466b51b762a5c49ae3fb6c2c7233ffe1c96e48c", GitTreeState:"clean", BuildDate:"2023-06-23T09:27:28Z", GoVersion:"go1.20.5 X:boringcrypto", Compiler:"gc", Platform:"linux/amd64"}
```

How do I fix the issue? In StarRocksCluster CR status, there are fields about HPA.
```
    horizontalScaler:
      name: kube-starrocks-cn-autoscaler
      version: v2
```

we can first use this `version` to delete the HPA resource.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.