### PR TITLE
[Bug][issue-478] quota config-has annotation

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
     {{- end }}
     annotations:
-      app.starrocks.io/fe-config-hash: {{template "starrockscluster.fe.config.hash" . }}
+      app.starrocks.io/fe-config-hash: "{{template "starrockscluster.fe.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
       {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
       ad.datadoghq.com/fe.logs: '[{"service":"starrocks","source":"fe"}]'
@@ -241,7 +241,7 @@ spec:
       {{- end }}
     {{- end }}
     annotations:
-      app.starrocks.io/be-config-hash: {{template "starrockscluster.be.config.hash" . }}
+      app.starrocks.io/be-config-hash: "{{template "starrockscluster.be.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
       {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
       ad.datadoghq.com/be.logs: '[{"service":"starrocks","source":"be"}]'
@@ -567,7 +567,7 @@ spec:
       {{- end }}
     {{- end }}
     annotations:
-      app.starrocks.io/cn-config-hash: {{template "starrockscluster.cn.config.hash" . }}
+      app.starrocks.io/cn-config-hash: "{{template "starrockscluster.cn.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
       {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
       ad.datadoghq.com/cn.logs: '[{"service":"starrocks","source":"cn"}]'


### PR DESCRIPTION
# Description

Add quota to `app.starrocks.io/xx-config-hash` annotation

# Related Issue(s)

https://github.com/StarRocks/starrocks-kubernetes-operator/issues/478

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ ] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ ] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).


-----
## Test Plan

```
helm template starrocks . -f values.yaml
```

```
# two CRs with/out quote
$ diff be-hash-no-quoted.yaml be-hash-quoted.yaml 
135c135
<       app.starrocks.io/fe-config-hash: e615d940
---
>       app.starrocks.io/fe-config-hash: "e615d940"
156c156
<       app.starrocks.io/be-config-hash: 00722900
---
>       app.starrocks.io/be-config-hash: "00722900"

# apply both manually

$ k apply -f be-hash-no-quoted.yaml --dry-run="server"
configmap/kube-starrocks-be-cm created (server dry run)
configmap/kube-starrocks-fe-cm created (server dry run)
The StarRocksCluster "kube-starrocks" is invalid: spec.starRocksBeSpec.annotations.app.starrocks.io/be-config-hash: Invalid value: "integer": spec.starRocksBeSpec.annotations.app.starrocks.io/be-config-hash in body must be of type string: "integer"

$ k apply -f be-hash-quoted.yaml --dry-run="server"
configmap/kube-starrocks-be-cm created (server dry run)
configmap/kube-starrocks-fe-cm created (server dry run)
starrockscluster.starrocks.com/kube-starrocks created (server dry run)

$ diff be-hash-no-quoted.yaml be-hash-quoted.yaml 
135c135
<       app.starrocks.io/fe-config-hash: e615d940
---
>       app.starrocks.io/fe-config-hash: "e615d940"
156c156
<       app.starrocks.io/be-config-hash: 00722900
---
>       app.starrocks.io/be-config-hash: "00722900"

```
