### PR TITLE
[Enhancement] Support to customize resources for starrocks helm chart

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/resources.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/resources.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.resources }}
+{{- toYaml . | nindent 0 }}
+---
+{{- end }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -726,6 +726,14 @@ configMaps: []
   #       this is the content of the configmap
   #       when mounted, key will be the name of the file
 
+# If you needs to deploy other resources, e.g. serviceAccount, you can add them here.
+resources: []
+  # - apiVersion: v1
+  #   kind: ServiceAccount
+  #   metadata:
+  #     name: sa-for-starrocks
+  #     namespace: starrocks
+
 # specify the fe proxy deploy or not.
 starrocksFeProxySpec:
   # specify the fe proxy deploy or not.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -823,6 +823,14 @@ starrocks:
     #       this is the content of the configmap
     #       when mounted, key will be the name of the file
   
+  # If you needs to deploy other resources, e.g. serviceAccount, you can add them here.
+  resources: []
+    # - apiVersion: v1
+    #   kind: ServiceAccount
+    #   metadata:
+    #     name: sa-for-starrocks
+    #     namespace: starrocks
+  
   # specify the fe proxy deploy or not.
   starrocksFeProxySpec:
     # specify the fe proxy deploy or not.


### PR DESCRIPTION
# Description

When deploying StarRocks using Helm chart, users often need additional configurations in their environment. For example, in an EKS environment, they may need to deploy SecurityGroupPolicy and TargetGroupBinding. The user's solution is to download the chart, modify it, which poses a significant challenge when upgrading the chart.

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
