### PR TITLE
[BugFix] set proxy_http_version 1.1

### DIFF
--- a/pkg/subcontrollers/feproxy/feproxy_configmap.go
+++ b/pkg/subcontrollers/feproxy/feproxy_configmap.go
@@ -61,6 +61,7 @@ http {
   ignore_invalid_headers off;
   underscores_in_headers on;
   proxy_read_timeout 600s;
+  proxy_http_version 1.1;
 
   client_body_temp_path /tmp/client_temp;
   proxy_temp_path       /tmp/proxy_temp_path;


### PR DESCRIPTION
# Description

StarRocks has released a new version, 3.3.6, which has a bug: for Stream Load requests, FE forcibly requires setting the 100-continue request header, which belongs to the HTTP 1.1 protocol, but Nginx defaults to using the HTTP 1.0 protocol for forwarding, causing Stream Load requests sent to feproxy to fail. 

StarRocks will fix this issue in future versions, but for feproxy users, adding the proxy_http_version 1.1 setting will be compatible with this defect in version 3.3.6.

See https://github.com/StarRocks/starrocks/pull/53010 and https://github.com/StarRocks/starrocks/pull/52582