### PR TITLE
[Feanture] Enable graceful shutdown

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -395,6 +395,13 @@ starrocksFESpec:
     edit_log_port = 9010
     mysql_service_nio_enabled = true
     sys_log_level = INFO
+    # When shutting down FE, it will wait for min_graceful_exit_time_second seconds before refusing new requests. If you
+    # want to ensure that queries, writes, and other operations complete smoothly, you need to ensure that the time it
+    # takes for the Pod to become Not Ready is less than min_graceful_exit_time_second. The default Pod configuration is
+    # probe.FailureThreshold = 3, probe.PeriodSeconds = 5, so in the worst case, the Pod will have (3+1)*5 = 20s to
+    # transition to Node Not Ready state. Since the default value of min_graceful_exit_time_second is 15, we change it to a larger value.
+    # Note: StarRocks version must be greater than or equal to 3.4.2 to support this configuration, otherwise it will not take effect.
+    min_graceful_exit_time_second = 25
   # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take
   # precedence and values in config field will be discarded.
   # Note: When using configyaml, the number needs to be quoted to avoid being converted to scientific notation.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -512,6 +512,13 @@ starrocks:
       edit_log_port = 9010
       mysql_service_nio_enabled = true
       sys_log_level = INFO
+      # When shutting down FE, it will wait for min_graceful_exit_time_second seconds before refusing new requests. If you
+      # want to ensure that queries, writes, and other operations complete smoothly, you need to ensure that the time it
+      # takes for the Pod to become Not Ready is less than min_graceful_exit_time_second. The default Pod configuration is
+      # probe.FailureThreshold = 3, probe.PeriodSeconds = 5, so in the worst case, the Pod will have (3+1)*5 = 20s to
+      # transition to Node Not Ready state. Since the default value of min_graceful_exit_time_second is 15, we change it to a larger value.
+      # Note: StarRocks version must be greater than or equal to 3.4.2 to support this configuration, otherwise it will not take effect.
+      min_graceful_exit_time_second = 25
     # A map object for setting the config. When configyaml is set, to non-empty, the configs in configyaml will take
     # precedence and values in config field will be discarded.
     # Note: When using configyaml, the number needs to be quoted to avoid being converted to scientific notation.

--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -374,13 +374,15 @@ func GetConfigDir(spec v1.SpecInterface) string {
 }
 
 func GetPreStopScriptPath(spec v1.SpecInterface) string {
+	// we do not need set --timeout parameter for stop_xx.sh, because the terminationGracePeriodSeconds configuration
+	// on Pod will take the same effect
 	switch v := spec.(type) {
 	case *v1.StarRocksFeSpec:
-		return fmt.Sprintf("%s/fe_prestop.sh", GetStarRocksRootPath(v.FeEnvVars))
+		return fmt.Sprintf("%s/fe/bin/stop_fe.sh -g", GetStarRocksRootPath(v.FeEnvVars))
 	case *v1.StarRocksBeSpec:
-		return fmt.Sprintf("%s/be_prestop.sh", GetStarRocksRootPath(v.BeEnvVars))
+		return fmt.Sprintf("%s/be/bin/stop_be.sh -g", GetStarRocksRootPath(v.BeEnvVars))
 	case *v1.StarRocksCnSpec:
-		return fmt.Sprintf("%s/cn_prestop.sh", GetStarRocksRootPath(v.CnEnvVars))
+		return fmt.Sprintf("%s/cn/bin/stop_cn.sh -g", GetStarRocksRootPath(v.CnEnvVars))
 	}
 	return ""
 }


### PR DESCRIPTION
# Description

Starting from StarRocks version 3.4.2, StarRocks supports the -g parameter to further support graceful shutdown. The purpose of this PR is to introduce this parameter. For older versions of StarRocks, this parameter will be ignored.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
