### PR TITLE
feat: add resources option for init_job

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -33,6 +33,9 @@ spec:
         image: {{ .Values.starrocksFESpec.image.repository }}:{{ include "starrockscluster.fe.image.tag" . }}
         {{- end }}
         imagePullPolicy: IfNotPresent
+        {{- if .Values.initPassword.resources }}
+        resources: {{- toYaml .Values.initPassword.resources | nindent 10 }}
+        {{- end }}
         command:
         - /bin/bash
         args:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -22,6 +22,15 @@ initPassword:
   image: ""
   # The annotations for the Job, not including the annotations for the pod.
   annotations: {}
+  # resources for init_job pod.
+  resources: {}
+  #resources:
+  #  requests:
+  #    cpu: 500m
+  #    memory: 400Mi
+  #  limits:
+  #    cpu: 500m
+  #    memory: 800Mi
 
 # TimeZone is used to set the environment variable TZ for pod, with Asia/Shanghai as the default.
 timeZone: Asia/Shanghai

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -130,6 +130,15 @@ starrocks:
     image: ""
     # The annotations for the Job, not including the annotations for the pod.
     annotations: {}
+    # resources for init_job pod.
+    resources: {}
+    #resources:
+    #  requests:
+    #    cpu: 500m
+    #    memory: 400Mi
+    #  limits:
+    #    cpu: 500m
+    #    memory: 800Mi
   
   # TimeZone is used to set the environment variable TZ for pod, with Asia/Shanghai as the default.
   timeZone: Asia/Shanghai


### PR DESCRIPTION
# Description

Add in helm chart possibility to add resources configuration for the init_password pod.

We are using openshift, on our cluster we have some kyverno rules set and the need-containers-ressources rules is applied.

We wanted to change the default password but the init_job container coudln't be deployed because the limits/requests wasn't set.


# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
