### PR TITLE
[BugFix] Ensure query port can be configured in init-password job

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -213,6 +213,20 @@ the first 8 digits are taken, which will be used as the annotations for pods.
   {{- end }}
 {{- end }}
 
+{{- define "starrockscluster.fe.query.port" -}}
+{{- $config := index .Values.starrocksFESpec.config  -}}
+{{- $configMap := dict -}}
+{{- range $line := splitList "\n" $config -}}
+{{- $pair := splitList "=" $line -}}
+{{- if eq (len $pair) 2 -}}
+{{- $_ := set $configMap (trim (index $pair 0)) (trim (index $pair 1)) -}}
+{{- end -}}
+{{- end -}}
+{{- if (index $configMap "query_port") -}}
+{{- print (index $configMap "query_port") }}
+{{- end }}
+{{- end }}
+
 {{- define "starrockscluster.fe.http.port" -}}
 {{- $config := index .Values.starrocksFESpec.config  -}}
 {{- $configMap := dict -}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -24,7 +24,7 @@ spec:
         args:
         - /opt/starrocks/fe_initpwd.sh
         - {{ template "starrockscluster.name" . }}-fe-0.{{ template "starrockscluster.name" . }}-fe-search
-        - "9030"
+        - "{{- default 9030 (include "starrockscluster.fe.query.port" .) }}"
         env:
         - name: INIT_PWD
           valueFrom:


### PR DESCRIPTION
# Description

A scenario that requires modifying the container listening query port:

1. The source cluster is deployed on virtual machines, while the target cluster is deployed on k8s. External access to the internal IP of k8s is not possible, but pods within k8s can access external IPs.
2. The migration tool is deployed outside of k8s. The StarRocks cluster on k8s is exposed through /etc/host (frontend domain name, node IP of k8s) + NodePort.
3. In the cross-cluster migration tool, use the port obtained from `Show Frontend` for recording in Frontend. At the same time, use this port to access the target cluster (instead of configuring target_fe_query_port).
4. The target cluster pulls data from the source cluster.

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
