### PR TITLE
[Enhancement] Init pwd job pod annotations

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -12,6 +12,11 @@ metadata:
   {{- end }}
 spec:
   template:
+    {{- if .Values.initPassword.podAnnotations }}
+    metadata:
+      annotations:
+        {{- toYaml .Values.initPassword.podAnnotations | nindent 8 }}
+    {{- end }}
     spec:
       {{- if or .Values.starrocksFESpec.imagePullSecrets .Values.starrocksCluster.componentValues.imagePullSecrets }}
       imagePullSecrets:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -13,7 +13,7 @@ nameOverride: "kube-starrocks"
 #       you should also not set the initPassword.
 #       If you install StarRocks using helm install and set the initPassword, please always retain the configuration of initPassword.
 initPassword:
-  enabled: false
+  enabled: true
   # Note: If you are using Argo CD to deploy the StarRocks cluster, you must set isInstall to false after the first installation.
   # This is because Argo CD support helm like this: helm template <options> | kubectl apply -f -. If isInstall is true, the
   # initPassword job will be executed every time you run the command.
@@ -27,6 +27,8 @@ initPassword:
   image: ""
   # The annotations for the Job, not including the annotations for the pod.
   annotations: {}
+  # The annotations for the Job's Pod, not including the annotations for the job.
+  podAnnotations: {}
   # resources for init_job pod.
   resources: {}
   #resources:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -13,7 +13,7 @@ nameOverride: "kube-starrocks"
 #       you should also not set the initPassword.
 #       If you install StarRocks using helm install and set the initPassword, please always retain the configuration of initPassword.
 initPassword:
-  enabled: true
+  enabled: false
   # Note: If you are using Argo CD to deploy the StarRocks cluster, you must set isInstall to false after the first installation.
   # This is because Argo CD support helm like this: helm template <options> | kubectl apply -f -. If isInstall is true, the
   # initPassword job will be executed every time you run the command.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -144,6 +144,8 @@ starrocks:
     image: ""
     # The annotations for the Job, not including the annotations for the pod.
     annotations: {}
+    # The annotations for the Job's Pod, not including the annotations for the job.
+    podAnnotations: {}
     # resources for init_job pod.
     resources: {}
     #resources:


### PR DESCRIPTION
# Description

This PR adds the ability for the init-pwd job to configure the job's pod annotations. 

The change was motivated by a need to pass annotations to the pod of the job to disable isito proxy from keeping the job from not completing.

> the PR should include helm chart changes and operator changes.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ ] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ ] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
