### PR TITLE
Support service labels

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -2721,13 +2721,16 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations store Kubernetes Service annotations.
+                        description: |-
+                          Annotations store Kubernetes Service annotations. These will be added to the external service
+                          only (not internal).
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels store Kubernetes Service labels. StarRocks
-                          may add its own default labels.
+                        description: |-
+                          Labels store Kubernetes Service labels. These will be added to the external service only (not
+                          internal). StarRocks may add its own default labels.
                         type: object
                       loadBalancerIP:
                         description: |-
@@ -7703,13 +7706,16 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations store Kubernetes Service annotations.
+                        description: |-
+                          Annotations store Kubernetes Service annotations. These will be added to the external service
+                          only (not internal).
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels store Kubernetes Service labels. StarRocks
-                          may add its own default labels.
+                        description: |-
+                          Labels store Kubernetes Service labels. These will be added to the external service only (not
+                          internal). StarRocks may add its own default labels.
                         type: object
                       loadBalancerIP:
                         description: |-
@@ -10538,13 +10544,16 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations store Kubernetes Service annotations.
+                        description: |-
+                          Annotations store Kubernetes Service annotations. These will be added to the external service
+                          only (not internal).
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels store Kubernetes Service labels. StarRocks
-                          may add its own default labels.
+                        description: |-
+                          Labels store Kubernetes Service labels. These will be added to the external service only (not
+                          internal). StarRocks may add its own default labels.
                         type: object
                       loadBalancerIP:
                         description: |-
@@ -13568,13 +13577,16 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations store Kubernetes Service annotations.
+                        description: |-
+                          Annotations store Kubernetes Service annotations. These will be added to the external service
+                          only (not internal).
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels store Kubernetes Service labels. StarRocks
-                          may add its own default labels.
+                        description: |-
+                          Labels store Kubernetes Service labels. These will be added to the external service only (not
+                          internal). StarRocks may add its own default labels.
                         type: object
                       loadBalancerIP:
                         description: |-

--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -2723,6 +2723,12 @@ spec:
                           type: string
                         description: Annotations store Kubernetes Service annotations.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels store Kubernetes Service labels. StarRocks
+                          may add its own default labels.
+                        type: object
                       loadBalancerIP:
                         description: |-
                           Only applies to Service Type: LoadBalancer.
@@ -7699,6 +7705,12 @@ spec:
                           type: string
                         description: Annotations store Kubernetes Service annotations.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels store Kubernetes Service labels. StarRocks
+                          may add its own default labels.
+                        type: object
                       loadBalancerIP:
                         description: |-
                           Only applies to Service Type: LoadBalancer.
@@ -10527,6 +10539,12 @@ spec:
                         additionalProperties:
                           type: string
                         description: Annotations store Kubernetes Service annotations.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels store Kubernetes Service labels. StarRocks
+                          may add its own default labels.
                         type: object
                       loadBalancerIP:
                         description: |-
@@ -13551,6 +13569,12 @@ spec:
                         additionalProperties:
                           type: string
                         description: Annotations store Kubernetes Service annotations.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels store Kubernetes Service labels. StarRocks
+                          may add its own default labels.
                         type: object
                       loadBalancerIP:
                         description: |-

--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -3317,13 +3317,16 @@ spec:
                       annotations:
                         additionalProperties:
                           type: string
-                        description: Annotations store Kubernetes Service annotations.
+                        description: |-
+                          Annotations store Kubernetes Service annotations. These will be added to the external service
+                          only (not internal).
                         type: object
                       labels:
                         additionalProperties:
                           type: string
-                        description: Labels store Kubernetes Service labels. StarRocks
-                          may add its own default labels.
+                        description: |-
+                          Labels store Kubernetes Service labels. These will be added to the external service only (not
+                          internal). StarRocks may add its own default labels.
                         type: object
                       loadBalancerIP:
                         description: |-

--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -3319,6 +3319,12 @@ spec:
                           type: string
                         description: Annotations store Kubernetes Service annotations.
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels store Kubernetes Service labels. StarRocks
+                          may add its own default labels.
+                        type: object
                       loadBalancerIP:
                         description: |-
                           Only applies to Service Type: LoadBalancer.

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -1327,6 +1327,10 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       loadBalancerIP:
                         type: string
                       loadBalancerSourceRanges:
@@ -3684,6 +3688,10 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       loadBalancerIP:
                         type: string
                       loadBalancerSourceRanges:
@@ -4984,6 +4992,10 @@ spec:
                   service:
                     properties:
                       annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
                         additionalProperties:
                           type: string
                         type: object
@@ -6386,6 +6398,10 @@ spec:
                   service:
                     properties:
                       annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
                         additionalProperties:
                           type: string
                         type: object

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -1641,6 +1641,10 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       loadBalancerIP:
                         type: string
                       loadBalancerSourceRanges:

--- a/doc/api.md
+++ b/doc/api.md
@@ -2049,6 +2049,18 @@ map[string]string
 </tr>
 <tr>
 <td>
+<code>labels</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Labels store Kubernetes Service labels. StarRocks may add its own default labels.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>type</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#servicetype-v1-core">
@@ -2509,5 +2521,5 @@ AutoScalingPolicy
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>42e17ab</code>.
+on git commit <code>5b706db</code>.
 </em></p>

--- a/doc/api.md
+++ b/doc/api.md
@@ -2044,7 +2044,8 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Annotations store Kubernetes Service annotations.</p>
+<p>Annotations store Kubernetes Service annotations. These will be added to the external service
+only (not internal).</p>
 </td>
 </tr>
 <tr>
@@ -2056,7 +2057,8 @@ map[string]string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Labels store Kubernetes Service labels. StarRocks may add its own default labels.</p>
+<p>Labels store Kubernetes Service labels. These will be added to the external service only (not
+internal). StarRocks may add its own default labels.</p>
 </td>
 </tr>
 <tr>
@@ -2521,5 +2523,5 @@ AutoScalingPolicy
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5b706db</code>.
+on git commit <code>dbe00d8</code>.
 </em></p>

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -68,6 +68,10 @@ spec:
         {{- if .Values.starrocksFESpec.service.annotations}}
         {{- toYaml .Values.starrocksFESpec.service.annotations | nindent 8 }}
         {{- end }}
+      labels:
+        {{- if .Values.starrocksFESpec.service.labels}}
+        {{- toYaml .Values.starrocksFESpec.service.labels | nindent 8 }}
+        {{- end }}
       {{- end }}
     {{- end }}
     annotations:
@@ -324,6 +328,10 @@ spec:
         {{- end }}
         {{- if .Values.starrocksBeSpec.service.annotations }}
         {{- toYaml .Values.starrocksBeSpec.service.annotations | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- if .Values.starrocksBeSpec.service.labels}}
+        {{- toYaml .Values.starrocksBeSpec.service.labels | nindent 8 }}
         {{- end }}
       {{- end }}
     {{- end }}
@@ -750,6 +758,10 @@ spec:
         {{- if .Values.starrocksCnSpec.service.annotations }}
         {{- toYaml .Values.starrocksCnSpec.service.annotations | nindent 8 }}
         {{- end }}
+      labels:
+        {{- if .Values.starrocksCnSpec.service.labels}}
+        {{- toYaml .Values.starrocksCnSpec.service.labels | nindent 8 }}
+        {{- end }}
       {{- end }}
     {{- end }}
     annotations:
@@ -874,6 +886,10 @@ spec:
       {{- if .Values.starrocksFeProxySpec.service.annotations }}
       annotations:
         {{- toYaml .Values.starrocksFeProxySpec.service.annotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.starrocksFeProxySpec.service.labels}}
+      labels:
+        {{- toYaml .Values.starrocksFeProxySpec.service.labels | nindent 8 }}
       {{- end }}
       {{- if and (eq "LoadBalancer" .Values.starrocksFeProxySpec.service.type) .Values.starrocksFeProxySpec.service.loadbalancerIP }}
       loadBalancerIP: {{ .Values.starrocksFeProxySpec.service.loadbalancerIP }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -68,10 +68,10 @@ spec:
         {{- if .Values.starrocksFESpec.service.annotations}}
         {{- toYaml .Values.starrocksFESpec.service.annotations | nindent 8 }}
         {{- end }}
+      {{- end }}
+      {{- if .Values.starrocksFESpec.service.labels}}
       labels:
-        {{- if .Values.starrocksFESpec.service.labels}}
         {{- toYaml .Values.starrocksFESpec.service.labels | nindent 8 }}
-        {{- end }}
       {{- end }}
     {{- end }}
     annotations:
@@ -329,10 +329,10 @@ spec:
         {{- if .Values.starrocksBeSpec.service.annotations }}
         {{- toYaml .Values.starrocksBeSpec.service.annotations | nindent 8 }}
         {{- end }}
+      {{- end }}
+      {{- if .Values.starrocksBeSpec.service.labels}}
       labels:
-        {{- if .Values.starrocksBeSpec.service.labels}}
         {{- toYaml .Values.starrocksBeSpec.service.labels | nindent 8 }}
-        {{- end }}
       {{- end }}
     {{- end }}
     annotations:
@@ -758,10 +758,10 @@ spec:
         {{- if .Values.starrocksCnSpec.service.annotations }}
         {{- toYaml .Values.starrocksCnSpec.service.annotations | nindent 8 }}
         {{- end }}
+      {{- end }}
+      {{- if .Values.starrocksCnSpec.service.labels}}
       labels:
-        {{- if .Values.starrocksCnSpec.service.labels}}
         {{- toYaml .Values.starrocksCnSpec.service.labels | nindent 8 }}
-        {{- end }}
       {{- end }}
     {{- end }}
     annotations:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -199,6 +199,8 @@ starrocksFESpec:
     loadbalancerIP: ""
     # add annotations for fe service.
     annotations: {}
+    # Add labels for fe service. The operator may add its own labels
+    labels: {}
     # config the service port for fe service.
     # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
     # containerPort in the service configuration. If both containerPort and name are specified, containerPort takes precedence.
@@ -492,6 +494,8 @@ starrocksCnSpec:
     loadbalancerIP: ""
     # add annotations for cn service.
     annotations: {}
+    # Add labels for cn service. The operator may add its own labels
+    labels: {}
     # config the service port for cn service.
     # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
     # containerPort in the service configuration. If both containerPort and name are specified, containerPort takes precedence.
@@ -827,6 +831,8 @@ starrocksBeSpec:
     loadbalancerIP: ""
     # add annotations for be service.
     annotations: {}
+    # Add labels for be service. The operator may add its own labels
+    labels: {}
     # config the service port for be service.
     # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
     # containerPort in the service configuration. If both containerPort and name are specified, containerPort takes precedence.
@@ -1136,6 +1142,8 @@ starrocksFeProxySpec:
     loadbalancerIP: ""
     # add annotations for fe service.
     annotations: {}
+    # Add labels for fe proxy service. The operator may add its own labels
+    labels: {}
     # config the service port for fe proxy service.
     # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
     # containerPort in the service configuration. If both containerPort and name are specified, containerPort takes precedence.

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -197,9 +197,9 @@ starrocksFESpec:
     type: "ClusterIP"
     # the loadBalancerIP for static ip config when the type=LoadBalancer and loadbalancerIp is not empty.
     loadbalancerIP: ""
-    # add annotations for fe service.
+    # add annotations for external fe service.
     annotations: {}
-    # Add labels for fe service. The operator may add its own labels
+    # Add labels for external fe service. The operator may add its own default labels.
     labels: {}
     # config the service port for fe service.
     # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
@@ -492,9 +492,9 @@ starrocksCnSpec:
     type: "ClusterIP"
     # the loadBalancerIP for static ip config when the type=LoadBalancer and loadBalancerIp is not empty.
     loadbalancerIP: ""
-    # add annotations for cn service.
+    # add annotations for external cn service.
     annotations: {}
-    # Add labels for cn service. The operator may add its own labels
+    # Add labels for external cn service. The operator may add its own default labels.
     labels: {}
     # config the service port for cn service.
     # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
@@ -829,9 +829,9 @@ starrocksBeSpec:
     type: "ClusterIP"
     # the loadBalancerIP for static ip config when the type=LoadBalancer and loadbalancerIp is not empty.
     loadbalancerIP: ""
-    # add annotations for be service.
+    # add annotations for external be service.
     annotations: {}
-    # Add labels for be service. The operator may add its own labels
+    # Add labels for external be service. The operator may add its own default labels.
     labels: {}
     # config the service port for be service.
     # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
@@ -1140,9 +1140,9 @@ starrocksFeProxySpec:
     type: ClusterIP
     # the loadBalancerIP for static ip config when the type=LoadBalancer and loadbalancerIp is not empty.
     loadbalancerIP: ""
-    # add annotations for fe service.
+    # add annotations for external fe proxy service.
     annotations: {}
-    # Add labels for fe proxy service. The operator may add its own labels
+    # Add labels for external fe proxy service. The operator may add its own default labels.
     labels: {}
     # config the service port for fe proxy service.
     # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -311,6 +311,8 @@ starrocks:
       loadbalancerIP: ""
       # add annotations for fe service.
       annotations: {}
+      # Add labels for fe service. The operator may add its own labels
+      labels: {}
       # config the service port for fe service.
       # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
       # containerPort in the service configuration. If both containerPort and name are specified, containerPort takes precedence.
@@ -604,6 +606,8 @@ starrocks:
       loadbalancerIP: ""
       # add annotations for cn service.
       annotations: {}
+      # Add labels for cn service. The operator may add its own labels
+      labels: {}
       # config the service port for cn service.
       # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
       # containerPort in the service configuration. If both containerPort and name are specified, containerPort takes precedence.
@@ -939,6 +943,8 @@ starrocks:
       loadbalancerIP: ""
       # add annotations for be service.
       annotations: {}
+      # Add labels for be service. The operator may add its own labels
+      labels: {}
       # config the service port for be service.
       # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
       # containerPort in the service configuration. If both containerPort and name are specified, containerPort takes precedence.
@@ -1248,6 +1254,8 @@ starrocks:
       loadbalancerIP: ""
       # add annotations for fe service.
       annotations: {}
+      # Add labels for fe proxy service. The operator may add its own labels
+      labels: {}
       # config the service port for fe proxy service.
       # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
       # containerPort in the service configuration. If both containerPort and name are specified, containerPort takes precedence.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -309,9 +309,9 @@ starrocks:
       type: "ClusterIP"
       # the loadBalancerIP for static ip config when the type=LoadBalancer and loadbalancerIp is not empty.
       loadbalancerIP: ""
-      # add annotations for fe service.
+      # add annotations for external fe service.
       annotations: {}
-      # Add labels for fe service. The operator may add its own labels
+      # Add labels for external fe service. The operator may add its own default labels.
       labels: {}
       # config the service port for fe service.
       # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
@@ -604,9 +604,9 @@ starrocks:
       type: "ClusterIP"
       # the loadBalancerIP for static ip config when the type=LoadBalancer and loadBalancerIp is not empty.
       loadbalancerIP: ""
-      # add annotations for cn service.
+      # add annotations for external cn service.
       annotations: {}
-      # Add labels for cn service. The operator may add its own labels
+      # Add labels for external cn service. The operator may add its own default labels.
       labels: {}
       # config the service port for cn service.
       # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
@@ -941,9 +941,9 @@ starrocks:
       type: "ClusterIP"
       # the loadBalancerIP for static ip config when the type=LoadBalancer and loadbalancerIp is not empty.
       loadbalancerIP: ""
-      # add annotations for be service.
+      # add annotations for external be service.
       annotations: {}
-      # Add labels for be service. The operator may add its own labels
+      # Add labels for external be service. The operator may add its own default labels.
       labels: {}
       # config the service port for be service.
       # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or
@@ -1252,9 +1252,9 @@ starrocks:
       type: ClusterIP
       # the loadBalancerIP for static ip config when the type=LoadBalancer and loadbalancerIp is not empty.
       loadbalancerIP: ""
-      # add annotations for fe service.
+      # add annotations for external fe proxy service.
       annotations: {}
-      # Add labels for fe proxy service. The operator may add its own labels
+      # Add labels for external fe proxy service. The operator may add its own default labels.
       labels: {}
       # config the service port for fe proxy service.
       # To assign a specific port or nodePort to a service, you should specify them by the corresponding name or

--- a/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
+++ b/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
@@ -78,6 +78,10 @@ spec:
         {{- toYaml .Values.spec.service.annotations | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.spec.service.labels }}
+      labels:
+        {{- toYaml .Values.spec.service.labels | nindent 8 }}
+      {{- end }}
     {{- end }}
     annotations:
       app.starrocks.io/cn-config-hash: "{{template "starrockswarehouse.config.hash" . }}"

--- a/helm-charts/charts/warehouse/values.yaml
+++ b/helm-charts/charts/warehouse/values.yaml
@@ -52,6 +52,8 @@ spec:
     loadbalancerIP: ""
     # add annotations for service.
     annotations: {}
+    # add labels for service.
+    labels: {}
     # config the service port for service.
     # if you want to use a dedicated port for service, you can config the port.
     # see https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports for more details.

--- a/helm-charts/charts/warehouse/values.yaml
+++ b/helm-charts/charts/warehouse/values.yaml
@@ -50,9 +50,9 @@ spec:
     type: "ClusterIP"
     # the loadBalancerIP for static ip config when the type=LoadBalancer and loadBalancerIp is not empty.
     loadbalancerIP: ""
-    # add annotations for service.
+    # add annotations for external service.
     annotations: {}
-    # add labels for service.
+    # add labels for external service.
     labels: {}
     # config the service port for service.
     # if you want to use a dedicated port for service, you can config the port.

--- a/pkg/apis/starrocks/v1/load_type.go
+++ b/pkg/apis/starrocks/v1/load_type.go
@@ -173,11 +173,13 @@ type StarRocksLoadSpec struct {
 
 // StarRocksService defines external service for starrocks component.
 type StarRocksService struct {
-	// Annotations store Kubernetes Service annotations.
+	// Annotations store Kubernetes Service annotations. These will be added to the external service
+	// only (not internal).
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// Labels store Kubernetes Service labels. StarRocks may add its own default labels.
+	// Labels store Kubernetes Service labels. These will be added to the external service only (not
+	// internal). StarRocks may add its own default labels.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 

--- a/pkg/apis/starrocks/v1/load_type.go
+++ b/pkg/apis/starrocks/v1/load_type.go
@@ -177,6 +177,10 @@ type StarRocksService struct {
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// Labels store Kubernetes Service labels. StarRocks may add its own default labels.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// type of service,the possible value for the service type are : ClusterIP, NodePort, LoadBalancer,ExternalName.
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 	// +optional

--- a/pkg/apis/starrocks/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/starrocks/v1/zz_generated.deepcopy.go
@@ -734,6 +734,13 @@ func (in *StarRocksService) DeepCopyInto(out *StarRocksService) {
 			(*out)[key] = val
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]StarRocksServicePort, len(*in))

--- a/pkg/common/resource_utils/service.go
+++ b/pkg/common/resource_utils/service.go
@@ -74,6 +74,15 @@ func BuildExternalService(object object.StarRocksObject, spec srapi.SpecInterfac
 	starRocksService := spec.GetService()
 	setServiceType(starRocksService, &svc)
 	anno := getServiceAnnotations(starRocksService)
+	userSuppliedLabels := getServiceLabels(starRocksService)
+	newLabels := map[string]string{}
+	for key, val := range labels {
+		newLabels[key] = val
+	}
+	for key, val := range userSuppliedLabels {
+		newLabels[key] = val
+	}
+	svc.Labels = newLabels
 	switch spec.(type) {
 	case *srapi.StarRocksFeSpec:
 		srPorts = getFeServicePorts(config, starRocksService)
@@ -233,6 +242,17 @@ func getServiceAnnotations(svc *srapi.StarRocksService) map[string]string {
 			annotations[key] = val
 		}
 		return annotations
+	}
+	return map[string]string{}
+}
+
+func getServiceLabels(svc *srapi.StarRocksService) map[string]string {
+	if svc != nil && svc.Labels != nil {
+		labels := map[string]string{}
+		for key, val := range svc.Labels {
+			labels[key] = val
+		}
+		return labels
 	}
 	return map[string]string{}
 }

--- a/pkg/common/resource_utils/service.go
+++ b/pkg/common/resource_utils/service.go
@@ -73,8 +73,8 @@ func BuildExternalService(object object.StarRocksObject, spec srapi.SpecInterfac
 
 	starRocksService := spec.GetService()
 	setServiceType(starRocksService, &svc)
-	anno := getServiceAnnotations(starRocksService)
-	userSuppliedLabels := getServiceLabels(starRocksService)
+	anno := getExternalServiceAnnotations(starRocksService)
+	userSuppliedLabels := getExternalServiceLabels(starRocksService)
 	newLabels := map[string]string{}
 	for key, val := range labels {
 		newLabels[key] = val
@@ -235,7 +235,7 @@ func mergePort(service *srapi.StarRocksService, defaultPort srapi.StarRocksServi
 	return port
 }
 
-func getServiceAnnotations(svc *srapi.StarRocksService) map[string]string {
+func getExternalServiceAnnotations(svc *srapi.StarRocksService) map[string]string {
 	if svc != nil && svc.Annotations != nil {
 		annotations := map[string]string{}
 		for key, val := range svc.Annotations {
@@ -246,7 +246,7 @@ func getServiceAnnotations(svc *srapi.StarRocksService) map[string]string {
 	return map[string]string{}
 }
 
-func getServiceLabels(svc *srapi.StarRocksService) map[string]string {
+func getExternalServiceLabels(svc *srapi.StarRocksService) map[string]string {
 	if svc != nil && svc.Labels != nil {
 		labels := map[string]string{}
 		for key, val := range svc.Labels {

--- a/pkg/common/resource_utils/service_test.go
+++ b/pkg/common/resource_utils/service_test.go
@@ -64,6 +64,43 @@ func Test_getServiceAnnotations(t *testing.T) {
 	}
 }
 
+func Test_getServiceLabels(t *testing.T) {
+	type args struct {
+		svc *srapi.StarRocksService
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "empty service",
+			args: args{
+				svc: &srapi.StarRocksService{},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "service with labels",
+			args: args{
+				svc: &srapi.StarRocksService{
+					Labels: map[string]string{
+						"test": "test",
+					},
+				},
+			},
+			want: map[string]string{"test": "test"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getServiceLabels(tt.args.svc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getServiceLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildExternalService_ForStarRocksWarehouse(t *testing.T) {
 	warehouse := &srapi.StarRocksWarehouse{
 		ObjectMeta: metav1.ObjectMeta{
@@ -171,6 +208,9 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 						Service: &srapi.StarRocksService{
 							Type:           corev1.ServiceTypeLoadBalancer,
 							LoadBalancerIP: "127.0.0.1",
+							Labels: map[string]string{
+								"user_supplied_label": "test",
+							},
 						},
 					},
 				},
@@ -181,6 +221,9 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 						Service: &srapi.StarRocksService{
 							Type:           corev1.ServiceTypeLoadBalancer,
 							LoadBalancerIP: "127.0.0.1",
+							Labels: map[string]string{
+								"user_supplied_label": "test",
+							},
 						},
 					},
 				},
@@ -191,6 +234,9 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 						Service: &srapi.StarRocksService{
 							Type:           corev1.ServiceTypeLoadBalancer,
 							LoadBalancerIP: "127.0.0.1",
+							Labels: map[string]string{
+								"user_supplied_label": "test",
+							},
 						},
 					},
 				},
@@ -218,7 +264,11 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 					Name:      "test-fe-service",
 					Namespace: "default",
 					Annotations: map[string]string{
-						srapi.ComponentResourceHash: "1826250052",
+						srapi.ComponentResourceHash: "2323011486",
+					},
+					Labels: map[string]string{
+						"starrocks_default_label": "test",
+						"user_supplied_label":     "test",
 					},
 					OwnerReferences: func() []metav1.OwnerReference {
 						ref := metav1.NewControllerRef(src, src.GroupVersionKind())
@@ -254,7 +304,11 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 					Name:      "test-be-service",
 					Namespace: "default",
 					Annotations: map[string]string{
-						srapi.ComponentResourceHash: "2188319972",
+						srapi.ComponentResourceHash: "2811174334",
+					},
+					Labels: map[string]string{
+						"starrocks_default_label": "test",
+						"user_supplied_label":     "test",
 					},
 					OwnerReferences: func() []metav1.OwnerReference {
 						ref := metav1.NewControllerRef(src, src.GroupVersionKind())
@@ -287,7 +341,11 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 					Name:      "test-cn-service",
 					Namespace: "default",
 					Annotations: map[string]string{
-						srapi.ComponentResourceHash: "4058356074",
+						srapi.ComponentResourceHash: "4173513860",
+					},
+					Labels: map[string]string{
+						"starrocks_default_label": "test",
+						"user_supplied_label":     "test",
 					},
 					OwnerReferences: func() []metav1.OwnerReference {
 						ref := metav1.NewControllerRef(src, src.GroupVersionKind())
@@ -333,17 +391,20 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 		}
 	}
 
+	starrocksDefaultLabels := map[string]string{
+		"starrocks_default_label": "test",
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			object := object.NewFromCluster(src)
 			gotFeService := BuildExternalService(object, src.Spec.StarRocksFeSpec,
-				map[string]interface{}{}, map[string]string{}, map[string]string{})
+				map[string]interface{}{}, map[string]string{}, starrocksDefaultLabels)
 			equal(gotFeService, tt.wantFeService)
 			gotBeService := BuildExternalService(object, src.Spec.StarRocksBeSpec,
-				map[string]interface{}{}, map[string]string{}, map[string]string{})
+				map[string]interface{}{}, map[string]string{}, starrocksDefaultLabels)
 			equal(gotBeService, tt.wantBeService)
 			gotCnService := BuildExternalService(object, src.Spec.StarRocksCnSpec,
-				map[string]interface{}{}, map[string]string{}, map[string]string{})
+				map[string]interface{}{}, map[string]string{}, starrocksDefaultLabels)
 			equal(gotCnService, tt.wantCnService)
 		})
 	}

--- a/pkg/common/resource_utils/service_test.go
+++ b/pkg/common/resource_utils/service_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils/templates/object"
 )
 
-func Test_getServiceAnnotations(t *testing.T) {
+func Test_getExternalServiceAnnotations(t *testing.T) {
 	type args struct {
 		svc *srapi.StarRocksService
 	}
@@ -57,14 +57,14 @@ func Test_getServiceAnnotations(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getServiceAnnotations(tt.args.svc); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getServiceAnnotations() = %v, want %v", got, tt.want)
+			if got := getExternalServiceAnnotations(tt.args.svc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getExternalServiceAnnotations() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func Test_getServiceLabels(t *testing.T) {
+func Test_getExternalServiceLabels(t *testing.T) {
 	type args struct {
 		svc *srapi.StarRocksService
 	}
@@ -94,8 +94,8 @@ func Test_getServiceLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getServiceLabels(tt.args.svc); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getServiceLabels() = %v, want %v", got, tt.want)
+			if got := getExternalServiceLabels(tt.args.svc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getExternalServiceLabels() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/k8sutils/templates/service/spec.go
+++ b/pkg/k8sutils/templates/service/spec.go
@@ -20,13 +20,15 @@ import (
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
 )
 
-func MakeSearchService(serviceName string, externalService *corev1.Service, ports []corev1.ServicePort) *corev1.Service {
+func MakeSearchService(serviceName string, externalService *corev1.Service, ports []corev1.ServicePort,
+	labels map[string]string) *corev1.Service {
 	searchSvc := &corev1.Service{}
 	externalService.ObjectMeta.DeepCopyInto(&searchSvc.ObjectMeta)
 	// some service annotations can only be used when `type` is 'LoadBalancer', e.g. service.beta.kubernetes.io/load-balancer-source-ranges
 	// we do not need to annotations for search service
 	searchSvc.Annotations = nil
 	searchSvc.Name = serviceName
+	searchSvc.Labels = labels
 	searchSvc.Spec = corev1.ServiceSpec{
 		ClusterIP: "None",
 		Ports:     ports,

--- a/pkg/k8sutils/templates/service/spec.go
+++ b/pkg/k8sutils/templates/service/spec.go
@@ -21,14 +21,17 @@ import (
 )
 
 func MakeSearchService(serviceName string, externalService *corev1.Service, ports []corev1.ServicePort,
-	labels map[string]string) *corev1.Service {
+	defaultLabels map[string]string) *corev1.Service {
 	searchSvc := &corev1.Service{}
 	externalService.ObjectMeta.DeepCopyInto(&searchSvc.ObjectMeta)
-	// some service annotations can only be used when `type` is 'LoadBalancer', e.g. service.beta.kubernetes.io/load-balancer-source-ranges
-	// we do not need to annotations for search service
+	// Set annotations to nil so external service annotations aren't copied. Interal / search service annotations aren't
+	// needed, and adding them can be an issue since some service annotations can only be used when `type` is
+	// 'LoadBalancer', e.g. service.beta.kubernetes.io/load-balancer-source-ranges.
 	searchSvc.Annotations = nil
 	searchSvc.Name = serviceName
-	searchSvc.Labels = labels
+	// Set labels to the default labels so external service labels aren't copied. Since labels are used to select objects,
+	// adding them to the internal / search service can be detrimental.
+	searchSvc.Labels = defaultLabels
 	searchSvc.Spec = corev1.ServiceSpec{
 		ClusterIP: "None",
 		Ports:     ports,

--- a/pkg/k8sutils/templates/service/spec_test.go
+++ b/pkg/k8sutils/templates/service/spec_test.go
@@ -29,6 +29,7 @@ func TestMakeSearchService(t *testing.T) {
 		serviceName     string
 		externalService *corev1.Service
 		ports           []corev1.ServicePort
+		labels          map[string]string
 	}
 	tests := []struct {
 		name string
@@ -40,6 +41,11 @@ func TestMakeSearchService(t *testing.T) {
 			args: args{
 				serviceName: "test",
 				externalService: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"label_to_be_discarded": "test",
+						},
+					},
 					Spec: corev1.ServiceSpec{
 						Selector: map[string]string{
 							"test": "test",
@@ -52,10 +58,16 @@ func TestMakeSearchService(t *testing.T) {
 						Port: 18030,
 					},
 				},
+				labels: map[string]string{
+					"test": "test",
+				},
 			},
 			want: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Labels: map[string]string{
+						"test": "test",
+					},
 				},
 				Spec: corev1.ServiceSpec{
 					ClusterIP: "None",
@@ -75,7 +87,7 @@ func TestMakeSearchService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MakeSearchService(tt.args.serviceName, tt.args.externalService, tt.args.ports); !reflect.DeepEqual(got, tt.want) {
+			if got := MakeSearchService(tt.args.serviceName, tt.args.externalService, tt.args.ports, tt.args.labels); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MakeSearchService() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -186,8 +186,9 @@ func (cc *CnController) SyncCnSpec(ctx context.Context, object object.StarRocksO
 	}
 
 	// build and deploy service
+	defaultLabels := load.Labels(object.AliasName, cnSpec)
 	externalsvc := rutils.BuildExternalService(object, cnSpec, config,
-		load.Selector(object.AliasName, cnSpec), load.Labels(object.AliasName, cnSpec))
+		load.Selector(object.AliasName, cnSpec), defaultLabels)
 	searchServiceName := service.SearchServiceName(object.AliasName, cnSpec)
 	internalService := service.MakeSearchService(searchServiceName, &externalsvc, []corev1.ServicePort{
 		{
@@ -195,7 +196,7 @@ func (cc *CnController) SyncCnSpec(ctx context.Context, object object.StarRocksO
 			Port:       rutils.GetPort(config, rutils.HEARTBEAT_SERVICE_PORT),
 			TargetPort: intstr.FromInt(int(rutils.GetPort(config, rutils.HEARTBEAT_SERVICE_PORT))),
 		},
-	})
+	}, defaultLabels)
 
 	if err := k8sutils.ApplyService(ctx, cc.k8sClient, &externalsvc, rutils.ServiceDeepEqual); err != nil {
 		logger.Error(err, "sync CN external service failed")


### PR DESCRIPTION
# Description

Currently adding K8s service annotations are supported but not labels. Support service labels through the following changes:

- Update CRD definitions in `config/crd/bases/` and `deploy/`
- Update Helm chart templates and values for `helm-charts/charts/kube-starrocks/` and `helm-charts/charts/warehouse/`
- Update `pkg/apis/starrocks/v1/`
- Update `pkg/common/resource_utils/service` and `pkg/k8sutils/templates/service/spec` to handle labels
  - Still support default labels generated by operator
- Update subcontrollers so that external service has labels but internal labels don't

# Related Issue(s)

https://github.com/StarRocks/starrocks-kubernetes-operator/issues/625

# Checklist

For operator, please complete the following checklist:

- [X] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [X] run `make test` to run UT.
- [X] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [X] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [X] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
