### PR TITLE
[Enhancement] Support basicAuth for serviceMonitor

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/servicemonitor.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/servicemonitor.yaml
@@ -16,6 +16,15 @@ spec:
       interval: {{ . }}
       {{- end }}
       path: /metrics
+      {{- if .Values.metrics.serviceMonitor.basicAuth.enabled }}
+      basicAuth:
+        username:
+          name: {{ .Values.metrics.serviceMonitor.basicAuth.usernameSecretName }}
+          key: {{ .Values.metrics.serviceMonitor.basicAuth.usernameSecretKey }}
+        password:
+          name: {{ .Values.metrics.serviceMonitor.basicAuth.passwordSecretName }}
+          key: {{ .Values.metrics.serviceMonitor.basicAuth.passwordSecretKey }}
+      {{- end }}
       relabelings:
         - sourceLabels: [__meta_kubernetes_endpoints_label_app_starrocks_ownerreference_name]
           targetLabel: app_starrocks_ownerreference_name

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -70,9 +70,22 @@ metrics:
     enabled: false
     # Prometheus ServiceMonitor labels
     labels: {}
-      # scraper: prometheus-operator
+    # scraper: prometheus-operator
     # Prometheus ServiceMonitor interval
     interval: 15s
+    # Whether to enable basic auth
+    basicAuth:
+      enabled: false
+      # The name of the secret that contains the username for basic auth.
+      # The secret should contain a key named "username".
+      usernameSecretName: ""
+      # The key in the secret that contains the username for basic auth.
+      usernameSecretKey: ""
+      # The name of the secret that contains the password for basic auth.
+      # The secret should contain a key named "password".
+      passwordSecretName: ""
+      # The key in the secret that contains the password for basic auth.
+      passwordSecretKey: ""
 
 # deploy a starrocks cluster
 starrocksCluster:

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -187,9 +187,22 @@ starrocks:
       enabled: false
       # Prometheus ServiceMonitor labels
       labels: {}
-        # scraper: prometheus-operator
+      # scraper: prometheus-operator
       # Prometheus ServiceMonitor interval
       interval: 15s
+      # Whether to enable basic auth
+      basicAuth:
+        enabled: false
+        # The name of the secret that contains the username for basic auth.
+        # The secret should contain a key named "username".
+        usernameSecretName: ""
+        # The key in the secret that contains the username for basic auth.
+        usernameSecretKey: ""
+        # The name of the secret that contains the password for basic auth.
+        # The secret should contain a key named "password".
+        passwordSecretName: ""
+        # The key in the secret that contains the password for basic auth.
+        passwordSecretKey: ""
   
   # deploy a starrocks cluster
   starrocksCluster:


### PR DESCRIPTION
# Description

allow an endpoint to authenticate over basic authentication, which can access more StarRocks metrics.

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
