### PR TITLE
[BugFix] Make multiple fe init password job can be deployed in one namespace

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/configmap.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/configmap.yaml
@@ -12,7 +12,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: init-pwd-shell
+  name: {{ template "starrockscluster.name" . }}-initpwd-shell
   namespace: {{ template "starrockscluster.namespace" . }}
 data:
   fe_initpwd.sh: |-

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -47,7 +47,7 @@ spec:
               name: {{ template "starrockscluster.initpassword.secret.name" . }}
         volumeMounts:
         - mountPath: /opt/starrocks/fe_initpwd.sh
-          name: fe-initpwd-shell
+          name: {{ template "starrockscluster.name" . }}-initpwd-shell
           subPath: fe_initpwd.sh
       volumes:
       - configMap:
@@ -55,9 +55,9 @@ spec:
           items:
             - key: fe_initpwd.sh
               path: fe_initpwd.sh
-          name: init-pwd-shell
+          name: {{ template "starrockscluster.name" . }}-initpwd-shell
           optional: false
-        name: fe-initpwd-shell
+        name: {{ template "starrockscluster.name" . }}-initpwd-shell
       restartPolicy: OnFailure
   backoffLimit: 10
 {{- end }}


### PR DESCRIPTION
# Description

In order to support deploying multiple StarRocks clusters to a single K8s namespace, we need to ensure that all resource names are unique. Currently, the name of the configmap for "fe init-password" is hardcoded.

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).