### PR TITLE
[BugFix] Make sure xx-config-hash is a valid string

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
     {{- end }}
     annotations:
-      app.starrocks.io/fe-config-hash: {{template "starrockscluster.fe.config.hash" . }}
+      app.starrocks.io/fe-config-hash: "{{template "starrockscluster.fe.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
       {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
       ad.datadoghq.com/fe.logs: '[{"service":"starrocks","source":"fe"}]'
@@ -241,7 +241,7 @@ spec:
       {{- end }}
     {{- end }}
     annotations:
-      app.starrocks.io/be-config-hash: {{template "starrockscluster.be.config.hash" . }}
+      app.starrocks.io/be-config-hash: "{{template "starrockscluster.be.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
       {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
       ad.datadoghq.com/be.logs: '[{"service":"starrocks","source":"be"}]'
@@ -567,7 +567,7 @@ spec:
       {{- end }}
     {{- end }}
     annotations:
-      app.starrocks.io/cn-config-hash: {{template "starrockscluster.cn.config.hash" . }}
+      app.starrocks.io/cn-config-hash: "{{template "starrockscluster.cn.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
       {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
       ad.datadoghq.com/cn.logs: '[{"service":"starrocks","source":"cn"}]'

--- a/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
+++ b/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
@@ -80,7 +80,7 @@ spec:
       {{- end }}
     {{- end }}
     annotations:
-      app.starrocks.io/cn-config-hash: {{template "starrockswarehouse.config.hash" . }}
+      app.starrocks.io/cn-config-hash: "{{template "starrockswarehouse.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
       {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
       ad.datadoghq.com/warehouse.logs: '[{"service":"warehouse"}]'


### PR DESCRIPTION
# Related Issue(s)

Fixes: #478 

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
