### PR TITLE
[BugFix] support to run fe-proxy under customize cluster domain instead of using default one: cluster.local

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters-settings:
       - pattern: 'interface{}'
         replacement: 'any'
   goimports:
-    local-prefixes: github.com/StarRocks/starrocks-kubernetes-operator/pkg
+    local-prefixes: github.com/StarRocks/starrocks-kubernetes-operator
   gomnd:
     # don't include the "operation" and "assign"
     checks:

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,9 @@
+package config
+
+import "fmt"
+
+var DNSDomainSuffix string
+
+func GetServiceDomainSuffix() string {
+	return fmt.Sprintf("svc.%s", DNSDomainSuffix)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/StarRocks/starrocks-kubernetes-operator/cmd/config"
 	srapi "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/controllers"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils"
@@ -45,6 +46,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&_namespace, "namespace", "", "if specified, "+
 		"restricts the manager's cache to watch objects in the desired namespace. Defaults to all namespaces.")
+	flag.StringVar(&config.DNSDomainSuffix, "dns-domain-suffix", "cluster.local", "The suffix of the dns domain in k8s")
 
 	// Set up logger.
 	opts := zap.Options{}
@@ -83,7 +85,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	//+kubebuilder:scaffold:builder
+	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		logger.Error(err, "unable to set up health check")

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         {{- if .Values.starrocksOperator.watchNamespace }}
         - --namespace={{ .Values.starrocksOperator.watchNamespace }}
         {{- end }}
+        {{- if .Values.starrocksOperator.dnsDomainSuffix }}
+        - --dns-domain-suffix={{ .Values.starrocksOperator.dnsDomainSuffix }}
+        {{- end }}
         env:
         - name: TZ
           value: {{ .Values.timeZone }}

--- a/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
@@ -97,3 +97,7 @@ starrocksOperator:
     - --zap-encoder=console
     # if you want open debug log, open this option
     # - --zap-log-level 4
+  # Operator need to specify the FQDN in nginx.conf when it set up fe-proxy service.
+  # By default, Operator will use cluster.local as the dnsDomainSuffix.
+  # If you set up a kubernetes cluster with a different dnsDomainSuffix, you need to set this value.
+  dnsDomainSuffix: ""

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -104,6 +104,10 @@ operator:
       - --zap-encoder=console
       # if you want open debug log, open this option
       # - --zap-log-level 4
+    # Operator need to specify the FQDN in nginx.conf when it set up fe-proxy service.
+    # By default, Operator will use cluster.local as the dnsDomainSuffix.
+    # If you set up a kubernetes cluster with a different dnsDomainSuffix, you need to set this value.
+    dnsDomainSuffix: ""
 
 starrocks:
   # set the nameOverride values for creating the same resources with parent chart.

--- a/pkg/subcontrollers/feproxy/feproxy_configmap.go
+++ b/pkg/subcontrollers/feproxy/feproxy_configmap.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	cmdconfig "github.com/StarRocks/starrocks-kubernetes-operator/cmd/config"
 	srapi "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
 	rutils "github.com/StarRocks/starrocks-kubernetes-operator/pkg/common/resource_utils"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils"
@@ -27,11 +28,11 @@ func (controller *FeProxyController) SyncConfigMap(ctx context.Context, src *sra
 
 	feSearchServiceName := service.SearchServiceName(src.Name, feSpec)
 	feExternalServiceName := service.ExternalServiceName(src.Name, feSpec)
-	proxyPass := fmt.Sprintf("http://%s.%s.%s:%d", feExternalServiceName, src.GetNamespace(), "svc.cluster.local", httpPort)
+	proxyPass := fmt.Sprintf("http://%s.%s.%s:%d", feExternalServiceName, src.GetNamespace(), cmdconfig.GetServiceDomainSuffix(), httpPort)
 
 	resolver := feProxySpec.Resolver
 	if resolver == "" {
-		resolver = "kube-dns.kube-system.svc.cluster.local"
+		resolver = fmt.Sprintf("%s.%s", "kube-dns.kube-system", cmdconfig.GetServiceDomainSuffix())
 	}
 
 	or := metav1.NewControllerRef(src, src.GroupVersionKind())


### PR DESCRIPTION
# Description

https://github.com/StarRocks/starrocks/issues/49984

We expose a parameter for operator to allow users to specify the dns domain suffix in k8s.

verify the modification:

1. sample configuration for nginx.conf
```
pid   /tmp/nginx.pid;
worker_processes 4;
include /usr/share/nginx/modules/*.conf;
events {
  worker_connections 256;
}

http {
  sendfile            on;
  tcp_nopush          on;
  tcp_nodelay         on;
  keepalive_timeout   65;
  types_hash_max_size 2048;
  client_max_body_size 0;
  ignore_invalid_headers off;
  underscores_in_headers on;
  proxy_read_timeout 600s;
  proxy_http_version 1.1;

  client_body_temp_path /tmp/client_temp;
  proxy_temp_path       /tmp/proxy_temp_path;
  fastcgi_temp_path     /tmp/fastcgi_temp;
  uwsgi_temp_path       /tmp/uwsgi_temp;
  scgi_temp_path        /tmp/scgi_temp;

  default_type        application/octet-stream;

  server {
    listen 8080;
    resolver kube-dns.kube-system.svc.cluster.ydx valid=10s;
    proxy_intercept_errors on;
    recursive_error_pages on;

    location /nginx/health {
      access_log off;
      return 200;
    }

    location / {
      # see https://serverfault.com/questions/240476/how-to-force-nginx-to-resolve-dns-of-a-dynamic-hostname-everytime-when-doing-p/593003#593003 for why we use set
      set $fe_service "http://kube-starrocks-fe-service.default.svc.cluster.ydx:8030";
      proxy_pass $fe_service;
      proxy_set_header Expect $http_expect;
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      error_page 307 = @handle_redirect;
    }

    location /api/transaction/load {
      set $fe_service "http://kube-starrocks-fe-service.default.svc.cluster.ydx:8030";
      proxy_pass $fe_service;
      proxy_pass_request_body off;
      proxy_set_header Expect $http_expect;
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      error_page 307 = @handle_redirect;
    }

    location ~ ^/api/.*/.*/_stream_load$ {
      set $fe_service "http://kube-starrocks-fe-service.default.svc.cluster.ydx:8030";
      proxy_pass $fe_service;
      proxy_pass_request_body off;
      proxy_set_header Expect $http_expect;
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      error_page 307 = @handle_redirect;
    }

    location @handle_redirect {
      if ($upstream_http_location ~ "kube-starrocks-fe-search") {
        rewrite ^ /_redirect_to_fe last;
      }
      if ($upstream_http_location !~ "kube-starrocks-fe-search") {
        rewrite ^ /_redirect_to_others last;
      }
    }

    location /_redirect_to_fe {
      set $redirect_uri '$upstream_http_location';
      proxy_pass $redirect_uri;
      proxy_set_header Expect $http_expect;
      proxy_pass_request_body off;
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      error_page 307 = @handle_redirect;
    }

    location /_redirect_to_others {
      set $redirect_uri '$upstream_http_location';
      proxy_pass $redirect_uri;
      proxy_set_header Expect $http_expect;
      proxy_pass_request_body on;
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      error_page 307 = @handle_redirect;
    }
  }
}
```

2. execute stream load request.

```
root@kube-starrocks-be-0:/opt/starrocks# curl --location-trusted -u root: -H "label:custom_label212" -H "Expect:100-continue" -H "column_separator:," -H "columns: col1, col2" -T aaa.data -XPUT http://kube-starrocks-fe-proxy-service:8080/api/control_db/test_table/_stream_load
{
    "TxnId": 6,
    "Label": "custom_label212",
    "Status": "Success",
    "Message": "OK",
    "NumberTotalRows": 4,
    "NumberLoadedRows": 4,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 38,
    "LoadTimeMs": 206,
    "BeginTxnTimeMs": 9,
    "StreamLoadPlanTimeMs": 121,
    "ReadDataTimeMs": 0,
    "WriteDataTimeMs": 52,
    "CommitAndPublishTimeMs": 21
}
```

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.