### PR TITLE
[BugFix] In Helm Chart, capabilities field needs to be supported for FE

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -89,6 +89,10 @@ spec:
     {{- if .Values.starrocksFESpec.readOnlyRootFilesystem }}
     readOnlyRootFilesystem: {{ .Values.starrocksFESpec.readOnlyRootFilesystem }}
     {{- end }}
+    {{- if .Values.starrocksFESpec.capabilities }}
+    capabilities:
+      {{- toYaml .Values.starrocksFESpec.capabilities | nindent 6 }}
+    {{- end }}
     {{- if or .Values.starrocksFESpec.nodeSelector .Values.starrocksCluster.componentValues.nodeSelector }}
     nodeSelector:
       {{- include "starrockscluster.fe.nodeSelector" . | nindent 6 }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -165,6 +165,13 @@ starrocksFESpec:
   # Whether this container has a read-only root filesystem.
   # Note: The FE/BE/CN container should support read-only root filesystem. The newest version of FE/BE/CN is 3.3.6, and does not support read-only root filesystem.
   readOnlyRootFilesystem: false
+  # add/drop capabilities for FE container.
+  capabilities: {}
+  #  add:
+  #    - PERFMON
+  #    - SYS_PTRACE
+  #  drop:
+  #    - SYS_ADMIN
   # specify the service name and port config and serviceType
   # the service type refer https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   service:

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -273,6 +273,13 @@ starrocks:
     # Whether this container has a read-only root filesystem.
     # Note: The FE/BE/CN container should support read-only root filesystem. The newest version of FE/BE/CN is 3.3.6, and does not support read-only root filesystem.
     readOnlyRootFilesystem: false
+    # add/drop capabilities for FE container.
+    capabilities: {}
+    #  add:
+    #    - PERFMON
+    #    - SYS_PTRACE
+    #  drop:
+    #    - SYS_ADMIN
     # specify the service name and port config and serviceType
     # the service type refer https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     service:


### PR DESCRIPTION
# Description

In Helm Chart, capabilities field needs to be supported for FE

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
