### PR TITLE
[Enhancement] Support multiple data volumes on helm chart

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -452,10 +452,23 @@ spec:
     {{- if or .Values.starrocksBeSpec.storageSpec.name .Values.starrocksBeSpec.emptyDirs .Values.starrocksBeSpec.hostPaths }}
     storageVolumes:
     {{- if .Values.starrocksBeSpec.storageSpec.name }}
+    {{- if gt (int .Values.starrocksBeSpec.storageSpec.storageCount) 1 }}
+    {{- $storageName := .Values.starrocksBeSpec.storageSpec.name -}}
+    {{- $storageClassName := .Values.starrocksBeSpec.storageSpec.storageClassName -}}
+    {{- $storageSize := .Values.starrocksBeSpec.storageSpec.storageSize -}}
+    {{- $storageMountPath := include "starrockscluster.be.data.path" . -}}
+    {{- range $i, $e := until (int .Values.starrocksBeSpec.storageSpec.storageCount) }}
+    - name: {{ $storageName }}{{ $i }}{{template "starrockscluster.be.data.suffix" . }}
+      storageClassName: {{ $storageClassName }}
+      storageSize: "{{ $storageSize }}"
+      mountPath: {{ $storageMountPath }}{{ $i }}
+    {{- end }}
+    {{- else}}
     - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.data.suffix" . }}
       storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
       storageSize: "{{ .Values.starrocksBeSpec.storageSpec.storageSize }}"
       mountPath: {{template "starrockscluster.be.data.path" . }}
+    {{- end }}
     - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.log.suffix" . }}
       storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
       storageSize: "{{ .Values.starrocksBeSpec.storageSpec.logStorageSize }}"
@@ -704,10 +717,23 @@ spec:
     {{- if or .Values.starrocksCnSpec.storageSpec.name .Values.starrocksCnSpec.emptyDirs .Values.starrocksCnSpec.hostPaths }}
     storageVolumes:
     {{- if .Values.starrocksCnSpec.storageSpec.name }}
+    {{- if gt (int .Values.starrocksCnSpec.storageSpec.storageCount) 1 }}
+    {{- $storageName := .Values.starrocksCnSpec.storageSpec.name -}}
+    {{- $storageClassName := .Values.starrocksCnSpec.storageSpec.storageClassName -}}
+    {{- $storageSize := .Values.starrocksCnSpec.storageSpec.storageSize -}}
+    {{- $storageMountPath := include "starrockscluster.cn.data.path" . -}}
+    {{- range $i, $e := until (int .Values.starrocksCnSpec.storageSpec.storageCount) }}
+    - name: {{ $storageName }}{{ $i }}{{template "starrockscluster.cn.data.suffix" . }}
+      storageClassName: {{ $storageClassName }}
+      storageSize: "{{ $storageSize }}"
+      mountPath: {{ $storageMountPath }}{{ $i }}
+    {{- end }}
+    {{- else }}
     - name: {{ .Values.starrocksCnSpec.storageSpec.name }}{{template "starrockscluster.cn.data.suffix" . }}
       storageClassName: {{ .Values.starrocksCnSpec.storageSpec.storageClassName }}
       storageSize: "{{ .Values.starrocksCnSpec.storageSpec.storageSize }}"
       mountPath: {{template "starrockscluster.cn.data.path" . }}
+    {{- end }}
     - name: {{ .Values.starrocksCnSpec.storageSpec.name }}{{template "starrockscluster.cn.log.suffix" . }}
       storageClassName: {{ .Values.starrocksCnSpec.storageSpec.storageClassName }}
       storageSize: "{{ .Values.starrocksCnSpec.storageSpec.logStorageSize }}"

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -559,13 +559,17 @@ starrocksCnSpec:
     storageClassName: ""
     # the storage size of per persistent volume for data.
     storageSize: 1Ti
-    # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
     # the number of persistent volumes for data.
-    # if its value is greater than 1:
-    #   1. the storageMountPath will follow the format, e.g. /opt/starrocks/cn/storage0, /opt/starrocks/cn/storage1, ...
-    #   2. You must add in config the following configuration: storage_root_path = /opt/starrocks/cn/storage0;/opt/starrocks/cn/storage1;...
+    # if storageCount == 1
+    #   the storageMountPath field is used to specify the mount path of the persistent volume. If storageMountPath is empty,
+    #   the storageMountPath will be set to /opt/starrocks/cn/storage.
+    #   If storageMountPath is not /opt/starrocks/cn/storage, you must add in config the following configuration: storage_root_path = xxx.
+    # if storageCount > 1
+    #   the storageMountPath field is used to specify the prefix of mount path of the persistent volume. For example, if the
+    #   storageMountPath is /opt/starrocks/cn/storage, the real mount path will be /opt/starrocks/cn/storage0, /opt/starrocks/cn/storage1, ...
+    #   You must add in config the following configuration: storage_root_path = /opt/starrocks/cn/storage0;/opt/starrocks/cn/storage1;...
     storageCount: 1
-    # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
+    # see the comment of storageCount for the usage of storageMountPath.
     storageMountPath: ""
     # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
@@ -822,11 +826,16 @@ starrocksBeSpec:
     # the storage size of per persistent volume for data.
     storageSize: 1Ti
     # the number of persistent volumes for data.
-    # if its value is greater than 1:
-    #   1. the storageMountPath will follow the format, e.g. /opt/starrocks/be/storage0, /opt/starrocks/be/storage1, ...
-    #   2. You must add in config the following configuration: storage_root_path = /opt/starrocks/be/storage0;/opt/starrocks/be/storage1;...
+    # if storageCount == 1
+    #   the storageMountPath field is used to specify the mount path of the persistent volume. If storageMountPath is empty,
+    #   the storageMountPath will be set to /opt/starrocks/be/storage.
+    #   If storageMountPath /opt/starrocks/be/storage, you must add in config the following configuration: storage_root_path = xxx.
+    # if storageCount > 1
+    #   the storageMountPath field is used to specify the prefix of mount path of the persistent volume. For example, if the
+    #   storageMountPath is /opt/starrocks/be/storage, the real mount path will be /opt/starrocks/be/storage0, /opt/starrocks/be/storage1, ...
+    #   You must add in config the following configuration: storage_root_path = /opt/starrocks/be/storage0;/opt/starrocks/be/storage1;...
     storageCount: 1
-    # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/be/storage.
+    # see the comment of storageCount for the usage of storageMountPath.
     storageMountPath: ""
     # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -557,8 +557,14 @@ starrocksCnSpec:
     # You must set name when you set storageClassName
     # Note: Because hostPath field is not supported here, hostPath is not allowed to be set in storageClassName.
     storageClassName: ""
-    # the storage size of persistent volume for data.
+    # the storage size of per persistent volume for data.
     storageSize: 1Ti
+    # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
+    # the number of persistent volumes for data.
+    # if its value is greater than 1:
+    #   1. the storageMountPath will follow the format, e.g. /opt/starrocks/cn/storage0, /opt/starrocks/cn/storage1, ...
+    #   2. You must add in config the following configuration: storage_root_path = /opt/starrocks/cn/storage0;/opt/starrocks/cn/storage1;...
+    storageCount: 1
     # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
     storageMountPath: ""
     # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
@@ -813,8 +819,13 @@ starrocksBeSpec:
     # You must set name when you set storageClassName
     # Note: Because hostPath field is not supported here, hostPath is not allowed to be set in storageClassName.
     storageClassName: ""
-    # the storage size of persistent volume for data.
+    # the storage size of per persistent volume for data.
     storageSize: 1Ti
+    # the number of persistent volumes for data.
+    # if its value is greater than 1:
+    #   1. the storageMountPath will follow the format, e.g. /opt/starrocks/be/storage0, /opt/starrocks/be/storage1, ...
+    #   2. You must add in config the following configuration: storage_root_path = /opt/starrocks/be/storage0;/opt/starrocks/be/storage1;...
+    storageCount: 1
     # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/be/storage.
     storageMountPath: ""
     # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -667,13 +667,17 @@ starrocks:
       storageClassName: ""
       # the storage size of per persistent volume for data.
       storageSize: 1Ti
-      # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
       # the number of persistent volumes for data.
-      # if its value is greater than 1:
-      #   1. the storageMountPath will follow the format, e.g. /opt/starrocks/cn/storage0, /opt/starrocks/cn/storage1, ...
-      #   2. You must add in config the following configuration: storage_root_path = /opt/starrocks/cn/storage0;/opt/starrocks/cn/storage1;...
+      # if storageCount == 1
+      #   the storageMountPath field is used to specify the mount path of the persistent volume. If storageMountPath is empty,
+      #   the storageMountPath will be set to /opt/starrocks/cn/storage.
+      #   If storageMountPath is not /opt/starrocks/cn/storage, you must add in config the following configuration: storage_root_path = xxx.
+      # if storageCount > 1
+      #   the storageMountPath field is used to specify the prefix of mount path of the persistent volume. For example, if the
+      #   storageMountPath is /opt/starrocks/cn/storage, the real mount path will be /opt/starrocks/cn/storage0, /opt/starrocks/cn/storage1, ...
+      #   You must add in config the following configuration: storage_root_path = /opt/starrocks/cn/storage0;/opt/starrocks/cn/storage1;...
       storageCount: 1
-      # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
+      # see the comment of storageCount for the usage of storageMountPath.
       storageMountPath: ""
       # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
@@ -930,11 +934,16 @@ starrocks:
       # the storage size of per persistent volume for data.
       storageSize: 1Ti
       # the number of persistent volumes for data.
-      # if its value is greater than 1:
-      #   1. the storageMountPath will follow the format, e.g. /opt/starrocks/be/storage0, /opt/starrocks/be/storage1, ...
-      #   2. You must add in config the following configuration: storage_root_path = /opt/starrocks/be/storage0;/opt/starrocks/be/storage1;...
+      # if storageCount == 1
+      #   the storageMountPath field is used to specify the mount path of the persistent volume. If storageMountPath is empty,
+      #   the storageMountPath will be set to /opt/starrocks/be/storage.
+      #   If storageMountPath /opt/starrocks/be/storage, you must add in config the following configuration: storage_root_path = xxx.
+      # if storageCount > 1
+      #   the storageMountPath field is used to specify the prefix of mount path of the persistent volume. For example, if the
+      #   storageMountPath is /opt/starrocks/be/storage, the real mount path will be /opt/starrocks/be/storage0, /opt/starrocks/be/storage1, ...
+      #   You must add in config the following configuration: storage_root_path = /opt/starrocks/be/storage0;/opt/starrocks/be/storage1;...
       storageCount: 1
-      # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/be/storage.
+      # see the comment of storageCount for the usage of storageMountPath.
       storageMountPath: ""
       # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -665,8 +665,14 @@ starrocks:
       # You must set name when you set storageClassName
       # Note: Because hostPath field is not supported here, hostPath is not allowed to be set in storageClassName.
       storageClassName: ""
-      # the storage size of persistent volume for data.
+      # the storage size of per persistent volume for data.
       storageSize: 1Ti
+      # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
+      # the number of persistent volumes for data.
+      # if its value is greater than 1:
+      #   1. the storageMountPath will follow the format, e.g. /opt/starrocks/cn/storage0, /opt/starrocks/cn/storage1, ...
+      #   2. You must add in config the following configuration: storage_root_path = /opt/starrocks/cn/storage0;/opt/starrocks/cn/storage1;...
+      storageCount: 1
       # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/cn/storage.
       storageMountPath: ""
       # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
@@ -921,8 +927,13 @@ starrocks:
       # You must set name when you set storageClassName
       # Note: Because hostPath field is not supported here, hostPath is not allowed to be set in storageClassName.
       storageClassName: ""
-      # the storage size of persistent volume for data.
+      # the storage size of per persistent volume for data.
       storageSize: 1Ti
+      # the number of persistent volumes for data.
+      # if its value is greater than 1:
+      #   1. the storageMountPath will follow the format, e.g. /opt/starrocks/be/storage0, /opt/starrocks/be/storage1, ...
+      #   2. You must add in config the following configuration: storage_root_path = /opt/starrocks/be/storage0;/opt/starrocks/be/storage1;...
+      storageCount: 1
       # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/be/storage.
       storageMountPath: ""
       # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.


### PR DESCRIPTION
# Description

Support multiple data volumes on helm chart

This show how to configure multiple volumes for BE/CN.
```
spec:
  starrocksCnSpec:
    storageSpec:
      logStorageSize: 1Gi
      name: cn-storage
      storageSize: 100Gi
      storageCount: 3    # we want to mount 3 volumes and each volume size is 100Gi
    config: |
      sys_log_level = INFO
      # ports for admin, web, heartbeat service
      thrift_port = 9060
      webserver_port = 8040
      heartbeat_service_port = 9050
      brpc_port = 8060
      storage_root_path = /opt/starrocks/cn/storage0;/opt/starrocks/cn/storage1;/opt/starrocks/cn/storage2   # mount them
      
spec:
  starrocksBeSpec:
    storageSpec:
      logStorageSize: 1Gi
      name: be-storage
      storageSize: 100Gi
      storageCount: 2   # we want to mount 2 volumes and each volume size is 100Gi
    config: |
      be_port = 9060
      webserver_port = 8040
      heartbeat_service_port = 9050
      brpc_port = 8060
      sys_log_level = INFO
      default_rowset_type = beta
      storage_root_path = /opt/starrocks/be/storage0;/opt/starrocks/be/storage1    # mount them.
```

The result shows that It has worked.
```
root@kube-starrocks-be-0:/opt/starrocks/be# ls
bin  conf  lib  log  spill  storage  storage0  storage1  www
root@kube-starrocks-be-0:/opt/starrocks/be# ls storage
root@kube-starrocks-be-0:/opt/starrocks/be# ls storage0/
cluster_id  data  error_log  meta  persistent  tmp
root@kube-starrocks-be-0:/opt/starrocks/be# ls storage1/
cluster_id  data  meta  persistent  tmp

root@kube-starrocks-cn-0:/opt/starrocks/cn# ls
bin  conf  lib  log  spill  storage  storage0  storage1  storage2  www
root@kube-starrocks-cn-0:/opt/starrocks/cn# ls storage
root@kube-starrocks-cn-0:/opt/starrocks/cn# ls storage0
cluster_id  data  error_log  meta  persistent  tmp
root@kube-starrocks-cn-0:/opt/starrocks/cn# ls storage1
cluster_id  data  meta  persistent  tmp
root@kube-starrocks-cn-0:/opt/starrocks/cn# ls storage2
cluster_id  data  meta  persistent  tmp
```

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).