### PR TITLE
[helm]support config override in starrocksFESpec/starrocksBeSpec/starrocksCnSpec

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -52,22 +52,40 @@ starrockscluster
 
 {{- define "starrockscluster.fe.config" -}}
 fe.conf: |
-{{- if .Values.starrocksFESpec.config }}
-{{- .Values.starrocksFESpec.config | nindent 2 }}
+{{- if and .Values.starrocksFESpec.configyaml (kindIs "map" .Values.starrocksFESpec.configyaml) }}
+  {{- range $key, $value := .Values.starrocksFESpec.configyaml }}
+    {{ $key }} = {{ $value }}
+  {{- end }}
+{{- else if .Values.starrocksFESpec.configyaml }}
+  {{ fail "configyaml must be a map" }}
+{{- else }}
+  {{- .Values.starrocksFESpec.config | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "starrockscluster.cn.config" -}}
 cn.conf: |
-{{- if .Values.starrocksCnSpec.config }}
-{{- .Values.starrocksCnSpec.config | nindent 2 }}
+{{- if and .Values.starrocksCnSpec.configyaml (kindIs "map" .Values.starrocksCnSpec.configyaml) }}
+  {{- range $key, $value := .Values.starrocksCnSpec.configyaml }}
+    {{ $key }} = {{ $value }}
+  {{- end }}
+{{- else if .Values.starrocksCnSpec.configyaml }}
+  {{ fail "configyaml must be a map" }}
+{{- else }}
+  {{- .Values.starrocksCnSpec.config | nindent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "starrocksclster.be.config" -}}
 be.conf: |
-{{- if .Values.starrocksBeSpec.config }}
-{{- .Values.starrocksBeSpec.config | nindent 2 }}
+{{- if and .Values.starrocksBeSpec.configyaml (kindIs "map" .Values.starrocksBeSpec.configyaml) }}
+  {{- range $key, $value := .Values.starrocksBeSpec.configyaml }}
+    {{ $key }} = {{ $value }}
+  {{- end }}
+{{- else if .Values.starrocksBeSpec.configyaml }}
+  {{ fail "configyaml must be a map" }}
+{{- else }}
+  {{- .Values.starrocksBeSpec.config | nindent 2 }}
 {{- end }}
 {{- end }}
 
@@ -214,7 +232,12 @@ starrockscluster.fe.config.hash is used to calculate the hash value of the fe.co
 the first 8 digits are taken, which will be used as the annotations for pods.
 */}}
 {{- define "starrockscluster.fe.config.hash" }}
-  {{- if .Values.starrocksFESpec.config }}
+  {{- if and .Values.starrocksFESpec.configyaml (kindIs "map" .Values.starrocksFESpec.configyaml) }}
+    {{- $hash := toJson .Values.starrocksFESpec.configyaml | sha256sum | trunc 8 }}
+    {{- printf "%s" $hash }}
+  {{- else if .Values.starrocksFESpec.configyaml }}
+    {{ fail "configyaml must be a map" }}
+  {{- else if .Values.starrocksFESpec.config }}
     {{- $hash := toJson .Values.starrocksFESpec.config | sha256sum | trunc 8 }}
     {{- printf "%s" $hash }}
   {{- else }}
@@ -228,7 +251,12 @@ starrockscluster.be.config.hash is used to calculate the hash value of the be.co
 the first 8 digits are taken, which will be used as the annotations for pods.
 */}}
 {{- define "starrockscluster.be.config.hash" }}
-  {{- if .Values.starrocksBeSpec.config }}
+  {{- if and .Values.starrocksBeSpec.configyaml (kindIs "map" .Values.starrocksBeSpec.configyaml) }}
+    {{- $hash := toJson .Values.starrocksBeSpec.configyaml | sha256sum | trunc 8 }}
+    {{- printf "%s" $hash }}
+  {{- else if .Values.starrocksBeSpec.configyaml }}
+    {{ fail "configyaml must be a map" }}
+  {{- else if .Values.starrocksBeSpec.config }}
     {{- $hash := toJson .Values.starrocksBeSpec.config | sha256sum | trunc 8 }}
     {{- printf "%s" $hash }}
   {{- else }}
@@ -241,7 +269,12 @@ starrockscluster.cn.config.hash is used to calculate the hash value of the cn.co
 the first 8 digits are taken, which will be used as the annotations for pods.
 */}}
 {{- define "starrockscluster.cn.config.hash" }}
-  {{- if .Values.starrocksCnSpec.config }}
+  {{- if and .Values.starrocksCnSpec.configyaml (kindIs "map" .Values.starrocksCnSpec.configyaml) }}
+    {{- $hash := toJson .Values.starrocksCnSpec.configyaml | sha256sum | trunc 8 }}
+    {{- printf "%s" $hash }}
+  {{- else if .Values.starrocksCnSpec.configyaml }}
+    {{ fail "configyaml must be a map" }}
+  {{- else if .Values.starrocksCnSpec.config }}
     {{- $hash := toJson .Values.starrocksCnSpec.config | sha256sum | trunc 8 }}
     {{- printf "%s" $hash }}
   {{- else }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -312,6 +312,9 @@ starrocksFESpec:
     edit_log_port = 9010
     mysql_service_nio_enabled = true
     sys_log_level = INFO
+  # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take
+  # precedence and values in config field will be discarded.
+  configyaml: {}
   # mount secrets if necessary.
   # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
   secrets: []
@@ -598,6 +601,9 @@ starrocksCnSpec:
     webserver_port = 8040
     heartbeat_service_port = 9050
     brpc_port = 8060
+  # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take
+  # precedence and values in config field will be discarded.
+  configyaml: {}
   # mount secrets if necessary.
   # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
   secrets: []
@@ -850,6 +856,9 @@ starrocksBeSpec:
     brpc_port = 8060
     sys_log_level = INFO
     default_rowset_type = beta
+  # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take
+  # precedence and values in config field will be discarded.
+  configyaml: {}
   # mount secrets if necessary.
   # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
   secrets: []

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -420,17 +420,9 @@ starrocks:
       edit_log_port = 9010
       mysql_service_nio_enabled = true
       sys_log_level = INFO
-    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
-    configyaml:
-      LOG_DIR:  ${STARROCKS_HOME}/log
-      DATE: '"$(date +%Y%m%d-%H%M%S)"'
-      JAVA_OPTS: '"-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time"'
-      http_port: 8030
-      rpc_port: 9020
-      query_port: 9030
-      edit_log_port: 9010
-      mysql_service_nio_enabled: true
-      sys_log_level: INFO
+    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take
+    # precedence and values in config field will be discarded.
+    configyaml: {}
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []
@@ -717,14 +709,9 @@ starrocks:
       webserver_port = 8040
       heartbeat_service_port = 9050
       brpc_port = 8060
-    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
-    configyaml:
-      sys_log_level: INFO
-      # ports for admin, web, heartbeat service
-      thrift_port: 9060
-      webserver_port: 8040
-      heartbeat_service_port: 9050
-      brpc_port: 8060
+    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take
+    # precedence and values in config field will be discarded.
+    configyaml: {}
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []
@@ -977,14 +964,9 @@ starrocks:
       brpc_port = 8060
       sys_log_level = INFO
       default_rowset_type = beta
-    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
-    configyaml:
-      be_port: 9060
-      webserver_port: 8040
-      heartbeat_service_port: 9050
-      brpc_port: 8060
-      sys_log_level: INFO
-      default_rowset_type: beta
+    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take
+    # precedence and values in config field will be discarded.
+    configyaml: {}
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -421,7 +421,16 @@ starrocks:
       mysql_service_nio_enabled = true
       sys_log_level = INFO
     # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
-    configyaml: {}
+    configyaml:
+      LOG_DIR:  ${STARROCKS_HOME}/log
+      DATE: '"$(date +%Y%m%d-%H%M%S)"'
+      JAVA_OPTS: '"-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time"'
+      http_port: 8030
+      rpc_port: 9020
+      query_port: 9030
+      edit_log_port: 9010
+      mysql_service_nio_enabled: true
+      sys_log_level: INFO
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []
@@ -709,7 +718,13 @@ starrocks:
       heartbeat_service_port = 9050
       brpc_port = 8060
     # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
-    configyaml: {}
+    configyaml:
+      sys_log_level: INFO
+      # ports for admin, web, heartbeat service
+      thrift_port: 9060
+      webserver_port: 8040
+      heartbeat_service_port: 9050
+      brpc_port: 8060
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []
@@ -963,7 +978,13 @@ starrocks:
       sys_log_level = INFO
       default_rowset_type = beta
     # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
-    configyaml: {}
+    configyaml:
+      be_port: 9060
+      webserver_port: 8040
+      heartbeat_service_port: 9050
+      brpc_port: 8060
+      sys_log_level: INFO
+      default_rowset_type: beta
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -8,7 +8,7 @@ operator:
   # Default values for operator.
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
-  
+
   global:
     rbac:
       # if set true, the clusterrole, clusterrolebinding, serviceaccount resources will be created for
@@ -22,17 +22,17 @@ operator:
         annotations: {}
         # Optional labels to add to serviceaccount manifest
         labels: {}
-  
+
   # TimeZone is used to set the environment variable TZ for pod, with Asia/Shanghai as the default.
   timeZone: Asia/Shanghai
-  
+
   # set the nameOverride values for creating the same resources with parent chart.
   # In version v1.7.1 or before, there is only one chart called kube-starrocks, and the chart name is the prefix
   # of some resources created by the chart.
   # In version v1.8.0, the kube-starrocks chart is split into two charts, and to keep backward compatibility, the
   # nameOverride is used to set the prefix of the resources created by operator chart.
   nameOverride: "kube-starrocks"
-  
+
   starrocksOperator:
     # If enabled, the operator releated resources will be created, including the operator deployment, service account,
     # clusterrole, clusterrolebinding, and service account.
@@ -112,7 +112,7 @@ starrocks:
   # In version v1.8.0, the kube-starrocks chart is split into two charts, and to keep backward compatibility, the
   # nameOverride is used to set the prefix of the resources created by starrocks chart.
   nameOverride: "kube-starrocks"
-  
+
   # This configuration is used to modify the root password during initial deployment.
   # After deployment is completed, it won't take effect to modify the password here and to do a `helm upgrade`.
   # It also supports providing secret name that contains password, using the password in the secret instead of the plaintext in the values.yaml.
@@ -130,10 +130,10 @@ starrocks:
     image: ""
     # The annotations for the Job, not including the annotations for the pod.
     annotations: {}
-  
+
   # TimeZone is used to set the environment variable TZ for pod, with Asia/Shanghai as the default.
   timeZone: Asia/Shanghai
-  
+
   # This configuration is used to integrate with external system DataDog.
   # You can enable the integration by setting the enabled to true, e.g. datalog.log.enabled=true will enable datadog agent
   # to collect the log.
@@ -151,7 +151,7 @@ starrocks:
       cn: false # change to 'true' to enable profiling on CN pods;
       env: "starrocks-default" # the default value for DD_ENV;
       configMode: "service" # see https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator#configure-apm-and-dogstatsd-communication-mode
-  
+
   # This configuration is used to integrate with external system Prometheus.
   metrics:
     serviceMonitor:
@@ -165,7 +165,7 @@ starrocks:
         # scraper: prometheus-operator
       # Prometheus ServiceMonitor interval
       interval: 15s
-  
+
   # deploy a starrocks cluster
   starrocksCluster:
     # the name of starrockscluster cluster, if not set, the value of nameOverride fields will be used.
@@ -245,7 +245,7 @@ starrocks:
         #     topologyKey: "kubernetes.io/hostname"
       # the pod labels for user select or classify pods.
       podLabels: {}
-  
+
   # spec to deploy fe.
   starrocksFESpec:
     # number of replicas to deploy for a fe statefulset.
@@ -420,6 +420,8 @@ starrocks:
       edit_log_port = 9010
       mysql_service_nio_enabled = true
       sys_log_level = INFO
+    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
+    configyaml: {}
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []
@@ -437,10 +439,10 @@ starrocks:
     # terminationGracePeriodSeconds defines duration in seconds the FE pod needs to terminate gracefully.
     # default value is 120 seconds
     terminationGracePeriodSeconds: 120
-  
+
     # Please upgrade the CRD with v1.8.7 released version, if you want to use the following configuration.
     # including: startupProbeFailureSeconds, livenessProbeFailureSeconds, readinessProbeFailureSeconds
-  
+
     # StartupProbeFailureSeconds defines the total failure seconds of startup Probe.
     # default value is 300 seconds
     # You can set it to 0 to disable the probe.
@@ -487,7 +489,7 @@ starrocks:
       #   volumeMounts:
       #   - mountPath: /opt/starrocks/fe/meta
       #     name: fe-meta   # append -meta to the end of the name of the starrocksFESpec.storageSpec.name
-  
+
   # spec for compute node, compute node provide compute function.
   starrocksCnSpec:
     # number of replicas to deploy for CN component.
@@ -706,6 +708,8 @@ starrocks:
       webserver_port = 8040
       heartbeat_service_port = 9050
       brpc_port = 8060
+    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
+    configyaml: {}
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []
@@ -723,10 +727,10 @@ starrocks:
     # terminationGracePeriodSeconds defines duration in seconds the CN pod needs to terminate gracefully.
     # default value is 120 seconds
     terminationGracePeriodSeconds: 120
-  
+
     # Please upgrade the CRD with v1.8.7 released version, if you want to use the following configuration.
     # including: startupProbeFailureSeconds, livenessProbeFailureSeconds, readinessProbeFailureSeconds
-  
+
     # StartupProbeFailureSeconds defines the total failure seconds of startup Probe.
     # default value is 300 seconds
     # You can set it to 0 to disable the probe.
@@ -775,7 +779,7 @@ starrocks:
       #   volumeMounts:
       #   - mountPath: /opt/starrocks/cn/storage
       #     name: cn-data   # append -data to the end of the name of the starrocksCnSpec.storageSpec.name
-  
+
   # spec for component be, provide storage and compute function.
   starrocksBeSpec:
     # number of replicas to deploy.
@@ -958,6 +962,8 @@ starrocks:
       brpc_port = 8060
       sys_log_level = INFO
       default_rowset_type = beta
+    # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take precedence and values in config field will be discarded.
+    configyaml: {}
     # mount secrets if necessary.
     # see https://kubernetes.io/docs/concepts/storage/volumes/#using-subpath for more details about subPath.
     secrets: []
@@ -975,10 +981,10 @@ starrocks:
     # terminationGracePeriodSeconds defines duration in seconds the BE pod needs to terminate gracefully.
     # default value is 120 seconds
     terminationGracePeriodSeconds: 120
-  
+
     # Please upgrade the CRD with v1.8.7 released version, if you want to use the following configuration.
     # including: startupProbeFailureSeconds, livenessProbeFailureSeconds, readinessProbeFailureSeconds
-  
+
     # StartupProbeFailureSeconds defines the total failure seconds of startup Probe.
     # default value is 300 seconds
     # You can set it to 0 to disable the probe.
@@ -1025,7 +1031,7 @@ starrocks:
       #   volumeMounts:
       #   - mountPath: /opt/starrocks/be/storage
       #     name: be-data   # append -data to the end of the name of the starrocksBeSpec.storageSpec.name
-  
+
   # create secrets if necessary.
   secrets: []
     # e.g. create my-secret
@@ -1034,7 +1040,7 @@ starrocks:
     #     key: |
     #       this is the content of the secret
     #       when mounted, key will be the name of the file
-  
+
   # create configmaps if necessary.
   configMaps: []
     # e.g. create my-configmap
@@ -1043,7 +1049,7 @@ starrocks:
     #     key: |
     #       this is the content of the configmap
     #       when mounted, key will be the name of the file
-  
+
   # If you needs to deploy other resources, e.g. serviceAccount, you can add them here.
   # You can even deploy resources to different namespaces
   resources: []
@@ -1052,7 +1058,7 @@ starrocks:
     #   metadata:
     #     name: sa-for-starrocks
     #     namespace: starrocks
-  
+
   # specify the fe proxy deploy or not.
   starrocksFeProxySpec:
     # specify the fe proxy deploy or not.
@@ -1125,10 +1131,10 @@ starrocks:
       #   operator: "Equal|Exists"
       #   value: "value"
       #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
-  
+
     # Please upgrade the CRD with v1.8.7 released version, if you want to use the following configuration.
     # including: livenessProbeFailureSeconds, readinessProbeFailureSeconds
-  
+
     # LivenessProbeFailureSeconds defines the total failure seconds of liveness Probe.
     # default value is 15 seconds
     # You can set it to 0 to disable the probe.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -8,7 +8,7 @@ operator:
   # Default values for operator.
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
-
+  
   global:
     rbac:
       # if set true, the clusterrole, clusterrolebinding, serviceaccount resources will be created for
@@ -22,17 +22,17 @@ operator:
         annotations: {}
         # Optional labels to add to serviceaccount manifest
         labels: {}
-
+  
   # TimeZone is used to set the environment variable TZ for pod, with Asia/Shanghai as the default.
   timeZone: Asia/Shanghai
-
+  
   # set the nameOverride values for creating the same resources with parent chart.
   # In version v1.7.1 or before, there is only one chart called kube-starrocks, and the chart name is the prefix
   # of some resources created by the chart.
   # In version v1.8.0, the kube-starrocks chart is split into two charts, and to keep backward compatibility, the
   # nameOverride is used to set the prefix of the resources created by operator chart.
   nameOverride: "kube-starrocks"
-
+  
   starrocksOperator:
     # If enabled, the operator releated resources will be created, including the operator deployment, service account,
     # clusterrole, clusterrolebinding, and service account.
@@ -112,7 +112,7 @@ starrocks:
   # In version v1.8.0, the kube-starrocks chart is split into two charts, and to keep backward compatibility, the
   # nameOverride is used to set the prefix of the resources created by starrocks chart.
   nameOverride: "kube-starrocks"
-
+  
   # This configuration is used to modify the root password during initial deployment.
   # After deployment is completed, it won't take effect to modify the password here and to do a `helm upgrade`.
   # It also supports providing secret name that contains password, using the password in the secret instead of the plaintext in the values.yaml.
@@ -130,10 +130,10 @@ starrocks:
     image: ""
     # The annotations for the Job, not including the annotations for the pod.
     annotations: {}
-
+  
   # TimeZone is used to set the environment variable TZ for pod, with Asia/Shanghai as the default.
   timeZone: Asia/Shanghai
-
+  
   # This configuration is used to integrate with external system DataDog.
   # You can enable the integration by setting the enabled to true, e.g. datalog.log.enabled=true will enable datadog agent
   # to collect the log.
@@ -151,7 +151,7 @@ starrocks:
       cn: false # change to 'true' to enable profiling on CN pods;
       env: "starrocks-default" # the default value for DD_ENV;
       configMode: "service" # see https://docs.datadoghq.com/containers/cluster_agent/admission_controller/?tab=operator#configure-apm-and-dogstatsd-communication-mode
-
+  
   # This configuration is used to integrate with external system Prometheus.
   metrics:
     serviceMonitor:
@@ -165,7 +165,7 @@ starrocks:
         # scraper: prometheus-operator
       # Prometheus ServiceMonitor interval
       interval: 15s
-
+  
   # deploy a starrocks cluster
   starrocksCluster:
     # the name of starrockscluster cluster, if not set, the value of nameOverride fields will be used.
@@ -245,7 +245,7 @@ starrocks:
         #     topologyKey: "kubernetes.io/hostname"
       # the pod labels for user select or classify pods.
       podLabels: {}
-
+  
   # spec to deploy fe.
   starrocksFESpec:
     # number of replicas to deploy for a fe statefulset.
@@ -440,10 +440,10 @@ starrocks:
     # terminationGracePeriodSeconds defines duration in seconds the FE pod needs to terminate gracefully.
     # default value is 120 seconds
     terminationGracePeriodSeconds: 120
-
+  
     # Please upgrade the CRD with v1.8.7 released version, if you want to use the following configuration.
     # including: startupProbeFailureSeconds, livenessProbeFailureSeconds, readinessProbeFailureSeconds
-
+  
     # StartupProbeFailureSeconds defines the total failure seconds of startup Probe.
     # default value is 300 seconds
     # You can set it to 0 to disable the probe.
@@ -490,7 +490,7 @@ starrocks:
       #   volumeMounts:
       #   - mountPath: /opt/starrocks/fe/meta
       #     name: fe-meta   # append -meta to the end of the name of the starrocksFESpec.storageSpec.name
-
+  
   # spec for compute node, compute node provide compute function.
   starrocksCnSpec:
     # number of replicas to deploy for CN component.
@@ -729,10 +729,10 @@ starrocks:
     # terminationGracePeriodSeconds defines duration in seconds the CN pod needs to terminate gracefully.
     # default value is 120 seconds
     terminationGracePeriodSeconds: 120
-
+  
     # Please upgrade the CRD with v1.8.7 released version, if you want to use the following configuration.
     # including: startupProbeFailureSeconds, livenessProbeFailureSeconds, readinessProbeFailureSeconds
-
+  
     # StartupProbeFailureSeconds defines the total failure seconds of startup Probe.
     # default value is 300 seconds
     # You can set it to 0 to disable the probe.
@@ -781,7 +781,7 @@ starrocks:
       #   volumeMounts:
       #   - mountPath: /opt/starrocks/cn/storage
       #     name: cn-data   # append -data to the end of the name of the starrocksCnSpec.storageSpec.name
-
+  
   # spec for component be, provide storage and compute function.
   starrocksBeSpec:
     # number of replicas to deploy.
@@ -984,10 +984,10 @@ starrocks:
     # terminationGracePeriodSeconds defines duration in seconds the BE pod needs to terminate gracefully.
     # default value is 120 seconds
     terminationGracePeriodSeconds: 120
-
+  
     # Please upgrade the CRD with v1.8.7 released version, if you want to use the following configuration.
     # including: startupProbeFailureSeconds, livenessProbeFailureSeconds, readinessProbeFailureSeconds
-
+  
     # StartupProbeFailureSeconds defines the total failure seconds of startup Probe.
     # default value is 300 seconds
     # You can set it to 0 to disable the probe.
@@ -1034,7 +1034,7 @@ starrocks:
       #   volumeMounts:
       #   - mountPath: /opt/starrocks/be/storage
       #     name: be-data   # append -data to the end of the name of the starrocksBeSpec.storageSpec.name
-
+  
   # create secrets if necessary.
   secrets: []
     # e.g. create my-secret
@@ -1043,7 +1043,7 @@ starrocks:
     #     key: |
     #       this is the content of the secret
     #       when mounted, key will be the name of the file
-
+  
   # create configmaps if necessary.
   configMaps: []
     # e.g. create my-configmap
@@ -1052,7 +1052,7 @@ starrocks:
     #     key: |
     #       this is the content of the configmap
     #       when mounted, key will be the name of the file
-
+  
   # If you needs to deploy other resources, e.g. serviceAccount, you can add them here.
   # You can even deploy resources to different namespaces
   resources: []
@@ -1061,7 +1061,7 @@ starrocks:
     #   metadata:
     #     name: sa-for-starrocks
     #     namespace: starrocks
-
+  
   # specify the fe proxy deploy or not.
   starrocksFeProxySpec:
     # specify the fe proxy deploy or not.
@@ -1134,10 +1134,10 @@ starrocks:
       #   operator: "Equal|Exists"
       #   value: "value"
       #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
-
+  
     # Please upgrade the CRD with v1.8.7 released version, if you want to use the following configuration.
     # including: livenessProbeFailureSeconds, readinessProbeFailureSeconds
-
+  
     # LivenessProbeFailureSeconds defines the total failure seconds of liveness Probe.
     # default value is 15 seconds
     # You can set it to 0 to disable the probe.


### PR DESCRIPTION
# Description
https://github.com/StarRocks/starrocks-kubernetes-operator/issues/494

# Test
### 1) Test config spec setting
with values1.yaml, run 
```
helm template --debug kube-starrocks --values kube-starrocks/values.yaml --values kube-starrocks/values-1.yaml

```
```
# spec for component be, provide storage and compute function.
starrocks:
  starrocksFESpec:
    configyaml:
      query_port: 9031
      foo: FEAdditionalValue
      additonal: values
  starrocksBeSpec:
    configyaml:
      be_port: 9061
      foo: BEAdditionalValue
  starrocksCluster:
    enabledCn: true
  starrocksCnSpec:
    configyaml:
      heartbeat_service_port: 9051
      foo: CNAdditionalValue
```
Got 
![image](https://github.com/user-attachments/assets/2ffd01ce-6480-4e93-a5e4-cd4dccfc212a)
![image](https://github.com/user-attachments/assets/9ba3efc3-f75e-4ab5-856c-6fcb8d8fc4fd)
![image](https://github.com/user-attachments/assets/ff02eb1c-48b9-45e1-88de-7e962d13d444)

### 2) Test config hash
with template below, a minor change in the configyaml values generate totally different hash value
```
fe-config-hash: "{{template "starrockscluster.fe.config.hash" . }}"
be-config-hash: "{{template "starrockscluster.be.config.hash" . }}"
cn-config-hash: "{{template "starrockscluster.cn.config.hash" . }}"

```
![image](https://github.com/user-attachments/assets/459b3741-2675-465c-aea4-53ffac4dfc87)
![image](https://github.com/user-attachments/assets/eba1395c-5499-427b-b2f6-f780f301fd08)
![image](https://github.com/user-attachments/assets/0141a26e-2ae1-4348-8c92-0f2aff77bde0)

### 3) Test with quote in values
```
  starrocksFESpec:
    configyaml:
      LOG_DIR : ${STARROCKS_HOME}/log
      DATE : '"$(date +%Y%m%d-%H%M%S)"'
      JAVA_OPTS: '"-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time"'
      mysql_service_nio_enabled: false
```
![image](https://github.com/user-attachments/assets/581ed473-d3e8-4f98-a372-e184689dd132)
### 4) Test with configyaml not setting
Verified that it uses the string value in config field

### 5) Verified default value setting from configyaml
![image](https://github.com/user-attachments/assets/ae3ce544-d80e-4277-93c4-af9189c06aab)
![image](https://github.com/user-attachments/assets/9bddc568-b0d2-4508-a910-a82df600d6ec)
![image](https://github.com/user-attachments/assets/20935114-55e9-4f04-886c-4b10f4a94935)

# Related Issue(s)

N/A


# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).

