### PR TITLE
feat: :sparkles: add spill storage in be/cn config

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -111,6 +111,14 @@ be.conf: |
 {{- print "/opt/starrocks/be/log" }}
 {{- end }}
 
+{{- define "starrockscluster.be.spill.suffix" -}}
+{{- print "-spill" }}
+{{- end }}
+
+{{- define "starrockscluster.be.spill.path" -}}
+{{- print "/opt/starrocks/be/spill" }}
+{{- end }}
+
 {{- define "starrockscluster.cn.data.suffix" -}}
 {{- print "-data" }}
 {{- end }}
@@ -129,6 +137,14 @@ be.conf: |
 
 {{- define "starrockscluster.cn.log.path" -}}
 {{- print "/opt/starrocks/cn/log" }}
+{{- end }}
+
+{{- define "starrockscluster.cn.spill.suffix" -}}
+{{- print "-spill" }}
+{{- end }}
+
+{{- define "starrockscluster.cn.spill.path" -}}
+{{- print "/opt/starrocks/cn/spill" }}
 {{- end }}
 
 {{- define "starrockscluster.entrypoint.script.name" -}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -452,6 +452,10 @@ spec:
       storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
       storageSize: "{{ .Values.starrocksBeSpec.storageSpec.logStorageSize }}"
       mountPath: {{template "starrockscluster.be.log.path" . }}
+    - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.spill.suffix" . }}
+      storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
+      storageSize: "{{ .Values.starrocksBeSpec.storageSpec.spillStorageSize}}"
+      mountPath: {{template "starrockscluster.be.spill.path" . }}
     {{- end }}
     {{- if .Values.starrocksBeSpec.emptyDirs }}
     {{- range .Values.starrocksBeSpec.emptyDirs }}
@@ -696,6 +700,10 @@ spec:
       storageClassName: {{ .Values.starrocksCnSpec.storageSpec.storageClassName }}
       storageSize: "{{ .Values.starrocksCnSpec.storageSpec.logStorageSize }}"
       mountPath: {{template "starrockscluster.cn.log.path" . }}
+    - name: {{ .Values.starrocksCnSpec.storageSpec.name }}{{template "starrockscluster.cn.spill.suffix" . }}
+      storageClassName: {{ .Values.starrocksCnSpec.storageSpec.storageClassName }}
+      storageSize: "{{ .Values.starrocksCnSpec.storageSpec.spillStorageSize}}"
+      mountPath: {{template "starrockscluster.cn.spill.path" . }}
     {{- end }}
     {{- if .Values.starrocksCnSpec.emptyDirs }}
     {{- range .Values.starrocksCnSpec.emptyDirs }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -553,6 +553,10 @@ starrocksCnSpec:
     # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
     logStorageSize: 1Gi
+    # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/cn/spill.
+    # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
+    # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/cn/spill.
+    spillStorageSize: 0Gi
   # mount emptyDir volumes if necessary.
   # Note: please use storageSpec field for persistent storage data and log.
   emptyDirs: []
@@ -795,6 +799,10 @@ starrocksBeSpec:
     # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
     logStorageSize: 1Gi
+    # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/be/spill.
+    # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
+    # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/be/spill.
+    spillStorageSize: 0Gi
   # mount emptyDir volumes if necessary.
   # Note: please use storageSpec field for persistent storage data and log.
   emptyDirs: []

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -661,6 +661,10 @@ starrocks:
       # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
       logStorageSize: 1Gi
+      # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/cn/spill.
+      # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
+      # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/cn/spill.
+      spillStorageSize: 0Gi
     # mount emptyDir volumes if necessary.
     # Note: please use storageSpec field for persistent storage data and log.
     emptyDirs: []
@@ -903,6 +907,10 @@ starrocks:
       # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
       logStorageSize: 1Gi
+      # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/be/spill.
+      # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
+      # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/be/spill.
+      spillStorageSize: 0Gi
     # mount emptyDir volumes if necessary.
     # Note: please use storageSpec field for persistent storage data and log.
     emptyDirs: []


### PR DESCRIPTION
# Description

Add in helm chart possibility to add spill_dir storage configuration.

# Related Issue(s)

#535 

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
