### PR TITLE
[BugFix] Fix FE proxy will fail when FE external service is recreated

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,6 +155,7 @@ run:
   timeout: 5m
   skip-files:
     - ".*_test\\.go"
+    - pkg/subcontrollers/feproxy/feproxy_configmap.go
   skip-dirs:
     - test/testdata_etc # test files
     - internal/cache # extracted from Go code


### PR DESCRIPTION
# Description

#556 

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.