### PR TITLE
[Enhancement] support annotations and image filed for init-password job

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -4,6 +4,10 @@ kind: Job
 metadata:
   name: starrocks-initpwd
   namespace: {{ template "starrockscluster.namespace" . }}
+  {{- if .Values.initPassword.annotations }}
+  annotations:
+    {{- toYaml .Values.initPassword.annotations | nindent 4 }}
+  {{- end }}
 spec:
   template:
     spec:
@@ -17,7 +21,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "starrockscluster.name" . }}-initpwd
+        {{- if .Values.initPassword.image }}
+        image: {{ .Values.initPassword.image }}
+        {{- else }}
         image: {{ .Values.starrocksFESpec.image.repository }}:{{ include "starrockscluster.fe.image.tag" . }}
+        {{- end }}
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -17,6 +17,11 @@ initPassword:
   password: ""
   # The secret name that contains password, the key of the secret is "password", and you should create it first.
   passwordSecret: ""
+  # The image of the initPassword job, if it is not set, the FE image will be used.
+  # see https://github.com/StarRocks/starrocks-kubernetes-operator/issues/453 for why we need to set the image.
+  image: ""
+  # The annotations for the initPassword job.
+  annotations: {}
 
 # TimeZone is used to set the environment variable TZ for pod, with Asia/Shanghai as the default.
 timeZone: Asia/Shanghai

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -110,6 +110,11 @@ starrocks:
     password: ""
     # The secret name that contains password, the key of the secret is "password", and you should create it first.
     passwordSecret: ""
+    # The image of the initPassword job, if it is not set, the FE image will be used.
+    # see https://github.com/StarRocks/starrocks-kubernetes-operator/issues/453 for why we need to set the image.
+    image: ""
+    # The annotations for the initPassword job.
+    annotations: {}
   
   # TimeZone is used to set the environment variable TZ for pod, with Asia/Shanghai as the default.
   timeZone: Asia/Shanghai


### PR DESCRIPTION
# Related Issue(s)

Fixes: #453

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
