### PR TITLE
[BugFix] Add dependencies for kube-starrocks chart

### DIFF
--- a/helm-charts/charts/kube-starrocks/Chart.yaml
+++ b/helm-charts/charts/kube-starrocks/Chart.yaml
@@ -41,6 +41,14 @@ keywords:
   - database
   - olap
 
+dependencies:
+  - name: operator
+    version: 1.9.4
+    repository: "file://charts/operator"
+  - name: starrocks
+    version: 1.9.4
+    repository: "file://charts/starrocks"
+
 sources:
   - https://github.com/StarRocks/starrocks
 


### PR DESCRIPTION
# Description

Fix the following error:

```
$ helm lint .
==> Linting .
[ERROR] /tmp/kube-starrocks: chart metadata is missing these dependencies: operator,starrocks

Error: 1 chart(s) linted, 1 chart(s) failed
```