### PR TITLE
[BugFix] Fix StatefulSet Update Strategy Handling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -156,8 +156,10 @@ run:
   skip-files:
     - ".*_test\\.go"
     - pkg/subcontrollers/feproxy/feproxy_configmap.go
+    - scripts/migrate-chart-value/main.go
   skip-dirs:
     - test/testdata_etc # test files
     - internal/cache # extracted from Go code
     - internal/renameio # extracted from Go code
     - internal/robustio # extracted from Go code
+    - /opt/homebrew

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -30,7 +30,7 @@ spec:
     {{- if .Values.starrocksFESpec.maxUnavailablePods }}
     updateStrategy:
       rollingUpdate:
-        maxUnavailable: "{{ .Values.starrocksFESpec.maxUnavailablePods }}"
+        maxUnavailable: {{ .Values.starrocksFESpec.maxUnavailablePods }}
     {{- end }}
     {{- /*
     support both resources and resource for backward compatibility
@@ -277,7 +277,7 @@ spec:
     {{- if .Values.starrocksBeSpec.maxUnavailablePods }}
     updateStrategy:
       rollingUpdate:
-        maxUnavailable: "{{ .Values.starrocksBeSpec.maxUnavailablePods }}"
+        maxUnavailable: {{ .Values.starrocksBeSpec.maxUnavailablePods }}
     {{- end }}
     {{- /*
     support both resources and resource for backward compatibility
@@ -556,7 +556,7 @@ spec:
     {{- if .Values.starrocksCnSpec.maxUnavailablePods }}
     updateStrategy:
       rollingUpdate:
-        maxUnavailable: "{{ .Values.starrocksCnSpec.maxUnavailablePods }}"
+        maxUnavailable: {{ .Values.starrocksCnSpec.maxUnavailablePods }}
     {{- end }}
     {{- if or .Values.starrocksCnSpec.serviceAccount .Values.starrocksCluster.componentValues.serviceAccount }}
     serviceAccount: {{ include "starrockscluster.cn.serviceAccount" . }}

--- a/pkg/common/resource_utils/statefulset.go
+++ b/pkg/common/resource_utils/statefulset.go
@@ -34,6 +34,7 @@ type hashStatefulsetObject struct {
 	serviceName          string
 	volumeClaimTemplates []corev1.PersistentVolumeClaim
 	replicas             int32
+	updateStrategy       appv1.StatefulSetUpdateStrategy
 }
 
 // StatefulsetHashObject construct the hash spec for deep equals to exist statefulset.
@@ -60,6 +61,7 @@ func statefulSetHashObject(sts *appv1.StatefulSet, excludeReplica bool) hashStat
 		serviceName:          sts.Spec.ServiceName,
 		volumeClaimTemplates: sts.Spec.VolumeClaimTemplates,
 		replicas:             replicas,
+		updateStrategy:       sts.Spec.UpdateStrategy,
 	}
 }
 
@@ -91,8 +93,7 @@ func StatefulSetDeepEqual(new *appv1.StatefulSet, old *appv1.StatefulSet, exclud
 
 	// avoid the update from kubectl.
 	return newHashv == oldHashv &&
-		new.Namespace == old.Namespace /* &&
-		oldGeneration == old.Generation*/
+		new.Namespace == old.Namespace
 }
 
 // MergeStatefulSets merge exist statefulset and new statefulset.


### PR DESCRIPTION
# Description

 - Removed unnecessary quotes around `maxUnavailable` in `starrockscluster.yaml` to ensure proper YAML parsing and value interpretation.
 - Added `updateStrategy` to the `hashStatefulsetObject` struct in `statefulset.go` to include update strategy in the hash calculation.

Fixes #615

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
