### PR TITLE
[Enhancement] support be_http_port and be_port in conf

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -426,6 +426,10 @@ starrocksCnSpec:
     # - name: tmp-data
     #   mountPath: /tmp
   # the config start for cn, the base information as follows.
+  # From StarRocks 3.1, the official documentation use:
+  #   1. be_port instead of thrift_port, but the thrift_port is still supported.
+  #   2. be_http_port instead of webserver_port, but the webserver_port is still supported.
+  # In order to avoid the impact of the change on the user's deployment, we still use the old configuration.
   config: |
     sys_log_level = INFO
     # ports for admin, web, heartbeat service
@@ -585,6 +589,9 @@ starrocksBeSpec:
     # - name: tmp-data
     #   mountPath: /tmp
   # the config for start be. the base information as follows.
+  # From StarRocks 3.1, the official documentation use:
+  #   1. be_http_port instead of webserver_port, but the webserver_port is still supported.
+  # In order to avoid the impact of the change on the user's deployment, we still use the old configuration.
   config: |
     be_port = 9060
     webserver_port = 8040

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -519,6 +519,10 @@ starrocks:
       # - name: tmp-data
       #   mountPath: /tmp
     # the config start for cn, the base information as follows.
+    # From StarRocks 3.1, the official documentation use:
+    #   1. be_port instead of thrift_port, but the thrift_port is still supported.
+    #   2. be_http_port instead of webserver_port, but the webserver_port is still supported.
+    # In order to avoid the impact of the change on the user's deployment, we still use the old configuration.
     config: |
       sys_log_level = INFO
       # ports for admin, web, heartbeat service
@@ -678,6 +682,9 @@ starrocks:
       # - name: tmp-data
       #   mountPath: /tmp
     # the config for start be. the base information as follows.
+    # From StarRocks 3.1, the official documentation use:
+    #   1. be_http_port instead of webserver_port, but the webserver_port is still supported.
+    # In order to avoid the impact of the change on the user's deployment, we still use the old configuration.
     config: |
       be_port = 9060
       webserver_port = 8040

--- a/pkg/common/resource_utils/configmap.go
+++ b/pkg/common/resource_utils/configmap.go
@@ -34,9 +34,18 @@ const (
 
 // the cn or be ports key
 const (
-	THRIFT_PORT            = "thrift_port"
-	BE_PORT                = "be_port"
-	WEBSERVER_PORT         = "webserver_port"
+	// THRIFT_PORT is the old name in CN.
+	// From StarRocks 3.1, both CN and BE use the same port name be_port.
+	THRIFT_PORT = "thrift_port"
+	BE_PORT     = "be_port"
+
+	// WEBSERVER_PORT and BE_HTTP_PORT
+	// From StarRocks 3.0, the name of HTTP port is changed to be_http_port in BE and CN.
+	WEBSERVER_PORT = "webserver_port"
+	BE_HTTP_PORT   = "be_http_port"
+
+	// HEARTBEAT_SERVICE_PORT and BRPC_PORT
+	// both BE and CN have the these ports
 	HEARTBEAT_SERVICE_PORT = "heartbeat_service_port"
 	BRPC_PORT              = "brpc_port"
 )
@@ -56,6 +65,7 @@ var DefMap = map[string]int32{
 	THRIFT_PORT:            9060,
 	BE_PORT:                9060,
 	WEBSERVER_PORT:         8040,
+	BE_HTTP_PORT:           8040,
 	HEARTBEAT_SERVICE_PORT: 9050,
 	BRPC_PORT:              8060,
 }
@@ -84,6 +94,15 @@ func GetPort(config map[string]interface{}, key string) int32 {
 		if port, err := strconv.ParseInt(v.(string), 10, 32); err == nil {
 			return int32(port)
 		}
+	} else if key == THRIFT_PORT {
+		// from StarRocks 3.1, the name of thrift_port is changed to be_port.
+		// If both be_port and thrift_port are set, the thrift_port will be used in StarRocks.
+		// see https://github.com/StarRocks/starrocks/pull/31747
+		return GetPort(config, BE_PORT)
+	} else if key == WEBSERVER_PORT {
+		// If both webserver_port and be_http_port are set, the be_http_port will be used in StarRocks.
+		// todo(yandongxiao): Call GetPort(config, BE_HTTP_PORT) not GetPort(config, WEBSERVER_PORT).
+		return GetPort(config, BE_HTTP_PORT)
 	}
 	return DefMap[key]
 }

--- a/pkg/common/resource_utils/configmap.go
+++ b/pkg/common/resource_utils/configmap.go
@@ -91,10 +91,12 @@ func ResolveConfigMap(configMap *corev1.ConfigMap, key string) (map[string]inter
 // GetPort get ports from config file.
 func GetPort(config map[string]interface{}, key string) int32 {
 	if v, ok := config[key]; ok {
-		if port, err := strconv.ParseInt(v.(string), 10, 32); err == nil {
+		if port, err := strconv.ParseInt(v.(string), 10, 32); err == nil && port != 0 {
 			return int32(port)
 		}
-	} else if key == THRIFT_PORT {
+	}
+
+	if key == THRIFT_PORT {
 		// from StarRocks 3.1, the name of thrift_port is changed to be_port.
 		// If both be_port and thrift_port are set, the thrift_port will be used in StarRocks.
 		// see https://github.com/StarRocks/starrocks/pull/31747
@@ -104,5 +106,6 @@ func GetPort(config map[string]interface{}, key string) int32 {
 		// todo(yandongxiao): Call GetPort(config, BE_HTTP_PORT) not GetPort(config, WEBSERVER_PORT).
 		return GetPort(config, BE_HTTP_PORT)
 	}
+
 	return DefMap[key]
 }


### PR DESCRIPTION
# Description

In the latest StarRocks version, the port names for BE and CN have been modified. The good news is that the old port names can still be used. However, if users use the new port names, Operators may not recognize them, leading to Operators potentially using default ports as liveness and readiness ports. This could result in container startup failures.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
