### PR TITLE
[Enhancement] clean minor version of k8s

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
+	"unicode"
 
 	"github.com/go-logr/logr"
 
@@ -322,8 +324,20 @@ func GetKubernetesVersion() error {
 	}
 
 	KUBE_MAJOR_VERSION = version.Major
-	KUBE_MINOR_VERSION = version.Minor
+	// KUBE_MINOR_VERSION is the minor version of the kubernetes cluster, but in cloud provider, the minor version may
+	// be like "28+" from alibaba cloud. So we need to remove the non-digit characters.
+	KUBE_MINOR_VERSION = CleanMinorVersion(version.Minor)
 	return nil
+}
+
+// cleanMinorVersion removes non-digit characters from a Kubernetes minor version string.
+func CleanMinorVersion(version string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsDigit(r) {
+			return r
+		}
+		return -1 // Drop non-digit characters
+	}, version)
 }
 
 // GetEnvVarValue returns the value of an environment variable. It handles both Value and ValueFrom cases.

--- a/pkg/k8sutils/k8sutils_test.go
+++ b/pkg/k8sutils/k8sutils_test.go
@@ -642,3 +642,36 @@ func TestApplyStatefulSet(t *testing.T) {
 		})
 	}
 }
+
+func Test_cleanMinorVersion(t *testing.T) {
+	type args struct {
+		version string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "clean minor version",
+			args: args{
+				version: "20",
+			},
+			want: "20",
+		},
+		{
+			name: "clean minor version with non-digit character",
+			args: args{
+				version: "20+",
+			},
+			want: "20",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := k8sutils.CleanMinorVersion(tt.args.version); got != tt.want {
+				t.Errorf("cleanMinorVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

In cloud provider, the minor version may be like "28+" from alibaba cloud. So we need to remove the non-digit characters.

this is from alibaba cloud

```
{
  "major": "1",
  "minor": "28+",
  "gitVersion": "v1.28.3-aliyun.1",
  "gitCommit": "7b6ea506b6deb03bac7aaeb10f6ee0a99004b147",
  "gitTreeState": "clean",
  "buildDate": "2023-10-19T07:10:40Z",
  "goVersion": "go1.20.10",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```

and this is from eks cloud
```
{
  "major": "1",
  "minor": "27",
  "gitVersion": "v1.27.8-gke.1067004",
  "gitCommit": "6f460c12ad45abb234c18ec4f0ea335a1203c415",
  "gitTreeState": "clean",
  "buildDate": "2024-01-04T22:48:32Z",
  "goVersion": "go1.20.11 X:boringcrypto",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.