### PR TITLE
[Enhancement] Upgrade golang version to 1.22

### DIFF
--- a/.github/workflows/action-golangci-lint.yml
+++ b/.github/workflows/action-golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/action-make-test.yml
+++ b/.github/workflows/action-make-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.22
       - name: Call make ci-manifests
         run: make ci-manifests
       - name: Call make test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/StarRocks/starrocks-kubernetes-operator
 
-go 1.20
+go 1.22
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.1


### PR DESCRIPTION
# Description

when execute `make test`, it will need to install setup-envtest binary. Encountered the following error.
```
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest (in sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240327193027-21368602d84b): go.mod:3: invalid go version '1.22.0': must match format 1.23
make: *** [envtest] Error 1
```

need to upgrade to golang version 1.22 to solve this problem.