### PR TITLE
add simple Helm example

### DIFF
--- a/examples/helm/ha_cluster_with_proxy_and_password.yaml
+++ b/examples/helm/ha_cluster_with_proxy_and_password.yaml
@@ -1,0 +1,58 @@
+---
+#
+# This values file overrides the default kube-starrocks chart to:
+# - add a default password for the root user
+# - deploy a highly-available StarRocks cluster with 3 FE pods and 3 BE pods
+# - deploy a LoadBalancer for the FE service
+# - deploy a LoadBalancer for the FE Proxy service
+# Note: This is not a production-level cluster, the CPU, Memory, and Disk resources
+# are set very low to allow this to be deployed in a Kubernetes cluster with limited
+# resources. For production sizing information please see:
+# https://docs.starrocks.io/docs/deployment/plan_cluster/
+#
+# To use this values file:
+# - [Add the Helm repo](../../doc/add_helm_repo_howto.md)
+# - Set a passord for the StarRocks database root user:
+#   kubectl create secret generic starrocks-root-pass --from-literal=password='g()()dpa$$word'
+# - Download this file:
+#   curl -O https://raw.githubusercontent.com/StarRocks/starrocks-kubernetes-operator/main/examples/examples/helm/ha_cluster_with_proxy_and_password.yaml
+# - Deploy:
+#   helm install -f ha_cluster_with_proxy_and_password.yaml starrocks starrocks-community/kube-starrocks
+#
+# Once the operator and cluster are ready you can access the system with a MySQL
+# client at the IP Address of the kube-starrocks-fe-service on port 9030.
+#
+# For example:
+# mysql -h < kube-starrocks-fe-service IP > -P9030 -uroot -p
+# 
+# Note: You will be prompted for the password you set in the secret earlier
+#   
+starrocks:
+    initPassword:
+        enabled: true
+            # Set a password secret, for example:
+            # kubectl create secret generic starrocks-root-pass --from-literal=password='g()()dpa$$word'
+        passwordSecret: starrocks-root-pass
+
+    starrocksFESpec:
+        replicas: 3
+        service:
+            type: LoadBalancer
+        resources:
+            requests:
+                cpu: 1
+                memory: 1Gi
+
+    starrocksBeSpec:
+        replicas: 3
+        resources:
+            requests:
+                cpu: 1
+                memory: 2Gi
+        storageSpec:
+            storageSize: 15Gi
+
+    starrocksFeProxySpec:
+        enabled: true
+        service:
+            type: LoadBalancer

--- a/examples/starrocks/deploy_a_ha_starrocks_cluster.yaml
+++ b/examples/starrocks/deploy_a_ha_starrocks_cluster.yaml
@@ -3,7 +3,7 @@
 # leader, and the other two are the followers.
 # the number of BEs required depends on the default `replication_num` which is `3` by default.
 # StarRocks cluster.
-# The requests and limits of FE and BE are set based on https://docs.starrocks.io/en-us/latest/deployment/plan_cluster
+# The requests and limits of FE and BE are set based on https://docs.starrocks.io/docs/deployment/plan_cluster/
 
 apiVersion: starrocks.com/v1
 kind: StarRocksCluster

--- a/examples/starrocks/deploy_a_starrocks_cluster_running_in_shared_data_mode.yaml
+++ b/examples/starrocks/deploy_a_starrocks_cluster_running_in_shared_data_mode.yaml
@@ -4,7 +4,7 @@
 # You will have to download and edit this YAML file to specify the details for your shared storage. See the 
 # examples in the docs, and add your customizations to the ConfigMap `starrockscluster-sample-fe-cm` at the 
 # bottom of this file.
-# https://docs.starrocks.io/en-us/latest/deployment/deploy_shared_data#configure-fe-nodes-for-shared-data-starrocks
+# https://docs.starrocks.io/docs/deployment/shared_data/
 
 apiVersion: starrocks.com/v1
 kind: StarRocksCluster

--- a/examples/starrocks/deploy_a_starrocks_cluster_with_fe_proxy.yaml
+++ b/examples/starrocks/deploy_a_starrocks_cluster_with_fe_proxy.yaml
@@ -2,7 +2,7 @@
 # To load data from outside the Kubernetes cluster into StarRocks deployed within the Kubernetes
 # cluster, you can deploy the FE Proxy component. So that External data import tools, like flink,
 # can use the STREAM LOAD syntax to import data into StarRocks clusters.
-# see https://docs.starrocks.io/en-us/latest/loading/Flink-connector-starrocks for more information
+# see https://docs.starrocks.io/docs/loading/Flink-connector-starrocks/ for more information
 # about how to use flink to import data into StarRocks.
 
 apiVersion: starrocks.com/v1


### PR DESCRIPTION
# Description

This provides a values file to use the kube-starrocks Helm chart to deploy a 3FE/3BE cluster
with an initial password set and the FE and FE Proxy exposed using LoadBalancers.

I plan to use this values file in a doc quick start. The FE Proxy LoadBalancer is so I can use Stream Load in the example.

This PR also fixes some doc links that are broken.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ ] make sure you have updated the [values.yaml](../../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ ] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
