### PR TITLE
[BugFix] Support podLabels for FeProxy component in Helm Chart

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -941,4 +941,8 @@ spec:
       mountPath: {{ .mountPath }}
     {{- end }}
     {{- end }}
+    {{- if .Values.starrocksFeProxySpec.podLabels }}
+    podLabels:
+      {{- toYaml .Values.starrocksFeProxySpec.podLabels | nindent 6 }}
+    {{- end }}
   {{- end }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -1275,3 +1275,5 @@ starrocksFeProxySpec:
       # e.g., mount an emptyDir volume to /tmp
       # - name: tmp-data
       #   mountPath: /tmp
+  # the pod labels for user select or classify pods.
+  podLabels: {}

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -1392,3 +1392,5 @@ starrocks:
         # e.g., mount an emptyDir volume to /tmp
         # - name: tmp-data
         #   mountPath: /tmp
+    # the pod labels for user select or classify pods.
+    podLabels: {}


### PR DESCRIPTION
# Description

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
