### PR TITLE
[Enhancement] Add support for custom log and spill storage class names

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -224,7 +224,11 @@ spec:
       storageSize: "{{ .Values.starrocksFESpec.storageSpec.storageSize }}"
       mountPath: {{ template "starrockscluster.fe.meta.path" . }}
     - name: {{ .Values.starrocksFESpec.storageSpec.name }}{{ template "starrockscluster.fe.log.suffix" . }}
+      {{- if .Values.starrocksFESpec.storageSpec.logStorageClassName }}
+      storageClassName: {{ .Values.starrocksFESpec.storageSpec.logStorageClassName }}
+      {{- else }}
       storageClassName: {{ .Values.starrocksFESpec.storageSpec.storageClassName }}
+      {{- end }}
       storageSize: "{{ .Values.starrocksFESpec.storageSpec.logStorageSize }}"
       mountPath: {{ template "starrockscluster.fe.log.path" . }}
     {{- end }}
@@ -486,11 +490,19 @@ spec:
       mountPath: {{template "starrockscluster.be.data.path" . }}
     {{- end }}
     - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.log.suffix" . }}
+      {{- if .Values.starrocksBeSpec.storageSpec.logStorageClassName }}
+      storageClassName: {{ .Values.starrocksBeSpec.storageSpec.logStorageClassName }}
+      {{- else }}
       storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
+      {{- end }}
       storageSize: "{{ .Values.starrocksBeSpec.storageSpec.logStorageSize }}"
       mountPath: {{template "starrockscluster.be.log.path" . }}
     - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.spill.suffix" . }}
+      {{- if .Values.starrocksBeSpec.storageSpec.spillStorageClassName }}
+      storageClassName: {{ .Values.starrocksBeSpec.storageSpec.spillStorageClassName }}
+      {{- else }}
       storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
+      {{- end }}
       storageSize: "{{ .Values.starrocksBeSpec.storageSpec.spillStorageSize}}"
       mountPath: {{template "starrockscluster.be.spill.path" . }}
     {{- end }}
@@ -759,11 +771,19 @@ spec:
       mountPath: {{template "starrockscluster.cn.data.path" . }}
     {{- end }}
     - name: {{ .Values.starrocksCnSpec.storageSpec.name }}{{template "starrockscluster.cn.log.suffix" . }}
+      {{- if .Values.starrocksCnSpec.storageSpec.logStorageClassName }}
+      storageClassName: {{ .Values.starrocksCnSpec.storageSpec.logStorageClassName }}
+      {{- else }}
       storageClassName: {{ .Values.starrocksCnSpec.storageSpec.storageClassName }}
+      {{- end }}
       storageSize: "{{ .Values.starrocksCnSpec.storageSpec.logStorageSize }}"
       mountPath: {{template "starrockscluster.cn.log.path" . }}
     - name: {{ .Values.starrocksCnSpec.storageSpec.name }}{{template "starrockscluster.cn.spill.suffix" . }}
+      {{- if .Values.starrocksCnSpec.storageSpec.spillStorageClassName }}
+      storageClassName: {{ .Values.starrocksCnSpec.storageSpec.spillStorageClassName }}
+      {{- else }}
       storageClassName: {{ .Values.starrocksCnSpec.storageSpec.storageClassName }}
+      {{- end }}
       storageSize: "{{ .Values.starrocksCnSpec.storageSpec.spillStorageSize}}"
       mountPath: {{template "starrockscluster.cn.spill.path" . }}
     {{- end }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -287,6 +287,8 @@ starrocksFESpec:
     storageSize: 10Gi
     # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/fe/meta.
     storageMountPath: ""
+    # If not set will use the value of the storageClassName field.
+    logStorageClassName: ""
     # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/fe/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
     logStorageSize: 5Gi
@@ -597,12 +599,16 @@ starrocksCnSpec:
     storageCount: 1
     # see the comment of storageCount for the usage of storageMountPath.
     storageMountPath: ""
+    # If not set will use the value of the storageClassName field.
+    logStorageClassName: ""
     # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
     logStorageSize: 20Gi
     # If logMountPath is empty, the logMountPath will be set to /opt/starrocks/cn/log.
     # If logMountPath is not /opt/starrocks/cn/log, you must add in config the following configuration: sys_log_dir = xxx.
     logMountPath: ""
+    # If not set will use the value of the storageClassName field.
+    spillStorageClassName: ""
     # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/cn/spill.
     # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
     # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/cn/spill.
@@ -884,12 +890,16 @@ starrocksBeSpec:
     storageCount: 1
     # see the comment of storageCount for the usage of storageMountPath.
     storageMountPath: ""
+    # If not set will use the value of the storageClassName field.
+    logStorageClassName: ""
     # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
     # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
     logStorageSize: 20Gi
     # If logMountPath is empty, the logMountPath will be set to /opt/starrocks/be/log.
     # If logMountPath is not /opt/starrocks/be/log, you must add in config the following configuration: sys_log_dir = xxx.
     logMountPath: ""
+    # If not set will use the value of the storageClassName field.
+    spillStorageClassName: ""
     # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/be/spill.
     # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
     # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/be/spill.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -395,6 +395,8 @@ starrocks:
       storageSize: 10Gi
       # If storageMountPath is empty, the storageMountPath will be set to /opt/starrocks/fe/meta.
       storageMountPath: ""
+      # If not set will use the value of the storageClassName field.
+      logStorageClassName: ""
       # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/fe/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
       logStorageSize: 5Gi
@@ -705,12 +707,16 @@ starrocks:
       storageCount: 1
       # see the comment of storageCount for the usage of storageMountPath.
       storageMountPath: ""
+      # If not set will use the value of the storageClassName field.
+      logStorageClassName: ""
       # the storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
       logStorageSize: 20Gi
       # If logMountPath is empty, the logMountPath will be set to /opt/starrocks/cn/log.
       # If logMountPath is not /opt/starrocks/cn/log, you must add in config the following configuration: sys_log_dir = xxx.
       logMountPath: ""
+      # If not set will use the value of the storageClassName field.
+      spillStorageClassName: ""
       # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/cn/spill.
       # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
       # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/cn/spill.
@@ -992,12 +998,16 @@ starrocks:
       storageCount: 1
       # see the comment of storageCount for the usage of storageMountPath.
       storageMountPath: ""
+      # If not set will use the value of the storageClassName field.
+      logStorageClassName: ""
       # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
       # If you set it to 0Gi, the related PVC will not be created, and the log will not be persisted.
       logStorageSize: 20Gi
       # If logMountPath is empty, the logMountPath will be set to /opt/starrocks/be/log.
       # If logMountPath is not /opt/starrocks/be/log, you must add in config the following configuration: sys_log_dir = xxx.
       logMountPath: ""
+      # If not set will use the value of the storageClassName field.
+      spillStorageClassName: ""
       # Setting this parameter can persist spill storage, and the mount path is /opt/starrocks/be/spill.
       # If you set it to 0Gi, the related PVC will not be created, and the spill will not be persisted.
       # You need to add in be.conf spill_local_storage_dir=/opt/starrocks/be/spill.


### PR DESCRIPTION
# Description

Add support for custom log and spill storage class names

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
