### PR TITLE
[Documentation] add comment for runAsNonRoot

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -103,6 +103,9 @@ starrocksCluster:
       #   - "example.com"
     # If runAsNonRoot is true, the container is run as non-root user.
     # The userId will be set to 1000, and the groupID will be set to 1000.
+    # Note: If you have started the container through root, and then FE/BE began to create directories, write files, etc.
+    #       under the mounted directory as root. When you start the container as a non-root user, the container will not
+    #       have permission to access these files. So you'd better set runAsNonRoot to true when you set up the cluster.
     runAsNonRoot: false
     # schedulerName allows you to specify which scheduler will be used for your pods.
     schedulerName: ""
@@ -179,6 +182,9 @@ starrocksFESpec:
   annotations: {}
   # If runAsNonRoot is true, the container is run as non-root user.
   # The userId will be set to 1000, and the groupID will be set to 1000.
+  # Note: If you have started the container through root, and then FE/BE began to create directories, write files, etc.
+  #       under the mounted directory as root. When you start the container as a non-root user, the container will not
+  #       have permission to access these files. So you'd better set runAsNonRoot to true when you set up the cluster.
   runAsNonRoot: false
   # Whether this container has a read-only root filesystem.
   # Note: The FE/BE/CN container should support read-only root filesystem. The newest version of FE/BE/CN is 3.3.6, and does not support read-only root filesystem.
@@ -472,6 +478,9 @@ starrocksCnSpec:
   annotations: {}
   # If runAsNonRoot is true, the container is run as non-root user.
   # The userId will be set to 1000, and the groupID will be set to 1000.
+  # Note: If you have started the container through root, and then FE/BE began to create directories, write files, etc.
+  #       under the mounted directory as root. When you start the container as a non-root user, the container will not
+  #       have permission to access these files. So you'd better set runAsNonRoot to true when you set up the cluster.
   runAsNonRoot: false
   # Whether this container has a read-only root filesystem.
   # Note: The FE/BE/CN container should support read-only root filesystem. The newest version of FE/BE/CN is 3.3.6, and does not support read-only root filesystem.
@@ -807,6 +816,9 @@ starrocksBeSpec:
   annotations: {}
   # If runAsNonRoot is true, the container is run as non-root user.
   # The userId will be set to 1000, and the groupID will be set to 1000.
+  # Note: If you have started the container through root, and then FE/BE began to create directories, write files, etc.
+  #       under the mounted directory as root. When you start the container as a non-root user, the container will not
+  #       have permission to access these files. So you'd better set runAsNonRoot to true when you set up the cluster.
   runAsNonRoot: false
   # Whether this container has a read-only root filesystem.
   # Note: The FE/BE/CN container should support read-only root filesystem. The newest version of FE/BE/CN is 3.3.6, and does not support read-only root filesystem.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -215,6 +215,9 @@ starrocks:
         #   - "example.com"
       # If runAsNonRoot is true, the container is run as non-root user.
       # The userId will be set to 1000, and the groupID will be set to 1000.
+      # Note: If you have started the container through root, and then FE/BE began to create directories, write files, etc.
+      #       under the mounted directory as root. When you start the container as a non-root user, the container will not
+      #       have permission to access these files. So you'd better set runAsNonRoot to true when you set up the cluster.
       runAsNonRoot: false
       # schedulerName allows you to specify which scheduler will be used for your pods.
       schedulerName: ""
@@ -291,6 +294,9 @@ starrocks:
     annotations: {}
     # If runAsNonRoot is true, the container is run as non-root user.
     # The userId will be set to 1000, and the groupID will be set to 1000.
+    # Note: If you have started the container through root, and then FE/BE began to create directories, write files, etc.
+    #       under the mounted directory as root. When you start the container as a non-root user, the container will not
+    #       have permission to access these files. So you'd better set runAsNonRoot to true when you set up the cluster.
     runAsNonRoot: false
     # Whether this container has a read-only root filesystem.
     # Note: The FE/BE/CN container should support read-only root filesystem. The newest version of FE/BE/CN is 3.3.6, and does not support read-only root filesystem.
@@ -584,6 +590,9 @@ starrocks:
     annotations: {}
     # If runAsNonRoot is true, the container is run as non-root user.
     # The userId will be set to 1000, and the groupID will be set to 1000.
+    # Note: If you have started the container through root, and then FE/BE began to create directories, write files, etc.
+    #       under the mounted directory as root. When you start the container as a non-root user, the container will not
+    #       have permission to access these files. So you'd better set runAsNonRoot to true when you set up the cluster.
     runAsNonRoot: false
     # Whether this container has a read-only root filesystem.
     # Note: The FE/BE/CN container should support read-only root filesystem. The newest version of FE/BE/CN is 3.3.6, and does not support read-only root filesystem.
@@ -919,6 +928,9 @@ starrocks:
     annotations: {}
     # If runAsNonRoot is true, the container is run as non-root user.
     # The userId will be set to 1000, and the groupID will be set to 1000.
+    # Note: If you have started the container through root, and then FE/BE began to create directories, write files, etc.
+    #       under the mounted directory as root. When you start the container as a non-root user, the container will not
+    #       have permission to access these files. So you'd better set runAsNonRoot to true when you set up the cluster.
     runAsNonRoot: false
     # Whether this container has a read-only root filesystem.
     # Note: The FE/BE/CN container should support read-only root filesystem. The newest version of FE/BE/CN is 3.3.6, and does not support read-only root filesystem.


### PR DESCRIPTION
# Description

Change the default value of runAsNonRoot to true

# Checklist

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
