### PR TITLE
[BugFix] Use namespaced scope permission to list warehouses

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"os"
 	"time"
@@ -79,7 +78,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := controllers.SetupWarehouseReconciler(context.Background(), mgr); err != nil {
+	if err := controllers.SetupWarehouseReconciler(mgr, _namespace); err != nil {
 		logger.Error(err, "unable to set up warehouse reconciler")
 		os.Exit(1)
 	}

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -60,8 +60,8 @@ func TestSetupWarehouseReconciler(t *testing.T) {
 	}()
 
 	type args struct {
-		mgr controllerruntime.Manager
-		ctx context.Context
+		mgr       controllerruntime.Manager
+		namespace string
 	}
 	tests := []struct {
 		name    string
@@ -75,7 +75,7 @@ func TestSetupWarehouseReconciler(t *testing.T) {
 					env1 = fake.NewEnvironment(fake.WithClusterCRD())
 					return fake.NewManager(env1)
 				}(),
-				ctx: context.Background(),
+				namespace: "",
 			},
 			wantErr: false,
 		},
@@ -85,7 +85,7 @@ func TestSetupWarehouseReconciler(t *testing.T) {
 				mgr: func() controllerruntime.Manager {
 					return fake.NewManager(env2)
 				}(),
-				ctx: context.Background(),
+				namespace: "",
 			},
 			wantErr: false,
 		},
@@ -95,7 +95,7 @@ func TestSetupWarehouseReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := SetupWarehouseReconciler(tt.args.ctx, tt.args.mgr); (err != nil) != tt.wantErr {
+			if err := SetupWarehouseReconciler(tt.args.mgr, tt.args.namespace); (err != nil) != tt.wantErr {
 				t.Errorf("SetupWarehouseReconciler() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
# Description

Use namespaced scope permission to list warehouses

# Related Issue(s)

#512 

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.