### PR TITLE
[issue481]expose datadog config.mode in helm chart

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -74,7 +74,7 @@ spec:
       {{- include "starrockscluster.fe.podLabels" . | nindent 6 }}
       {{- end }}
       {{- if .Values.datadog.profiling.fe }}
-      admission.datadoghq.com/config.mode: service
+      admission.datadoghq.com/config.mode: {{ .Values.datadog.profiling.configMode }}
       admission.datadoghq.com/enabled: "true"
       {{- end }}
     {{- end }}
@@ -287,7 +287,7 @@ spec:
       {{- include "starrockscluster.be.podLabels" . | nindent 6 }}
       {{- end }}
       {{- if .Values.datadog.profiling.be }}
-      admission.datadoghq.com/config.mode: service
+      admission.datadoghq.com/config.mode: {{ .Values.datadog.profiling.configMode }}
       admission.datadoghq.com/enabled: "true"
       {{- end }}
     {{- end }}
@@ -452,7 +452,7 @@ spec:
       {{- include "starrockscluster.cn.podLabels" . | nindent 6 }}
       {{- end }}
       {{- if .Values.datadog.profiling.cn }}
-      admission.datadoghq.com/config.mode: service
+      admission.datadoghq.com/config.mode: {{ .Values.datadog.profiling.configMode }}
       admission.datadoghq.com/enabled: "true"
       {{- end }}
     {{- end }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -42,6 +42,7 @@ datadog:
     be: false # change to 'true' to enable profiling on BE pods;
     cn: false # change to 'true' to enable profiling on CN pods;
     env: "starrocks-default" # the default value for DD_ENV;
+    configMode: "service" # see https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator#configure-apm-and-dogstatsd-communication-mode
 
 # This configuration is used to integrate with external system Prometheus.
 metrics:

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -139,6 +139,7 @@ starrocks:
       be: false # change to 'true' to enable profiling on BE pods;
       cn: false # change to 'true' to enable profiling on CN pods;
       env: "starrocks-default" # the default value for DD_ENV;
+      configMode: "service" # see https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator#configure-apm-and-dogstatsd-communication-mode
   
   # This configuration is used to integrate with external system Prometheus.
   metrics:


### PR DESCRIPTION
# Description

Please provide a detailed description of the changes you have made. Include the motivation for these changes, and any
additional context that may be important.
> the PR should include helm chart changes and operator changes.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).


-------------------
## Test Plan
* default
```
+    fe: true # change to 'true' to enable profiling on FE pods;
+    be: true # change to 'true' to enable profiling on BE pods;
+    configMode: "service"

===>
$ helm template starrocks . | grep 'config.mode'
      admission.datadoghq.com/config.mode: service
      admission.datadoghq.com/config.mode: service
```

* `socket`
```
+    fe: true # change to 'true' to enable profiling on FE pods;
+    be: true # change to 'true' to enable profiling on BE pods;
+    configMode: "socket"

===>
$ helm template starrocks . | grep 'config.mode'
      admission.datadoghq.com/config.mode: socket
      admission.datadoghq.com/config.mode: socket
```