### PR TITLE
Update values.yaml

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -226,8 +226,11 @@ starrocksFESpec:
   # fe storageSpec for persistent metadata.
   # Note: Once set, the following fields will not be allowed to be modified.
   storageSpec:
-    # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, which
-    # are ephemeral and data will be lost on pod restart. For persistent storage, it is recommended to specify a volume name prefix.
+    # Specifies the name prefix of the volumes to mount. If left unspecified,
+    # `emptyDir` volumes will be used by default, which are ephemeral and data
+    # will be lost on pod restart.
+    #
+    # For persistent storage, specify a volume name prefix.
     # For example, using `fe` as the name prefix would be appropriate.
     name: ""
     # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
@@ -483,8 +486,11 @@ starrocksCnSpec:
   # specify storageclass name and request size.
   # Note: Once set, the following fields will not be allowed to be modified.
   storageSpec:
-    # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, and only for log, which
-    # are ephemeral and logs will be lost on pod restart. For persistent storage, it is recommended to specify a volume name prefix.
+    # Specifies the name prefix of the volumes to mount. If left unspecified,
+    # `emptyDir` volumes will be used by default and only for log.
+    # The logs will be lost on pod restart when using emptyDir volumes.
+    #
+    # For persistent storage, specify a volume name prefix.
     # For example, using `cn` as the name prefix would be appropriate.
     name: ""
     # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
@@ -704,8 +710,11 @@ starrocksBeSpec:
   # be storageSpec for persistent storage.
   # Note: Once set, the following fields will not be allowed to be modified.
   storageSpec:
-    # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, which
-    # are ephemeral and data will be lost on pod restart. For persistent storage, it is recommended to specify a volume name prefix.
+    # Specifies the name prefix of the volumes to mount. If left unspecified,
+    # `emptyDir` volumes will be used by default, which are ephemeral and data
+    # will be lost on pod restart.
+    #
+    # For persistent storage, specify a volume name prefix.
     # For example, using `be` as the name prefix would be appropriate.
     name: ""
     # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -487,7 +487,7 @@ starrocksCnSpec:
   # Note: Once set, the following fields will not be allowed to be modified.
   storageSpec:
     # Specifies the name prefix of the volumes to mount. If left unspecified,
-    # `emptyDir` volumes will be used by default and only for log.
+    # `emptyDir` volumes will be used, which are ephemeral, and only for log.
     # The logs will be lost on pod restart when using emptyDir volumes.
     #
     # For persistent storage, specify a volume name prefix.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -335,7 +335,7 @@ starrocks:
     # Note: Once set, the following fields will not be allowed to be modified.
     storageSpec:
       # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, which
-      # are ephemeral and data will be lost on pod restart. For persistent storage, it is recommended to specify a volume name prefix.
+      # are ephemeral and data will be lost on pod restart. For persistent storage, specify a volume name prefix.
       # For example, using `fe` as the name prefix would be appropriate.
       name: ""
       # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
@@ -592,7 +592,7 @@ starrocks:
     # Note: Once set, the following fields will not be allowed to be modified.
     storageSpec:
       # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, and only for log, which
-      # are ephemeral and logs will be lost on pod restart. For persistent storage, it is recommended to specify a volume name prefix.
+      # are ephemeral and logs will be lost on pod restart. For persistent storage, specify a volume name prefix.
       # For example, using `cn` as the name prefix would be appropriate.
       name: ""
       # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
@@ -813,7 +813,7 @@ starrocks:
     # Note: Once set, the following fields will not be allowed to be modified.
     storageSpec:
       # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, which
-      # are ephemeral and data will be lost on pod restart. For persistent storage, it is recommended to specify a volume name prefix.
+      # are ephemeral and data will be lost on pod restart. For persistent storage, specify a volume name prefix.
       # For example, using `be` as the name prefix would be appropriate.
       name: ""
       # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -595,7 +595,7 @@ starrocks:
     # Note: Once set, the following fields will not be allowed to be modified.
     storageSpec:
       # Specifies the name prefix of the volumes to mount. If left unspecified,
-      # `emptyDir` volumes will be used by default and only for log.
+      # `emptyDir` volumes will be used, which are ephemeral, and only for log.
       # The logs will be lost on pod restart when using emptyDir volumes.
       #
       # For persistent storage, specify a volume name prefix.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -334,8 +334,11 @@ starrocks:
     # fe storageSpec for persistent metadata.
     # Note: Once set, the following fields will not be allowed to be modified.
     storageSpec:
-      # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, which
-      # are ephemeral and data will be lost on pod restart. For persistent storage, specify a volume name prefix.
+      # Specifies the name prefix of the volumes to mount. If left unspecified,
+      # `emptyDir` volumes will be used by default, which are ephemeral and data
+      # will be lost on pod restart.
+      #
+      # For persistent storage, specify a volume name prefix.
       # For example, using `fe` as the name prefix would be appropriate.
       name: ""
       # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
@@ -591,8 +594,11 @@ starrocks:
     # specify storageclass name and request size.
     # Note: Once set, the following fields will not be allowed to be modified.
     storageSpec:
-      # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, and only for log, which
-      # are ephemeral and logs will be lost on pod restart. For persistent storage, specify a volume name prefix.
+      # Specifies the name prefix of the volumes to mount. If left unspecified,
+      # `emptyDir` volumes will be used by default and only for log.
+      # The logs will be lost on pod restart when using emptyDir volumes.
+      #
+      # For persistent storage, specify a volume name prefix.
       # For example, using `cn` as the name prefix would be appropriate.
       name: ""
       # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
@@ -812,8 +818,11 @@ starrocks:
     # be storageSpec for persistent storage.
     # Note: Once set, the following fields will not be allowed to be modified.
     storageSpec:
-      # Specifies the name prefix of the volumes to mount. If left unspecified, `emptyDir` volumes will be used by default, which
-      # are ephemeral and data will be lost on pod restart. For persistent storage, specify a volume name prefix.
+      # Specifies the name prefix of the volumes to mount. If left unspecified,
+      # `emptyDir` volumes will be used by default, which are ephemeral and data
+      # will be lost on pod restart.
+      #
+      # For persistent storage, specify a volume name prefix.
       # For example, using `be` as the name prefix would be appropriate.
       name: ""
       # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.


### PR DESCRIPTION
I think that a volume name prefix is required for persistent storage. When I set the name the PVCs were created.

Maybe I am wrong, maybe if a storageClassName is set and the prefix is left empty then PVCs will also get created?

# Description

Please provide a detailed description of the changes you have made. Include the motivation for these changes, and any
additional context that may be important.
> the PR should include helm chart changes and operator changes.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ ] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
