### PR TITLE
[Bugfix] Use a reasonable volume size for logging for BE/CN

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -278,7 +278,7 @@ starrocksFESpec:
     # You must set name when you set storageClassName.
     # Note: Because hostPath field is not supported here, hostPath is not allowed to be set in storageClassName.
     storageClassName: ""
-    # the persistent volume size， default 10Gi.
+    # the persistent volume size for data.
     # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
     storageSize: 10Gi
     # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/fe/meta.
@@ -563,7 +563,7 @@ starrocksCnSpec:
     storageMountPath: ""
     # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
-    logStorageSize: 1Gi
+    logStorageSize: 20Gi
     # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/cn/spill.
     # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
     # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/cn/spill.
@@ -819,7 +819,7 @@ starrocksBeSpec:
     storageMountPath: ""
     # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
-    logStorageSize: 1Gi
+    logStorageSize: 20Gi
     # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/be/spill.
     # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
     # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/be/spill.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -386,7 +386,7 @@ starrocks:
       # You must set name when you set storageClassName.
       # Note: Because hostPath field is not supported here, hostPath is not allowed to be set in storageClassName.
       storageClassName: ""
-      # the persistent volume size， default 10Gi.
+      # the persistent volume size for data.
       # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
       storageSize: 10Gi
       # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/fe/meta.
@@ -671,7 +671,7 @@ starrocks:
       storageMountPath: ""
       # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
-      logStorageSize: 1Gi
+      logStorageSize: 20Gi
       # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/cn/spill.
       # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
       # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/cn/spill.
@@ -927,7 +927,7 @@ starrocks:
       storageMountPath: ""
       # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
-      logStorageSize: 1Gi
+      logStorageSize: 20Gi
       # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/be/spill.
       # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
       # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/be/spill.


### PR DESCRIPTION
# Description

When user use Helm Chart to deploy a StarRocks Cluster, the `logStorageSize` value for BE/CN is 1Gi by default. It is too small, and the problem is that when user encounter a problem with BE/CN, they can't get the latest logs!

BE/CN will rotate logs when the size of logs is greater than 10Gi by default. So Allocating 20GB for log storage and 1TB for data storage is more reasonable.

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
