### PR TITLE
[Enhancement] Support tolerations for init-password job

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -19,6 +19,10 @@ spec:
       affinity:
         {{- include "starrockscluster.fe.affinity" . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.starrocksFESpec.tolerations .Values.starrocksCluster.componentValues.tolerations }}
+      tolerations:
+        {{- include "starrockscluster.fe.tolerations" . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "starrockscluster.name" . }}-initpwd
         {{- if .Values.initPassword.image }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -184,6 +184,7 @@ starrocksFESpec:
     #       name: mysecret
     #       key: username
   # affinity for fe pod scheduling.
+  # Note: It will affect the scheduling of the init-password job.
   affinity: {}
     # nodeAffinity:
     #   requiredDuringSchedulingIgnoredDuringExecution:
@@ -195,6 +196,7 @@ starrocksFESpec:
     #         - target-host-name
   # Node tolerations for fe pod scheduling to nodes with taints
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # Note: It will affect the scheduling of the init-password job.
   tolerations: []
     # - key: "key"
     #   operator: "Equal|Exists"

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -281,6 +281,7 @@ starrocks:
       #       name: mysecret
       #       key: username
     # affinity for fe pod scheduling.
+    # Note: It will affect the scheduling of the init-password job.
     affinity: {}
       # nodeAffinity:
       #   requiredDuringSchedulingIgnoredDuringExecution:
@@ -292,6 +293,7 @@ starrocks:
       #         - target-host-name
     # Node tolerations for fe pod scheduling to nodes with taints
     # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    # Note: It will affect the scheduling of the init-password job.
     tolerations: []
       # - key: "key"
       #   operator: "Equal|Exists"


### PR DESCRIPTION
# Description

when .Values.starrocksFESpec.tolerations or .Values.starrocksCluster.componentValues.tolerations is configured, the FE init-password Job will respect this.

This is the rendered result:
```
kind: Job
metadata:
  name: starrocks-initpwd
  namespace: starrocks
spec:
  template:
    spec:
      tolerations:
        - effect: NoSchedule
          key: key
          operator: Equal|Exists
          value: value
```

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
