### PR TITLE
[Documentation] Remove `storageClassName: ""` Configuration

### DIFF
--- a/doc/cn/logging_and_related_configurations_howto.md
+++ b/doc/cn/logging_and_related_configurations_howto.md
@@ -34,7 +34,7 @@ spec:
       - mountPath: /opt/starrocks/fe/log
         name: fe-storage-log
         storageSize: 10Gi
-        storageClassName: ""
+        # storageClassName: ""  # 如果 storageClassName 为空，Kubernetes 将使用默认的存储卷类型。
 ```
 
 `storageClassName` 如果为空，Kubernetes 将使用默认的存储卷类型。你也可以通过 `kubectl get storageclass` 查看 Kubernetes
@@ -55,7 +55,7 @@ starrocks:
       name: "fe-storage"
       storageSize: 10Gi
       logStorageSize: 10Gi
-      storageClassName: ""
+      # storageClassName: ""  # 如果 storageClassName 为空，Kubernetes 将使用默认的存储卷类型。
 ```
 
 针对 starrocks Helm Chart，可以这样配置：
@@ -66,7 +66,7 @@ starrocksFESpec:
     name: "fe-storage"
     storageSize: 10Gi
     logStorageSize: 10Gi
-    storageClassName: ""
+    # storageClassName: ""  # 如果 storageClassName 为空，Kubernetes 将使用默认的存储卷类型。
 ```
 
 > 注意

--- a/doc/logging_and_related_configurations_howto.md
+++ b/doc/logging_and_related_configurations_howto.md
@@ -39,7 +39,7 @@ spec:
       - mountPath: /opt/starrocks/fe/log
         name: fe-storage-log
         storageSize: 10Gi
-        storageClassName: ""
+        # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
 ```
 
 If `storageClassName` is left blank, the default storage class will be used. You can view available storage classes in
@@ -64,7 +64,7 @@ starrocks:
       name: "fe-storage"
       storageSize: 10Gi
       logStorageSize: 10Gi
-      storageClassName: ""
+      # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
 ```
 
 For the starrocks Helm Chart, configure as:
@@ -75,7 +75,7 @@ starrocksFESpec:
     name: "fe-storage"
     storageSize: 10Gi
     logStorageSize: 10Gi
-    storageClassName: ""
+    # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
 ```
 
 > Note:

--- a/doc/mount_persistent_volume_howto.md
+++ b/doc/mount_persistent_volume_howto.md
@@ -32,7 +32,7 @@ spec:
     replicas: 1
     storageVolumes:
     - name: fe-storage-meta
-      storageClassName: standard-rwo  # standard-rwo is the default storageClassName in gke.
+      storageClassName: standard-rwo  # standard-rwo is the default storageClassName in GKE.
       # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
       storageSize: 10Gi
       mountPath: /opt/starrocks/fe/meta
@@ -80,7 +80,7 @@ starrocks:
       name: ""
       # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
       # you must set name when you set storageClassName
-      storageClassName: ""
+      # storageClassName: ""
       # the persistent volume size， default 10Gi.
       # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
       storageSize: 10Gi
@@ -110,7 +110,7 @@ starrocks:
          tag: 3.2-latest
       storageSpec:
          name: fe-storage
-         storageClassName: standard-rwo   # standard-rwo is the default storageClassName in gke.
+         storageClassName: standard-rwo   # standard-rwo is the default storageClassName in GKE.
          logStorageSize: 10Gi
          storageSize: 100Gi
    starrocksBeSpec:

--- a/examples/starrocks/deploy_a_starrocks_cluster_with_all_features.yaml
+++ b/examples/starrocks/deploy_a_starrocks_cluster_with_all_features.yaml
@@ -26,14 +26,14 @@ spec:
     storageVolumes:
       - name: fe-storage-meta
         # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
-        storageClassName: ""
+        # storageClassName: ""
         # the persistent volume size. FE container stop running if the disk free space which the
         # fe meta directory residents, is less than 5Gi.
         storageSize: 10Gi
         # the mount path for FE meta.
         mountPath: /opt/starrocks/fe/meta
       - name: fe-storage-log
-        storageClassName: ""
+        # storageClassName: ""
         # the size of storage volume for log
         storageSize: 1Gi
         # the mount path for FE log.
@@ -141,13 +141,13 @@ spec:
     storageVolumes:
       - name: be-storage-data
         # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
-        storageClassName: ""
+        # storageClassName: ""
         # the size of storage volume for data
         storageSize: 10Gi
         # the mount path for BE data.
         mountPath: /opt/starrocks/be/storage
       - name: be-storage-log
-        storageClassName: ""
+        # storageClassName: ""
         # the size of storage volume for log
         storageSize: 1Gi
         # the mount path for BE log.
@@ -248,13 +248,13 @@ spec:
     storageVolumes:
       - name: cn-storage-data
         # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
-        storageClassName: ""
+        # storageClassName: ""
         # the size of storage volume for data
         storageSize: 10Gi
         # the mount path of CN data
         mountPath: /opt/starrocks/cn/storage
       - name: cn-storage-log
-        storageClassName: ""
+        # storageClassName: ""
         # the size of storage volume for log
         storageSize: 1Gi
         # the mount path of CN log

--- a/examples/starrocks/deploy_a_starrocks_cluster_with_persistent_storage.yaml
+++ b/examples/starrocks/deploy_a_starrocks_cluster_with_persistent_storage.yaml
@@ -27,11 +27,11 @@ spec:
       memory: 16Gi
     storageVolumes:
     - name: fe-storage-meta
-      storageClassName: ""  # you can remove this line if you want to use the default storage class
+      # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 10Gi   # the size of storage volume for metadata
       mountPath: /opt/starrocks/fe/meta   # the path of metadata
     - name: fe-storage-log
-      storageClassName: ""  # you can remove this line if you want to use the default storage class
+      # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 1Gi    # the size of storage volume for log
       mountPath: /opt/starrocks/fe/log    # the path of log
   starRocksBeSpec:
@@ -45,11 +45,11 @@ spec:
       memory: 64Gi
     storageVolumes:
     - name: be-storage-data
-      storageClassName: ""  # you can remove this line if you want to use the default storage class
+      # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 10Gi   # the size of storage volume for data
       mountPath: /opt/starrocks/be/storage  # the path of data
     - name: be-storage-log
-      storageClassName: ""  # you can remove this line if you want to use the default storage class
+      # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 1Gi  # the size of storage volume for log
       mountPath: /opt/starrocks/be/log  # the path of log
   starRocksCnSpec:
@@ -63,10 +63,10 @@ spec:
       memory: 64Gi
     storageVolumes:
     - name: cn-storage-data
-      storageClassName: ""  # you can remove this line if you want to use the default storage class
+      # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 10Gi   # the size of storage volume for data
       mountPath: /opt/starrocks/cn/storage  # the path of data
     - name: cn-storage-log
-      storageClassName: ""  # you can remove this line if you want to use the default storage class
+      # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 1Gi  # the size of storage volume for log
       mountPath: /opt/starrocks/cn/log  # the path of log

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -280,7 +280,7 @@ type StorageVolume struct {
 	Name string `json:"name"`
 
 	// storageClassName is the name of the StorageClass required by the claim.
-	// If storageClassName is empty, the default StorageClass of kubernetes will be used.
+	// If storageClassName is not set, the default StorageClass of kubernetes will be used.
 	// there are some special storageClassName: emptyDir, hostPath. In this case, It will use emptyDir or hostPath, not PVC.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
 	// +optional

--- a/scripts/migrate-chart-value/main_test.go
+++ b/scripts/migrate-chart-value/main_test.go
@@ -81,7 +81,6 @@ starrocksFESpec:
       memory: 8Gi
   storageSpec:
     name: ""
-    storageClassName: ""
     storageSize: 1Gi
     logStorageSize: 1Gi
   config: |
@@ -159,7 +158,6 @@ starrocksBeSpec:
       memory: 8Gi
   storageSpec:
     name: ""
-    storageClassName: ""
     storageSize: 1Ti
     logStorageSize: 1Gi
   config: |
@@ -243,7 +241,6 @@ starrocks:
         memory: 8Gi
     storageSpec:
       name: ""
-      storageClassName: ""
       storageSize: 1Gi
       logStorageSize: 1Gi
     config: |
@@ -321,7 +318,6 @@ starrocks:
         memory: 8Gi
     storageSpec:
       name: ""
-      storageClassName: ""
       storageSize: 1Ti
       logStorageSize: 1Gi
     config: |


### PR DESCRIPTION
# Description

Deploy the following YAML file in a GKE environment:
```
# This manifest deploys a StarRocks cluster with 3 FEs, 3 BEs.
apiVersion: starrocks.com/v1
kind: StarRocksCluster
metadata:
  name: starrockscluster-sample
  namespace: starrocks
  labels:
    cluster: starrockscluster-sample
spec:
  starRocksFeSpec:
    image: "starrocks/fe-ubuntu:3.2-latest"
    # storageVolumes is optional. If you don't specify it, emptyDir will be used to store FE meta and log, and be aware
    # that the files and directories written to the volume will be completely lost upon container restarting.
    storageVolumes:
    - name: fe-storage-meta
      # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
      storageSize: 10Gi
      storageClassName: ""
      mountPath: /opt/starrocks/fe/meta
    - name: fe-storage-log
      storageSize: 5Gi
      storageClassName: ""
      mountPath: /opt/starrocks/fe/log
  starRocksBeSpec:
    image: "starrocks/be-ubuntu:3.2-latest"
    replicas: 1
    # storageVolumes is optional. If you don't specify it, emptyDir will be used to store BE data and log, and be aware
    # that the files and directories written to the volume will be completely lost upon container restarting.
    storageVolumes:
    - name: be-storage-data
      storageSize: 1Gi
      storageClassName: ""
      mountPath: /opt/starrocks/be/storage
    - name: be-storage-log
      storageSize: 1Gi
      storageClassName: ""
      mountPath: /opt/starrocks/be/log
```

Got the following error:

```
 k get pods
NAME                                       READY   STATUS    RESTARTS   AGE
kube-starrocks-operator-5c55f5569c-xxz2b   1/1     Running   0          135m
starrockscluster-sample-fe-0               0/1     Pending   0          11m
```

The pending reason is:
```
Events:
  Type     Reason             Age                 From                Message
  ----     ------             ----                ----                -------
  Normal   NotTriggerScaleUp  97s (x62 over 11m)  cluster-autoscaler  pod didn't trigger scale-up:
  Warning  FailedScheduling   94s (x4 over 11m)   default-scheduler   0/2 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/2 nodes are available: 2 Preemption is not helpful for scheduling..
```

Setting storageClassName to "" (an empty string) indicates that the PVC should not use dynamic volume provisioning to create a PV. Instead, it needs to be manually bound to a pre-existing PV.

# How to fix

If the storageClassName attribute is omitted in the PVC, it will use the default StorageClass configured for the cluster.