### PR TITLE
[Bugfix] Do not create the default data storage volume when deploying be with multiple volumes

### DIFF
--- a/doc/cn/logging_and_related_configurations_howto.md
+++ b/doc/cn/logging_and_related_configurations_howto.md
@@ -32,7 +32,7 @@ spec:
   starRocksFeSpec:
     storageVolumes:
       - mountPath: /opt/starrocks/fe/log
-        name: fe-storage-log
+        name: fe-log
         storageSize: 10Gi
         # storageClassName: ""  # 如果 storageClassName 为空，Kubernetes 将使用默认的存储卷类型。
 ```
@@ -52,7 +52,7 @@ spec:
 starrocks:
   starrocksFESpec:
     storageSpec:
-      name: "fe-storage"
+      name: "fe"
       storageSize: 10Gi
       logStorageSize: 10Gi
       # storageClassName: ""  # 如果 storageClassName 为空，Kubernetes 将使用默认的存储卷类型。
@@ -63,7 +63,7 @@ starrocks:
 ```yaml
 starrocksFESpec:
   storageSpec:
-    name: "fe-storage"
+    name: "fe"
     storageSize: 10Gi
     logStorageSize: 10Gi
     # storageClassName: ""  # 如果 storageClassName 为空，Kubernetes 将使用默认的存储卷类型。

--- a/doc/logging_and_related_configurations_howto.md
+++ b/doc/logging_and_related_configurations_howto.md
@@ -37,7 +37,7 @@ spec:
   starRocksFeSpec:
     storageVolumes:
       - mountPath: /opt/starrocks/fe/log
-        name: fe-storage-log
+        name: fe-log
         storageSize: 10Gi
         # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
 ```
@@ -61,7 +61,7 @@ For the kube-starrocks Helm Chart, you can configure as:
 starrocks:
   starrocksFESpec:
     storageSpec:
-      name: "fe-storage"
+      name: "fe"
       storageSize: 10Gi
       logStorageSize: 10Gi
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
@@ -72,7 +72,7 @@ For the starrocks Helm Chart, configure as:
 ```yaml
 starrocksFESpec:
   storageSpec:
-    name: "fe-storage"
+    name: "fe"
     storageSize: 10Gi
     logStorageSize: 10Gi
     # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.

--- a/doc/mount_persistent_volume_howto.md
+++ b/doc/mount_persistent_volume_howto.md
@@ -31,12 +31,12 @@ spec:
     image: "starrocks/fe-ubuntu:3.3-latest"
     replicas: 1
     storageVolumes:
-    - name: fe-storage-meta
+    - name: fe-meta
       storageClassName: standard-rwo  # standard-rwo is the default storageClassName in GKE.
       # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
       storageSize: 10Gi
       mountPath: /opt/starrocks/fe/meta
-    - name: fe-storage-log
+    - name: fe-log
       storageClassName: standard-rwo
       storageSize: 5Gi
       mountPath: /opt/starrocks/fe/log
@@ -44,11 +44,11 @@ spec:
     image: "starrocks/be-ubuntu:3.3-latest"
     replicas: 3
     storageVolumes:
-    - name: be-storage-data
+    - name: be-data
       storageClassName: standard-rwo
       storageSize: 1Ti
       mountPath: /opt/starrocks/be/storage
-    - name: be-storage-log
+    - name: be-log
       storageClassName: standard-rwo
       storageSize: 1Gi
       mountPath: /opt/starrocks/be/log
@@ -109,7 +109,7 @@ starrocks:
          repository: starrocks/fe-ubuntu
          tag: 3.3-latest
       storageSpec:
-         name: fe-storage
+         name: fe-data
          storageClassName: standard-rwo   # standard-rwo is the default storageClassName in GKE.
          logStorageSize: 10Gi
          storageSize: 100Gi

--- a/examples/starrocks/deploy_a_starrocks_cluster_with_all_features.yaml
+++ b/examples/starrocks/deploy_a_starrocks_cluster_with_all_features.yaml
@@ -24,7 +24,7 @@ spec:
       resolveKey: fe.conf
     # fe storage volumes for persistent metadata and log
     storageVolumes:
-      - name: fe-storage-meta
+      - name: fe-meta
         # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
         # storageClassName: ""
         # the persistent volume size. FE container stop running if the disk free space which the
@@ -32,7 +32,7 @@ spec:
         storageSize: 10Gi
         # the mount path for FE meta.
         mountPath: /opt/starrocks/fe/meta
-      - name: fe-storage-log
+      - name: fe-log
         # storageClassName: ""
         # the size of storage volume for log
         storageSize: 1Gi
@@ -148,14 +148,14 @@ spec:
       resolveKey: be.conf
     # be storage volumes for persistent storage.
     storageVolumes:
-      - name: be-storage-data
+      - name: be-data
         # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
         # storageClassName: ""
         # the size of storage volume for data
         storageSize: 10Gi
         # the mount path for BE data.
         mountPath: /opt/starrocks/be/storage
-      - name: be-storage-log
+      - name: be-log
         # storageClassName: ""
         # the size of storage volume for log
         storageSize: 1Gi
@@ -271,14 +271,14 @@ spec:
       configMapName: starrockscluster-sample-cn-cm
       resolveKey: cn.conf
     storageVolumes:
-      - name: cn-storage-data
+      - name: cn-data
         # the storageClassName represent the used storageclass name. if not set will use k8s cluster default storageclass.
         # storageClassName: ""
         # the size of storage volume for data
         storageSize: 10Gi
         # the mount path of CN data
         mountPath: /opt/starrocks/cn/storage
-      - name: cn-storage-log
+      - name: cn-log
         # storageClassName: ""
         # the size of storage volume for log
         storageSize: 1Gi

--- a/examples/starrocks/deploy_a_starrocks_cluster_with_cn.yaml
+++ b/examples/starrocks/deploy_a_starrocks_cluster_with_cn.yaml
@@ -22,12 +22,12 @@ spec:
     # storageVolumes is optional. If you don't specify it, emptyDir will be used to store FE meta and log, and the files
     # and directories written to the volume will be completely lost upon container restarting.
     storageVolumes:
-    - name: fe-storage-meta
+    - name: fe-meta
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
       # FE container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
       storageSize: 10Gi
       mountPath: /opt/starrocks/fe/meta
-    - name: fe-storage-log
+    - name: fe-log
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
       storageSize: 5Gi
       mountPath: /opt/starrocks/fe/log
@@ -45,11 +45,11 @@ spec:
     # storageVolumes is optional. If you don't specify it, emptyDir will be used to store BE data and log, and be aware
     # that the files and directories written to the volume will be completely lost upon container restarting.
     storageVolumes:
-    - name: be-storage-data
+    - name: be-data
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
       storageSize: 1Ti
       mountPath: /opt/starrocks/be/storage
-    - name: be-storage-log
+    - name: be-log
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
       storageSize: 1Gi
       mountPath: /opt/starrocks/be/log

--- a/examples/starrocks/deploy_a_starrocks_cluster_with_persistent_storage.yaml
+++ b/examples/starrocks/deploy_a_starrocks_cluster_with_persistent_storage.yaml
@@ -26,11 +26,11 @@ spec:
       cpu: 8
       memory: 16Gi
     storageVolumes:
-    - name: fe-storage-meta
+    - name: fe-meta
       # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 10Gi   # the size of storage volume for metadata
       mountPath: /opt/starrocks/fe/meta   # the path of metadata
-    - name: fe-storage-log
+    - name: fe-log
       # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 1Gi    # the size of storage volume for log
       mountPath: /opt/starrocks/fe/log    # the path of log
@@ -44,11 +44,11 @@ spec:
       cpu: 16
       memory: 64Gi
     storageVolumes:
-    - name: be-storage-data
+    - name: be-data
       # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 10Gi   # the size of storage volume for data
       mountPath: /opt/starrocks/be/storage  # the path of data
-    - name: be-storage-log
+    - name: be-log
       # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 1Gi  # the size of storage volume for log
       mountPath: /opt/starrocks/be/log  # the path of log
@@ -62,11 +62,11 @@ spec:
       cpu: 16
       memory: 64Gi
     storageVolumes:
-    - name: cn-storage-data
+    - name: cn-data
       # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 10Gi   # the size of storage volume for data
       mountPath: /opt/starrocks/cn/storage  # the path of data
-    - name: cn-storage-log
+    - name: cn-log
       # storageClassName: ""  # if storageClassName is not set, the default storage class will be used
       storageSize: 1Gi  # the size of storage volume for log
       mountPath: /opt/starrocks/cn/log  # the path of log

--- a/examples/starrocks/starrocks-fe-and-be.yaml
+++ b/examples/starrocks/starrocks-fe-and-be.yaml
@@ -20,12 +20,12 @@ spec:
     # storageVolumes is optional. If you don't specify it, emptyDir will be used to store FE meta and log, and be aware
     # that the files and directories written to the volume will be completely lost upon container restarting.
     storageVolumes:
-    - name: fe-storage-meta
+    - name: fe-meta
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
       # fe container stop running if the disk free space which the fe meta directory residents, is less than 5Gi.
       storageSize: 10Gi
       mountPath: /opt/starrocks/fe/meta
-    - name: fe-storage-log
+    - name: fe-log
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
       storageSize: 5Gi
       mountPath: /opt/starrocks/fe/log
@@ -43,11 +43,11 @@ spec:
     # storageVolumes is optional. If you don't specify it, emptyDir will be used to store BE data and log, and be aware
     # that the files and directories written to the volume will be completely lost upon container restarting.
     storageVolumes:
-    - name: be-storage-data
+    - name: be-data
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
       storageSize: 1Ti
       mountPath: /opt/starrocks/be/storage
-    - name: be-storage-log
+    - name: be-log
       # storageClassName: ""  # If storageClassName is not set, Kubernetes will use the default storage class.
       storageSize: 1Gi
       mountPath: /opt/starrocks/be/log

--- a/pkg/controllers/starrockscluster_controller_test.go
+++ b/pkg/controllers/starrockscluster_controller_test.go
@@ -72,7 +72,7 @@ func TestReconcileConstructFeResource(t *testing.T) {
 						},
 						StorageVolumes: []srapi.StorageVolume{
 							{
-								Name:             "fe-storage",
+								Name:             "fe-meta",
 								StorageClassName: rutils.GetStringPointer("shard-data"),
 								MountPath:        "/data/fe/meta",
 								StorageSize:      "10Gi",

--- a/pkg/k8sutils/k8sutils_test.go
+++ b/pkg/k8sutils/k8sutils_test.go
@@ -792,11 +792,22 @@ func TestHasMountPath(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "test has mount path",
+			name: "test dose not have mount path",
 			args: args{
 				mounts: []corev1.VolumeMount{
 					{
-						Name:      "fe-meta-storage",
+						MountPath: "/etc/fe/fe-meta",
+					},
+				},
+				newMountPath: "/opt/starrocks/fe/fe-meta",
+			},
+			want: false,
+		},
+		{
+			name: "test has mount path 1",
+			args: args{
+				mounts: []corev1.VolumeMount{
+					{
 						MountPath: "/opt/starrocks/fe/fe-meta",
 					},
 				},
@@ -809,13 +820,13 @@ func TestHasMountPath(t *testing.T) {
 			args: args{
 				mounts: []corev1.VolumeMount{
 					{
-						Name:      "fe-meta-storage",
-						MountPath: "/opt/starrocks/fe/fe-meta",
+						Name:      "storage",
+						MountPath: "/opt/starrocks/fe/fe-meta1",
 					},
 				},
-				newMountPath: "/opt/starrocks/fe/fe-meta2",
+				newMountPath: "/opt/starrocks/fe/fe-meta",
 			},
-			want: false,
+			want: true,
 		},
 	}
 	for _, tt := range tests {
@@ -829,8 +840,8 @@ func TestHasMountPath(t *testing.T) {
 
 func TestHasVolume(t *testing.T) {
 	type args struct {
-		volumes       []corev1.Volume
-		newVolumeName string
+		volumes           []corev1.Volume
+		defaultVolumeName string
 	}
 	tests := []struct {
 		name string
@@ -840,41 +851,47 @@ func TestHasVolume(t *testing.T) {
 		{
 			name: "test has volume",
 			args: args{
-				volumes: []corev1.Volume{
-					{
-						Name: "fe-meta",
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "fe-meta",
-							},
-						},
-					},
-				},
-				newVolumeName: "fe-meta",
+				volumes:           []corev1.Volume{{Name: "fe-meta"}},
+				defaultVolumeName: "fe-meta",
 			},
 			want: true,
 		},
 		{
 			name: "test has volume",
 			args: args{
-				volumes: []corev1.Volume{
-					{
-						Name: "fe-meta",
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: "fe-meta",
-							},
-						},
-					},
-				},
-				newVolumeName: "fe-meta2",
+				volumes:           []corev1.Volume{{Name: "be0-data"}},
+				defaultVolumeName: "be-data",
+			},
+			want: true,
+		},
+		{
+			name: "test does not have volume 1",
+			args: args{
+				volumes:           []corev1.Volume{{Name: "fe-meta"}},
+				defaultVolumeName: "fe-meta2",
+			},
+			want: false,
+		},
+		{
+			name: "test does not have volume 2",
+			args: args{
+				volumes:           []corev1.Volume{{Name: "fe-meta-1"}},
+				defaultVolumeName: "fe-meta",
+			},
+			want: false,
+		},
+		{
+			name: "test does not have volume 3",
+			args: args{
+				volumes:           []corev1.Volume{{Name: "fe-meta-1"}},
+				defaultVolumeName: "meta",
 			},
 			want: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := k8sutils.HasVolume(tt.args.volumes, tt.args.newVolumeName); got != tt.want {
+			if got := k8sutils.HasVolume(tt.args.volumes, tt.args.defaultVolumeName); got != tt.want {
 				t.Errorf("HasVolume() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/subcontrollers/fe/fe_controller_reconcile_test.go
+++ b/pkg/subcontrollers/fe/fe_controller_reconcile_test.go
@@ -58,7 +58,7 @@ func TestStarRocksClusterReconciler_FeReconcileSuccess(t *testing.T) {
 						},
 						StorageVolumes: []srapi.StorageVolume{
 							{
-								Name:             "fe-storage",
+								Name:             "fe-meta",
 								StorageClassName: rutils.GetStringPointer("shard-data"),
 								StorageSize:      "10Gi",
 								MountPath:        "/data/fe/meta",


### PR DESCRIPTION
# Description

Please provide a detailed description of the changes you have made. Include the motivation for these changes, and any
additional context that may be important.
> the PR should include helm chart changes and operator changes.

# Related Issue(s)

#611 

If this PR is included:
```
  volumes:
  - name: be1-data
    persistentVolumeClaim:
      claimName: be1-data-kube-starrocks-be-0
  - name: be-log
    persistentVolumeClaim:
      claimName: be-log-kube-starrocks-be-0
  - name: be0-data
    persistentVolumeClaim:
      claimName: be0-data-kube-starrocks-be-0
  - configMap:
      defaultMode: 420
      name: kube-starrocks-be-cm
    name: kube-starrocks-be-cm
```

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.