### PR TITLE
[Enhancement] Detect scale-in and drop CN node from FE

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
         - performance
         - style
     gocyclo:
-      min-complexity: 15
+      min-complexity: 16
     govet:
       settings:
         printf:

--- a/pkg/common/resource_utils/autoscaler.go
+++ b/pkg/common/resource_utils/autoscaler.go
@@ -40,7 +40,7 @@ type PodAutoscalerParams struct {
 	AutoscalerType  srapi.AutoScalerVersion
 	Namespace       string
 	Name            string
-	Labels          Labels
+	Labels          map[string]string
 	TargetName      string
 	OwnerReferences []metav1.OwnerReference
 	ScalerPolicy    *srapi.AutoScalingPolicy

--- a/pkg/common/resource_utils/autoscaler_test.go
+++ b/pkg/common/resource_utils/autoscaler_test.go
@@ -32,7 +32,7 @@ const _defaultNamespace = "default"
 const _defaultName = "test"
 
 func TestBuildHorizontalPodAutoscalerV1(t *testing.T) {
-	labels := Labels{}
+	labels := map[string]string{}
 	labels["cluster"] = _defaultName
 	labels["namespace"] = _defaultNamespace
 	pap := &PodAutoscalerParams{
@@ -83,7 +83,7 @@ func TestBuildHorizontalPodAutoscalerV1(t *testing.T) {
 }
 
 func TestBuildHorizontalPodAutoscalerV2beta2(t *testing.T) {
-	labels := Labels{}
+	labels := map[string]string{}
 	labels["cluster"] = "test"
 	labels["namespace"] = _defaultNamespace
 	pap := &PodAutoscalerParams{
@@ -262,7 +262,7 @@ func TestBuildHorizontalPodAutoscalerV2beta2(t *testing.T) {
 }
 
 func TestBuildHorizontalPodAutoscalerV2(t *testing.T) {
-	labels := Labels{}
+	labels := map[string]string{}
 	labels["cluster"] = "test"
 	labels["namespace"] = _defaultNamespace
 	pap := &PodAutoscalerParams{

--- a/pkg/common/resource_utils/metadata.go
+++ b/pkg/common/resource_utils/metadata.go
@@ -20,34 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type Labels map[string]string
-
-func (l Labels) Add(key, value string) {
-	l[key] = value
-}
-
-func (l Labels) AddLabel(label Labels) {
-	if label == nil {
-		return
-	}
-
-	for k, v := range label {
-		l[k] = v
-	}
-}
-
-type Annotations map[string]string
-
-func (a Annotations) Add(key, value string) {
-	a[key] = value
-}
-
-func (a Annotations) AddAnnotation(annotation Annotations) {
-	for k, v := range annotation {
-		a[k] = v
-	}
-}
-
 // MergeMetadata takes labels and annotations from the old resource and merges
 // them into the new resource. If a key is present in both resources, the new
 // resource wins. It also copies the ResourceVersion from the old resource to

--- a/pkg/common/resource_utils/metadata_test.go
+++ b/pkg/common/resource_utils/metadata_test.go
@@ -25,7 +25,7 @@ func TestMergeMetadata(t *testing.T) {
 						"new":     "new",
 						"exiting": "new",
 					},
-					Annotations: Annotations{
+					Annotations: map[string]string{
 						"new":     "new",
 						"exiting": "new",
 					},
@@ -39,7 +39,7 @@ func TestMergeMetadata(t *testing.T) {
 						"old":     "old",
 						"exiting": "old",
 					},
-					Annotations: Annotations{
+					Annotations: map[string]string{
 						"old":     "old",
 						"exiting": "old",
 					},
@@ -53,7 +53,7 @@ func TestMergeMetadata(t *testing.T) {
 					"exiting": "new",
 					"old":     "old",
 				},
-				Annotations: Annotations{
+				Annotations: map[string]string{
 					"new":     "new",
 					"exiting": "new",
 					"old":     "old",

--- a/pkg/k8sutils/k8sutils_test.go
+++ b/pkg/k8sutils/k8sutils_test.go
@@ -529,9 +529,7 @@ func TestApplyStatefulSet(t *testing.T) {
 					},
 				},
 				enableScaleTo1: true,
-				equal: func(new *appsv1.StatefulSet, actual *appsv1.StatefulSet) bool {
-					return rutils.StatefulSetDeepEqual(new, actual, false)
-				},
+				equal:          rutils.StatefulSetDeepEqual,
 			},
 			wantErr: false,
 		},
@@ -567,9 +565,7 @@ func TestApplyStatefulSet(t *testing.T) {
 					},
 				},
 				enableScaleTo1: true,
-				equal: func(new *appsv1.StatefulSet, actual *appsv1.StatefulSet) bool {
-					return rutils.StatefulSetDeepEqual(new, actual, false)
-				},
+				equal:          rutils.StatefulSetDeepEqual,
 			},
 			wantErr: false,
 		},
@@ -611,9 +607,7 @@ func TestApplyStatefulSet(t *testing.T) {
 					},
 				},
 				enableScaleTo1: false,
-				equal: func(new *appsv1.StatefulSet, actual *appsv1.StatefulSet) bool {
-					return rutils.StatefulSetDeepEqual(new, actual, false)
-				},
+				equal:          rutils.StatefulSetDeepEqual,
 			},
 			wantErr: true,
 		},

--- a/pkg/k8sutils/load/load.go
+++ b/pkg/k8sutils/load/load.go
@@ -16,9 +16,8 @@ package load
 
 import (
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
-	rutils "github.com/StarRocks/starrocks-kubernetes-operator/pkg/common/resource_utils"
 )
 
-func Selector(clusterName string, spec v1.SpecInterface) rutils.Labels {
+func Selector(clusterName string, spec v1.SpecInterface) map[string]string {
 	return Labels(Name(clusterName, spec), spec)
 }

--- a/pkg/k8sutils/load/load_test.go
+++ b/pkg/k8sutils/load/load_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
-	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/common/resource_utils"
 )
 
 func TestSelector(t *testing.T) {
@@ -16,7 +15,7 @@ func TestSelector(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want resource_utils.Labels
+		want map[string]string
 	}{
 		{
 			name: "test selector",

--- a/pkg/k8sutils/load/metadata.go
+++ b/pkg/k8sutils/load/metadata.go
@@ -16,7 +16,6 @@ package load
 
 import (
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
-	rutils "github.com/StarRocks/starrocks-kubernetes-operator/pkg/common/resource_utils"
 )
 
 func Name(clusterName string, spec v1.SpecInterface) string {
@@ -33,8 +32,8 @@ func Name(clusterName string, spec v1.SpecInterface) string {
 	return ""
 }
 
-func Labels(ownerReference string, spec v1.SpecInterface) rutils.Labels {
-	labels := rutils.Labels{}
+func Labels(ownerReference string, spec v1.SpecInterface) map[string]string {
+	labels := map[string]string{}
 	labels[v1.OwnerReference] = ownerReference
 	switch spec.(type) {
 	case *v1.StarRocksFeSpec:

--- a/pkg/k8sutils/load/metadata_test.go
+++ b/pkg/k8sutils/load/metadata_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
-	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/common/resource_utils"
 )
 
 func TestMakeName(t *testing.T) {
@@ -74,7 +73,7 @@ func TestMakeLabels(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want resource_utils.Labels
+		want map[string]string
 	}{
 		{
 			name: "test Labels for Be",
@@ -82,7 +81,7 @@ func TestMakeLabels(t *testing.T) {
 				ownerReference: "test",
 				spec:           &v1.StarRocksBeSpec{},
 			},
-			want: resource_utils.Labels{
+			want: map[string]string{
 				v1.OwnerReference:    "test",
 				v1.ComponentLabelKey: "be",
 			},
@@ -93,7 +92,7 @@ func TestMakeLabels(t *testing.T) {
 				ownerReference: "test",
 				spec:           &v1.StarRocksCnSpec{},
 			},
-			want: resource_utils.Labels{
+			want: map[string]string{
 				v1.OwnerReference:    "test",
 				v1.ComponentLabelKey: "cn",
 			},
@@ -104,7 +103,7 @@ func TestMakeLabels(t *testing.T) {
 				ownerReference: "test",
 				spec:           &v1.StarRocksFeSpec{},
 			},
-			want: resource_utils.Labels{
+			want: map[string]string{
 				v1.OwnerReference:    "test",
 				v1.ComponentLabelKey: "fe",
 			},

--- a/pkg/k8sutils/templates/object/meta_test.go
+++ b/pkg/k8sutils/templates/object/meta_test.go
@@ -83,9 +83,10 @@ func TestNewFromWarehouse(t *testing.T) {
 				ObjectMeta: &metav1.ObjectMeta{
 					Name: "starrocks",
 				},
-				ClusterName: "starrocks",
-				Kind:        "StarRocksWarehouse",
-				AliasName:   "starrocks-warehouse",
+				ClusterName:       "starrocks",
+				Kind:              "StarRocksWarehouse",
+				AliasName:         "starrocks-warehouse",
+				IsWarehouseObject: true,
 			},
 		},
 	}
@@ -93,6 +94,96 @@ func TestNewFromWarehouse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NewFromWarehouse(tt.args.warehouse); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewFromWarehouse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStarRocksObject_GetCNStatefulSetName(t *testing.T) {
+	type fields struct {
+		ClusterName       string
+		Kind              string
+		AliasName         string
+		IsWarehouseObject bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "test GetCNStatefulSetName for StarRocksCluster",
+			fields: fields{
+				ClusterName:       "cluster",
+				Kind:              "StarRocksCluster",
+				AliasName:         "cluster",
+				IsWarehouseObject: false,
+			},
+			want: "cluster-cn",
+		},
+		{
+			name: "test GetCNStatefulSetName for Warehouse",
+			fields: fields{
+				ClusterName:       "cluster",
+				Kind:              "StarRocksCluster",
+				AliasName:         "wh1-warehouse",
+				IsWarehouseObject: true,
+			},
+			want: "wh1-warehouse-cn",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			object := &StarRocksObject{
+				ClusterName:       tt.fields.ClusterName,
+				Kind:              tt.fields.Kind,
+				AliasName:         tt.fields.AliasName,
+				IsWarehouseObject: tt.fields.IsWarehouseObject,
+			}
+			if got := object.GetCNStatefulSetName(); got != tt.want {
+				t.Errorf("GetCNStatefulSetName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStarRocksObject_GetWarehouseNameInFE(t *testing.T) {
+	type fields struct {
+		ObjectMeta        *metav1.ObjectMeta
+		ClusterName       string
+		Kind              string
+		AliasName         string
+		IsWarehouseObject bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			fields: fields{
+				ObjectMeta: &metav1.ObjectMeta{
+					Name: "wh-1",
+				},
+				ClusterName:       "cluster",
+				Kind:              "StarRocksCluster",
+				AliasName:         "wh-1-warehouse",
+				IsWarehouseObject: true,
+			},
+			want: "wh_1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			object := &StarRocksObject{
+				ObjectMeta:        tt.fields.ObjectMeta,
+				ClusterName:       tt.fields.ClusterName,
+				Kind:              tt.fields.Kind,
+				AliasName:         tt.fields.AliasName,
+				IsWarehouseObject: tt.fields.IsWarehouseObject,
+			}
+			if got := object.GetWarehouseNameInFE(); got != tt.want {
+				t.Errorf("GetWarehouseNameInFE() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -57,23 +57,29 @@ func LifeCycle(lifeCycle *corev1.Lifecycle, preStopScriptPath string) *corev1.Li
 }
 
 func Labels(clusterName string, spec v1.SpecInterface) map[string]string {
+	addLabels := func(labels map[string]string, additionalLabels map[string]string) {
+		for k, v := range additionalLabels {
+			labels[k] = v
+		}
+	}
 	labels := load.Selector(clusterName, spec)
+
 	switch v := spec.(type) {
 	case *v1.StarRocksBeSpec:
 		if v != nil {
-			labels.AddLabel(v.PodLabels)
+			addLabels(labels, v.PodLabels)
 		}
 	case *v1.StarRocksCnSpec:
 		if v != nil {
-			labels.AddLabel(v.PodLabels)
+			addLabels(labels, v.PodLabels)
 		}
 	case *v1.StarRocksFeSpec:
 		if v != nil {
-			labels.AddLabel(v.PodLabels)
+			addLabels(labels, v.PodLabels)
 		}
 	case *v1.StarRocksFeProxySpec:
 		if v != nil {
-			labels.AddLabel(v.PodLabels)
+			addLabels(labels, v.PodLabels)
 		}
 	}
 	return labels

--- a/pkg/k8sutils/templates/statefulset/spec_test.go
+++ b/pkg/k8sutils/templates/statefulset/spec_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
-	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/common/resource_utils"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils/load"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils/templates/object"
 )
@@ -85,7 +84,7 @@ func TestMakeSelector(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want resource_utils.Labels
+		want map[string]string
 	}{
 		{
 			name: "test Selector",
@@ -93,7 +92,7 @@ func TestMakeSelector(t *testing.T) {
 				clusterName: "test",
 				spec:        &v1.StarRocksFeSpec{},
 			},
-			want: resource_utils.Labels{
+			want: map[string]string{
 				v1.OwnerReference:    "test-fe",
 				v1.ComponentLabelKey: "fe",
 			},

--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -110,7 +110,7 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 	externalsvc := rutils.BuildExternalService(object.NewFromCluster(src),
 		beSpec, config, load.Selector(src.Name, beSpec), defaultLabels)
 	// generate internal fe service, update the status of cn on src.
-	internalService := be.generateInternalService(ctx, src, &externalsvc, config, defaultLabels)
+	internalService := be.generateInternalService(src, &externalsvc, config, defaultLabels)
 
 	// create be statefulset
 	podTemplateSpec, err := be.buildPodTemplate(src, config)
@@ -182,9 +182,8 @@ func (be *BeController) UpdateClusterStatus(ctx context.Context, src *srapi.Star
 	return nil
 }
 
-func (be *BeController) generateInternalService(ctx context.Context,
-	src *srapi.StarRocksCluster, externalService *corev1.Service, config map[string]interface{},
-	labels map[string]string) *corev1.Service {
+func (be *BeController) generateInternalService(src *srapi.StarRocksCluster,
+	externalService *corev1.Service, config map[string]interface{}, labels map[string]string) *corev1.Service {
 	spec := src.Spec.StarRocksBeSpec
 	searchServiceName := service.SearchServiceName(src.Name, spec)
 	searchSvc := service.MakeSearchService(searchServiceName, externalService, []corev1.ServicePort{

--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -121,18 +121,12 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 	st := statefulset.MakeStatefulset(object.NewFromCluster(src), beSpec, podTemplateSpec)
 
 	// update the statefulset if feSpec be updated.
-	if err = k8sutils.ApplyStatefulSet(ctx, be.Client, &st, true, func(new *appsv1.StatefulSet, actual *appsv1.StatefulSet) bool {
-		return rutils.StatefulSetDeepEqual(new, actual, false)
-	}); err != nil {
+	if err = k8sutils.ApplyStatefulSet(ctx, be.Client, &st, true, rutils.StatefulSetDeepEqual); err != nil {
 		logger.Error(err, "apply statefulset failed")
 		return err
 	}
 
-	if err = k8sutils.ApplyService(ctx, be.Client, internalService, func(new *corev1.Service, esvc *corev1.Service) bool {
-		// for compatible v1.5, we use `cn-domain-search` for internal communicating.
-		internalService.Name = st.Spec.ServiceName
-		return rutils.ServiceDeepEqual(new, esvc)
-	}); err != nil {
+	if err = k8sutils.ApplyService(ctx, be.Client, internalService, rutils.ServiceDeepEqual); err != nil {
 		logger.Error(err, "apply internal service failed", "internalService", internalService)
 		return err
 	}
@@ -191,7 +185,6 @@ func (be *BeController) UpdateClusterStatus(ctx context.Context, src *srapi.Star
 func (be *BeController) generateInternalService(ctx context.Context,
 	src *srapi.StarRocksCluster, externalService *corev1.Service, config map[string]interface{},
 	labels map[string]string) *corev1.Service {
-	logger := logr.FromContextOrDiscard(ctx)
 	spec := src.Spec.StarRocksBeSpec
 	searchServiceName := service.SearchServiceName(src.Name, spec)
 	searchSvc := service.MakeSearchService(searchServiceName, externalService, []corev1.ServicePort{
@@ -201,16 +194,6 @@ func (be *BeController) generateInternalService(ctx context.Context,
 			TargetPort: intstr.FromInt(int(rutils.GetPort(config, rutils.HEARTBEAT_SERVICE_PORT))),
 		},
 	}, labels)
-
-	// for compatible version < v1.5
-	var esearchSvc corev1.Service
-	if err := be.Client.Get(ctx, types.NamespacedName{Namespace: src.Namespace, Name: "be-domain-search"}, &esearchSvc); err == nil {
-		if rutils.HaveEqualOwnerReference(&esearchSvc, searchSvc) {
-			searchSvc.Name = "be-domain-search"
-		}
-	} else if !apierrors.IsNotFound(err) {
-		logger.Error(err, "get internal service object failed")
-	}
 
 	return searchSvc
 }

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -232,7 +232,9 @@ func (cc *CnController) SyncCnSpec(ctx context.Context, object object.StarRocksO
 		srapi.ComponentLabelKey: srapi.DEFAULT_CN,
 		srapi.OwnerReference:    object.GetCNStatefulSetName(),
 	}
-	if err := cc.k8sClient.List(ctx, &actualCNPods, client.InNamespace(object.Namespace), matchingLabels); err != nil && !apierrors.IsNotFound(err) {
+
+	err = cc.k8sClient.List(ctx, &actualCNPods, client.InNamespace(object.Namespace), matchingLabels)
+	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Error(err, "list cn pod failed")
 		return err
 	}
@@ -548,15 +550,15 @@ func (cc *CnController) SyncComputeNodesInFE(ctx context.Context, object object.
 		expectReplicas = 1
 	}
 
-	var stsReplicas int
+	var stsReplicas int32
 	if actualSTS.Spec.Replicas != nil {
-		stsReplicas = int(*actualSTS.Spec.Replicas)
+		stsReplicas = *actualSTS.Spec.Replicas
 	} else {
 		stsReplicas = 1
 	}
 
 	// compare the replicas between the expected value and the actual value in StatefulSet.
-	if expectReplicas != int32(stsReplicas) {
+	if expectReplicas != stsReplicas {
 		logger.Info("expect replicas is not equal to statefulset replicas", "expectReplicas", expectReplicas, "stsReplicas", stsReplicas)
 		return ErrReplicasNotEqual
 	}

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -216,6 +216,11 @@ func (cc *CnController) SyncCnSpec(ctx context.Context, object object.StarRocksO
 		return err
 	}
 
+	// only take effect for shared-data mode
+	if !fe.IsRunInSharedDataMode(feconfig) {
+		return nil
+	}
+
 	// get actual statefulset object
 	var actualSTS appsv1.StatefulSet
 	namespacedName := types.NamespacedName{
@@ -574,9 +579,9 @@ func (cc *CnController) SyncComputeNodesInFE(ctx context.Context, object object.
 		return ErrReplicasNotEqual
 	}
 	const controllerRevisionHashKey = "controller-revision-hash"
-	for _, pod := range actualCNPods.Items {
-		if pod.Labels[controllerRevisionHashKey] == "" ||
-			pod.Labels[controllerRevisionHashKey] != actualSTS.Status.UpdateRevision {
+	for _, item := range actualCNPods.Items {
+		if item.Labels[controllerRevisionHashKey] == "" ||
+			item.Labels[controllerRevisionHashKey] != actualSTS.Status.UpdateRevision {
 			logger.Info("there is old pod, continue to wait for the statefulset to be ready")
 			return ErrHashValueNotEqual
 		}

--- a/pkg/subcontrollers/cn/cn_controller_test.go
+++ b/pkg/subcontrollers/cn/cn_controller_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -548,8 +547,8 @@ func TestCnController_SyncComputeNodesInFE(t *testing.T) {
 	type args struct {
 		ctx          context.Context
 		object       object.StarRocksObject
-		expectSTS    *appv1.StatefulSet
-		actualSTS    *appv1.StatefulSet
+		expectSTS    *appsv1.StatefulSet
+		actualSTS    *appsv1.StatefulSet
 		actualCNPods *corev1.PodList
 		db           *sql.DB
 	}
@@ -567,29 +566,29 @@ func TestCnController_SyncComputeNodesInFE(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				object: object.StarRocksObject{},
-				expectSTS: &appv1.StatefulSet{
+				expectSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(3),
 					},
 				},
-				actualSTS: &appv1.StatefulSet{
+				actualSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(4),
 					},
 				},
@@ -611,29 +610,29 @@ func TestCnController_SyncComputeNodesInFE(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				object: object.StarRocksObject{},
-				expectSTS: &appv1.StatefulSet{
+				expectSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(1),
 					},
 				},
-				actualSTS: &appv1.StatefulSet{
+				actualSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(1),
 					},
 				},
@@ -670,23 +669,23 @@ func TestCnController_SyncComputeNodesInFE(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				object: object.StarRocksObject{},
-				expectSTS: &appv1.StatefulSet{
+				expectSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(1),
 					},
 				},
-				actualSTS: &appv1.StatefulSet{
+				actualSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cn",
@@ -695,7 +694,7 @@ func TestCnController_SyncComputeNodesInFE(t *testing.T) {
 							"extra-label": "value",
 						},
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(1),
 					},
 				},
@@ -716,32 +715,32 @@ func TestCnController_SyncComputeNodesInFE(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				object: object.StarRocksObject{},
-				expectSTS: &appv1.StatefulSet{
+				expectSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(1),
 					},
 				},
-				actualSTS: &appv1.StatefulSet{
+				actualSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(1),
 					},
-					Status: appv1.StatefulSetStatus{
+					Status: appsv1.StatefulSetStatus{
 						UpdateRevision: "v1",
 					},
 				},
@@ -824,29 +823,29 @@ func TestCnController_SyncComputeNodesInFE(t *testing.T) {
 					AliasName:         "wh1-warehouse",
 					IsWarehouseObject: true,
 				},
-				expectSTS: &appv1.StatefulSet{
+				expectSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "wh1-warehouse-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(1),
 					},
 				},
-				actualSTS: &appv1.StatefulSet{
+				actualSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       rutils.StatefulSetKind,
-						APIVersion: appv1.SchemeGroupVersion.String(),
+						APIVersion: appsv1.SchemeGroupVersion.String(),
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "wh1-warehouse-cn",
 						Namespace: "default",
 					},
-					Spec: appv1.StatefulSetSpec{
+					Spec: appsv1.StatefulSetSpec{
 						Replicas: rutils.GetInt32Pointer(1),
 					},
 					Status: appsv1.StatefulSetStatus{

--- a/pkg/subcontrollers/cn/cn_mysql_test.go
+++ b/pkg/subcontrollers/cn/cn_mysql_test.go
@@ -303,7 +303,7 @@ func TestSQLExecutor_ExecuteDropWarehouse(t *testing.T) {
 				db: func() *sql.DB {
 					db, mock, err := sqlmock.New()
 					require.NoError(t, err)
-					mock.ExpectExec(fmt.Sprintf("DROP WAREHOUSE wh1")).
+					mock.ExpectExec("DROP WAREHOUSE wh1").
 						WillReturnResult(sqlmock.NewResult(1, 1))
 					return db
 				}(),

--- a/pkg/subcontrollers/cn/cn_mysql_test.go
+++ b/pkg/subcontrollers/cn/cn_mysql_test.go
@@ -2,6 +2,7 @@ package cn
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -47,7 +48,7 @@ func TestNewSQLExecutor(t *testing.T) {
 							APIVersion: appsv1.SchemeGroupVersion.String(),
 						},
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "my-sts-cn",
+							Name:      "my-sts",
 							Namespace: "default",
 							Annotations: map[string]string{
 								"test": "test",
@@ -119,7 +120,7 @@ func TestSQLExecutor_Execute(t *testing.T) {
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
-			name: "test Execute",
+			name: "test ExecuteContext",
 			fields: fields{
 				RootPassword:  "root",
 				FeServiceName: "localhost",
@@ -149,7 +150,177 @@ func TestSQLExecutor_Execute(t *testing.T) {
 			mock.ExpectExec(tt.args.statements).
 				WillReturnResult(sqlmock.NewResult(1, 1))
 
-			tt.wantErr(t, executor.Execute(tt.args.ctx, db, tt.args.statements), fmt.Sprintf("Execute(%v, %v)", tt.args.ctx, tt.args.statements))
+			err = executor.ExecuteContext(tt.args.ctx, db, tt.args.statements)
+			tt.wantErr(t, err, fmt.Sprintf("ExecuteContext(%v, %v)", tt.args.ctx, tt.args.statements))
+		})
+	}
+}
+
+func TestSQLExecutor_QueryShowComputeNodes(t *testing.T) {
+	type fields struct {
+		RootPassword       string
+		FeServiceName      string
+		FeServiceNamespace string
+		FeServicePort      string
+	}
+	type args struct {
+		ctx context.Context
+		db  *sql.DB
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "test ExecuteContext",
+			fields: fields{
+				RootPassword:  "",
+				FeServiceName: "localhost",
+				FeServicePort: "9030",
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &SQLExecutor{
+				RootPassword:       tt.fields.RootPassword,
+				FeServiceName:      tt.fields.FeServiceName,
+				FeServiceNamespace: tt.fields.FeServiceNamespace,
+				FeServicePort:      tt.fields.FeServicePort,
+			}
+			// create mock db
+			db, mock, err := sqlmock.New()
+			require.NoError(t, err)
+			defer db.Close()
+
+			// set expected behavior on mock db
+			mock.ExpectQuery(ShowComputeNodesStatement).WillReturnRows(
+				sqlmock.NewRows([]string{"ComputeNodeId", "IP", "WarehouseName"}).AddRow([]byte("id"), []byte("fqdn"), []byte("wh1")),
+			)
+
+			result, err := executor.QueryShowComputeNodes(tt.args.ctx, db)
+			tt.wantErr(t, err, fmt.Sprintf("ShowComputeNodes(%v, %v)", tt.args.ctx, tt.args.db))
+			assert.Equal(t, 1, len(result.ComputeNodesByWarehouse))
+			assert.Equal(t, "id", result.ComputeNodesByWarehouse["wh1"][0].ComputeNodeId)
+			assert.Equal(t, "fqdn", result.ComputeNodesByWarehouse["wh1"][0].FQDN)
+			assert.Equal(t, "wh1", result.ComputeNodesByWarehouse["wh1"][0].WarehouseName)
+		})
+	}
+}
+
+func TestSQLExecutor_ExecuteDropComputeNode(t *testing.T) {
+	type fields struct {
+		RootPassword       string
+		FeServiceName      string
+		FeServiceNamespace string
+		FeServicePort      string
+	}
+	type args struct {
+		ctx context.Context
+		db  *sql.DB
+		cn  ComputeNode
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "test ExecuteDropComputeNode",
+			fields: fields{
+				RootPassword:       "root",
+				FeServiceName:      "fe-search",
+				FeServiceNamespace: "default",
+				FeServicePort:      "9030",
+			},
+			args: args{
+				ctx: context.Background(),
+				db: func() *sql.DB {
+					db, mock, err := sqlmock.New()
+					require.NoError(t, err)
+					statement := fmt.Sprintf("ALTER SYSTEM DROP COMPUTE NODE \"%v:%v\" FROM WAREHOUSE %v", "fqdn", "9010", "wh1")
+					mock.ExpectExec(statement).WillReturnResult(sqlmock.NewResult(1, 1))
+					return db
+				}(),
+				cn: ComputeNode{
+					ComputeNodeId: "id",
+					FQDN:          "fqdn",
+					HeartbeatPort: "9010",
+					WarehouseName: "wh1",
+				},
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &SQLExecutor{
+				RootPassword:       tt.fields.RootPassword,
+				FeServiceName:      tt.fields.FeServiceName,
+				FeServiceNamespace: tt.fields.FeServiceNamespace,
+				FeServicePort:      tt.fields.FeServicePort,
+			}
+			tt.wantErr(t, executor.ExecuteDropComputeNode(tt.args.ctx, tt.args.db, tt.args.cn), fmt.Sprintf("ExecuteDropComputeNode(%v, %v, %v)", tt.args.ctx, tt.args.db, tt.args.cn))
+		})
+	}
+}
+
+func TestSQLExecutor_ExecuteDropWarehouse(t *testing.T) {
+	type fields struct {
+		RootPassword       string
+		FeServiceName      string
+		FeServiceNamespace string
+		FeServicePort      string
+	}
+	type args struct {
+		ctx           context.Context
+		db            *sql.DB
+		warehouseName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "test ExecuteDropComputeNode",
+			fields: fields{
+				RootPassword:       "root",
+				FeServiceName:      "fe-search",
+				FeServiceNamespace: "default",
+				FeServicePort:      "9030",
+			},
+			args: args{
+				ctx: context.Background(),
+				db: func() *sql.DB {
+					db, mock, err := sqlmock.New()
+					require.NoError(t, err)
+					mock.ExpectExec(fmt.Sprintf("DROP WAREHOUSE wh1")).
+						WillReturnResult(sqlmock.NewResult(1, 1))
+					return db
+				}(),
+				warehouseName: "wh1",
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &SQLExecutor{
+				RootPassword:       tt.fields.RootPassword,
+				FeServiceName:      tt.fields.FeServiceName,
+				FeServiceNamespace: tt.fields.FeServiceNamespace,
+				FeServicePort:      tt.fields.FeServicePort,
+			}
+			tt.wantErr(t, executor.ExecuteDropWarehouse(tt.args.ctx, tt.args.db, tt.args.warehouseName), fmt.Sprintf("ExecuteDropWarehouse(%v, %v, %v)", tt.args.ctx, tt.args.db, tt.args.warehouseName))
 		})
 	}
 }


### PR DESCRIPTION
# Description

## Background

When a scale-in operation happens:

For BE with shared-nothing deployment, the cleanup actions include:
1. Decommission operation (time-consuming)
2. Stop pod operation (need to wait for termination of BE pod)
4. Drop BE from SR

For CN with shared-data deployment, the cleanup actions include:
1. Stop pod operation (need to wait for termination of CN pod)
2. Drop CN from SR

Among them, `Decommission` and `Stop pod` are time-consuming operations, and the Operator cannot wait for the operation to complete in a blocking manner.

In summary, the cleanup actions `Stop pod` and `Drop node` are likely not in the same tuning loop. Therefore, we cannot rely on whether the current operation is a scaling-in operation to execute these logics.

## How

At the end of each tuning cycle, the operator performs the following validation steps:

### 1. Verify Replica Consistency

Compare the replicas field in the StarRocksCN Custom Resource Definition (CRD) with the spec.replicas field of the corresponding CN StatefulSet. These values must be identical.

### 2. Validate Running Pod Count
Compare the replicas field in the StarRocksCN CRD with the number of running and ready CN pods. These values must match.

### 3. Confirm Revision Hash Match

Ensure that the controller-revision-hash label on all running CN pods exactly matches the status.updateRevision field of the CN StatefulSet.

### 4. Perform DROP COMPUTE NODE

If all three conditions are met, the operator will compare the list of compute nodes registered in the Frontend (FE) cluster against the current running CN pods. Initiate the `DROP COMPUTE NODE` operation for any nodes that are no longer present in the pod list.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
