### PR TITLE
[BugFix] LoadBalancerSourceRanges field should be used in componnet hash

### DIFF
--- a/pkg/common/resource_utils/service.go
+++ b/pkg/common/resource_utils/service.go
@@ -111,15 +111,17 @@ func BuildExternalService(object object.StarRocksObject, spec srapi.SpecInterfac
 		}
 		ports = append(ports, servicePort)
 	}
+
 	// set Ports field before calculate resource hash
 	svc.Spec.Ports = ports
 	svc.Annotations = anno
-	anno[srapi.ComponentResourceHash] = hash.HashObject(serviceHashObject(&svc))
-	svc.Annotations = anno
-
+	// LoadBalancerSourceRanges is also used to calculate resource hash
 	if starRocksService != nil && starRocksService.LoadBalancerSourceRanges != nil {
 		svc.Spec.LoadBalancerSourceRanges = starRocksService.LoadBalancerSourceRanges
 	}
+
+	anno[srapi.ComponentResourceHash] = hash.HashObject(serviceHashObject(&svc))
+	svc.Annotations = anno
 	return svc
 }
 


### PR DESCRIPTION
# Description

when loadBalancerSourceRanges  field is updated, service should be updated. 

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.
