### PR TITLE
[Chore] format some template yaml files in helm chart

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -53,21 +53,21 @@ starrockscluster
 {{- define "starrockscluster.fe.config" -}}
 fe.conf: |
 {{- if .Values.starrocksFESpec.config }}
-{{ .Values.starrocksFESpec.config | indent 2 }}
+{{- .Values.starrocksFESpec.config | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "starrockscluster.cn.config" -}}
 cn.conf: |
-{{- if .Values.starrocksCnSpec.config | indent 2 }}
-{{ .Values.starrocksCnSpec.config | indent 2 }}
+{{- if .Values.starrocksCnSpec.config }}
+{{- .Values.starrocksCnSpec.config | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "starrocksclster.be.config" -}}
 be.conf: |
-{{- if .Values.starrocksBeSpec.config | indent 2 }}
-{{ .Values.starrocksBeSpec.config | indent 2 }}
+{{- if .Values.starrocksBeSpec.config }}
+{{- .Values.starrocksBeSpec.config | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/beconfigmap.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/beconfigmap.yaml
@@ -8,7 +8,7 @@ metadata:
     cluster: {{ template "starrockscluster.name" . }}
     app: "be"
 data:
-{{ include "starrocksclster.be.config" . | indent 2 }}
+  {{- include "starrocksclster.be.config" . | nindent 2 }}
 
 {{- end }}
 

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/cnconfigmap.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/cnconfigmap.yaml
@@ -8,6 +8,6 @@ metadata:
     cluster: {{ template "starrockscluster.name" . }}
     app: "cn"
 data:
-{{ include "starrockscluster.cn.config" . | indent 2 }}
+  {{- include "starrockscluster.cn.config" . | nindent 2 }}
 
 {{- end }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/feconfigmap.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/feconfigmap.yaml
@@ -7,4 +7,4 @@ metadata:
     cluster: {{ template "starrockscluster.name" . }}
     app: "fe"
 data:
-{{ include "starrockscluster.fe.config" . | indent 2 }}
+  {{- include "starrockscluster.fe.config" . | nindent 2 }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: {{ template "starrockscluster.namespace" . }}
   labels:
     cluster: {{ template "starrockscluster.name" . }}
-{{- include "starrockscluster.labels" . | nindent 4 }}
-{{- if .Values.starrocksCluster.annotations }}
+  {{- include "starrockscluster.labels" . | nindent 4 }}
+  {{- if .Values.starrocksCluster.annotations }}
   annotations:
-    {{ toYaml .Values.starrocksCluster.annotations | nindent 4 }}
-{{- end }}
+    {{- toYaml .Values.starrocksCluster.annotations | nindent 4 }}
+  {{- end }}
 spec:
   starRocksFeSpec:
     image: "{{ .Values.starrocksFESpec.image.repository }}:{{ include "starrockscluster.fe.image.tag" . }}"
@@ -53,9 +53,9 @@ spec:
       ad.datadoghq.com/fe.logs: {{ printf "[%s]" (printf "{%s, \"source\": \"fe\", \"service\": \"starrocks\"}" (trimAll " {}" .Values.datadog.log.logConfig) | fromJson | toJson) | squote }}
       {{- end }}
       {{- end }}
-{{- if .Values.starrocksFESpec.annotations }}
-{{ toYaml .Values.starrocksFESpec.annotations | indent 6 }}
-{{- end }}
+      {{- if .Values.starrocksFESpec.annotations }}
+      {{- toYaml .Values.starrocksFESpec.annotations | nindent 6 }}
+      {{- end }}
     {{- if or .Values.starrocksFESpec.imagePullSecrets .Values.starrocksCluster.componentValues.imagePullSecrets }}
     imagePullSecrets:
       {{- include "starrockscluster.fe.imagePullSecrets" . | nindent 6 }}
@@ -161,22 +161,22 @@ spec:
     sidecars:
       {{- toYaml .Values.starrocksFESpec.sidecars | nindent 6 }}
     {{- end }}
-{{- if .Values.starrocksFESpec.secrets }}
+    {{- if .Values.starrocksFESpec.secrets }}
     secrets:
     {{- range .Values.starrocksFESpec.secrets }}
     - name: {{ .name }}
       mountPath: {{ .mountPath }}
       subPath: {{ .subPath }}
     {{- end }}
-{{- end }}
-{{- if .Values.starrocksFESpec.configMaps }}
+    {{- end }}
+    {{- if .Values.starrocksFESpec.configMaps }}
     configMaps:
     {{- range .Values.starrocksFESpec.configMaps }}
       - name: {{ .name }}
         mountPath: {{ .mountPath }}
         subPath: {{ .subPath }}
     {{- end }}
-{{- end }}
+    {{- end }}
     configMapInfo:
       configMapName: {{ template  "starrockscluster.fe.configmap.name" . }}
       resolveKey: fe.conf
@@ -210,7 +210,7 @@ spec:
     {{- end }}
     {{- end }}
 
-{{- if .Values.starrocksCluster.enabledBe }}
+  {{- if .Values.starrocksCluster.enabledBe }}
   starRocksBeSpec:
     image: "{{ .Values.starrocksBeSpec.image.repository }}:{{ include "starrockscluster.be.image.tag" . }}"
     replicas: {{ .Values.starrocksBeSpec.replicas }}
@@ -253,9 +253,9 @@ spec:
       ad.datadoghq.com/be.logs: {{ printf "[%s]" (printf "{%s, \"source\": \"be\", \"service\": \"starrocks\"}" (trimAll " {}" .Values.datadog.log.logConfig) | fromJson | toJson) | squote }}
       {{- end }}
       {{- end }}
-{{- if .Values.starrocksBeSpec.annotations }}
-{{ toYaml .Values.starrocksBeSpec.annotations | indent 6 }}
-{{- end }}
+      {{- if .Values.starrocksBeSpec.annotations }}
+      {{- toYaml .Values.starrocksBeSpec.annotations | nindent 6 }}
+      {{- end }}
     {{- if or .Values.starrocksBeSpec.imagePullSecrets .Values.starrocksCluster.componentValues.imagePullSecrets }}
     imagePullSecrets:
       {{- include "starrockscluster.be.imagePullSecrets" . | nindent 6 }}
@@ -374,22 +374,22 @@ spec:
     sidecars:
       {{- toYaml .Values.starrocksBeSpec.sidecars | nindent 6 }}
     {{- end }}
-{{- if .Values.starrocksBeSpec.secrets }}
+    {{- if .Values.starrocksBeSpec.secrets }}
     secrets:
     {{- range .Values.starrocksBeSpec.secrets }}
     - name: {{ .name }}
       mountPath: {{ .mountPath }}
       subPath: {{ .subPath }}
     {{- end }}
-{{- end }}
-{{- if .Values.starrocksBeSpec.configMaps }}
+    {{- end }}
+    {{- if .Values.starrocksBeSpec.configMaps }}
     configMaps:
     {{- range .Values.starrocksBeSpec.configMaps }}
       - name: {{ .name }}
         mountPath: {{ .mountPath }}
         subPath: {{ .subPath }}
     {{- end }}
-{{- end }}
+    {{- end }}
     configMapInfo:
       configMapName: {{template "starrockscluster.be.configmap.name" . }}
       resolveKey: be.conf
@@ -423,7 +423,7 @@ spec:
     {{- end }}
     {{- end }}
   {{- end }}
-{{- if .Values.starrocksCluster.enabledCn }}
+  {{- if .Values.starrocksCluster.enabledCn }}
   starRocksCnSpec:
     image: "{{ .Values.starrocksCnSpec.image.repository }}:{{ include "starrockscluster.cn.image.tag" . }}"
     {{- if .Values.starrocksCnSpec.replicas }}
@@ -587,29 +587,29 @@ spec:
       ad.datadoghq.com/cn.logs: {{ printf "[%s]" (printf "{%s, \"source\": \"cn\", \"service\": \"starrocks\"}" (trimAll " {}" .Values.datadog.log.logConfig) | fromJson | toJson) | squote }}
       {{- end }}
       {{- end }}
-{{- if .Values.starrocksCnSpec.annotations }}
-{{ toYaml .Values.starrocksCnSpec.annotations | indent 6 }}
-{{- end }}
+      {{- if .Values.starrocksCnSpec.annotations }}
+      {{- toYaml .Values.starrocksCnSpec.annotations | nindent 6 }}
+      {{- end }}
     {{- if or .Values.starrocksCnSpec.imagePullSecrets .Values.starrocksCluster.componentValues.imagePullSecrets }}
     imagePullSecrets:
       {{- include "starrockscluster.cn.imagePullSecrets" . | nindent 6 }}
     {{- end }}
-{{- if .Values.starrocksCnSpec.secrets }}
+    {{- if .Values.starrocksCnSpec.secrets }}
     secrets:
     {{- range .Values.starrocksCnSpec.secrets }}
     - name: {{ .name }}
       mountPath: {{ .mountPath }}
       subPath: {{ .subPath }}
     {{- end }}
-{{- end }}
-{{- if .Values.starrocksCnSpec.configMaps }}
+    {{- end }}
+    {{- if .Values.starrocksCnSpec.configMaps }}
     configMaps:
     {{- range .Values.starrocksCnSpec.configMaps }}
       - name: {{ .name }}
         mountPath: {{ .mountPath }}
         subPath: {{ .subPath }}
     {{- end }}
-{{- end }}
+    {{- end }}
     configMapInfo:
       configMapName: {{template  "starrockscluster.cn.configmap.name" . }}
       resolveKey: cn.conf

--- a/helm-charts/charts/warehouse/templates/_helpers.tpl
+++ b/helm-charts/charts/warehouse/templates/_helpers.tpl
@@ -17,8 +17,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{- define "starrockswarehouse.config" -}}
 cn.conf: |
-{{- if .Values.spec.config | indent 2 }}
-{{ .Values.spec.config | indent 2 }}
+{{- if .Values.spec.config }}
+{{- .Values.spec.config | nindent 2 }}
 {{- end }}
 {{- end }}
 

--- a/helm-charts/charts/warehouse/templates/cnconfigmap.yaml
+++ b/helm-charts/charts/warehouse/templates/cnconfigmap.yaml
@@ -8,6 +8,6 @@ metadata:
     warehouse: {{ template "starrockswarehouse.name" . }}
     app: "warehouse"
 data:
-{{ include "starrockswarehouse.config" . | indent 2 }}
+  {{- include "starrockswarehouse.config" . | nindent 2 }}
 
 {{- end }}

--- a/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
+++ b/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
@@ -89,7 +89,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.spec.annotations }}
-      {{ toYaml .Values.spec.annotations | indent 6 }}
+      {{- toYaml .Values.spec.annotations | nindent 6 }}
       {{- end }}
     {{- if .Values.spec.imagePullSecrets }}
     imagePullSecrets:


### PR DESCRIPTION
# Description

Currently, there are two formats of template YAML files. This PR aims to standardize the format of YAML files, especially the indentation.

The main changes are in the config and annotation fields, so I compared them using the following values.yaml for rendering. **The contents before and after are exactly the same.**

```
starrocksCluster:
  enabledBe: true
  enabledCn: true

starrocksFESpec:
  config: |
    LOG_DIR = ${STARROCKS_HOME}/log
    DATE = "$(date +%Y%m%d-%H%M%S)"
    JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:${LOG_DIR}/fe.gc.log.$DATE"
    JAVA_OPTS_FOR_JDK_9="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time"
    http_port = 8030
    rpc_port = 9020
    query_port = 9030
    edit_log_port = 9010
  annotations:
    fe1: fe-annotations1
    fe2: fe-annotations2
  storageSpec:
    logStorageSize: 1Gi
    name: fe-storage
    storageSize: 10Gi

starrocksBeSpec:
  config: |
    be_port = 9060
    webserver_port = 8040
    heartbeat_service_port = 9050
    brpc_port = 8060
    sys_log_level = INFO
    default_rowset_type = beta
  annotations:
    be1: be-annotations1
    be2: be-annotations2

starrocksCnSpec:
  config: |
    sys_log_level = INFO
    # ports for admin, web, heartbeat service
    thrift_port = 9060
    webserver_port = 8040
    heartbeat_service_port = 9050
    brpc_port = 8060
  annotations:
    cn1: cn-annotations1
    cn2: cn-annotations2

```


# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
