### PR TITLE
[BugFix] When calculating the hash value of sts, persistentVolumeClaimRetentionPolicy should be included

### DIFF
--- a/pkg/common/hash/hash_test.go
+++ b/pkg/common/hash/hash_test.go
@@ -188,3 +188,26 @@ func TestTwoObject2(_ *testing.T) {
 		fmt.Println("two object has the same types and values")
 	}
 }
+
+// TestHashObject_with_nil checks hash consistency between two objects with different structures but identical field values.
+func TestHashObject_with_nil(_ *testing.T) {
+	type t1 struct {
+		name string
+		//nolint:unused
+		age *int
+	}
+	o1 := t1{
+		name: "test",
+	}
+
+	type t2 struct {
+		name string
+	}
+	o2 := t2{
+		name: "test",
+	}
+
+	if hash.HashObject(o1) == hash.HashObject(o2) {
+		fmt.Println("two object has the same types and values")
+	}
+}

--- a/pkg/common/resource_utils/statefulset.go
+++ b/pkg/common/resource_utils/statefulset.go
@@ -25,21 +25,21 @@ import (
 
 // hashStatefulsetObject contains the info for hash comparison.
 type hashStatefulsetObject struct {
-	name                 string
-	namespace            string
-	labels               map[string]string
-	finalizers           []string
-	selector             metav1.LabelSelector
-	podTemplate          corev1.PodTemplateSpec
-	serviceName          string
-	volumeClaimTemplates []corev1.PersistentVolumeClaim
-	replicas             int32
-	updateStrategy       appsv1.StatefulSetUpdateStrategy
+	name                                 string
+	namespace                            string
+	labels                               map[string]string
+	finalizers                           []string
+	selector                             metav1.LabelSelector
+	podTemplate                          corev1.PodTemplateSpec
+	serviceName                          string
+	volumeClaimTemplates                 []corev1.PersistentVolumeClaim
+	replicas                             int32
+	updateStrategy                       appsv1.StatefulSetUpdateStrategy
+	persistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy
 }
 
 // statefulSetHashObject construct the hash spec for deep equals to exist statefulset.
 func statefulSetHashObject(sts *appsv1.StatefulSet) hashStatefulsetObject {
-	// set -1 for the initial is zero.
 	replicas := int32(-1)
 	if sts.Spec.Replicas != nil {
 		replicas = *sts.Spec.Replicas
@@ -51,21 +51,22 @@ func statefulSetHashObject(sts *appsv1.StatefulSet) hashStatefulsetObject {
 	}
 
 	return hashStatefulsetObject{
-		name:                 sts.Name,
-		namespace:            sts.Namespace,
-		labels:               sts.Labels,
-		finalizers:           sts.Finalizers,
-		selector:             selector,
-		podTemplate:          sts.Spec.Template,
-		serviceName:          sts.Spec.ServiceName,
-		volumeClaimTemplates: sts.Spec.VolumeClaimTemplates,
-		replicas:             replicas,
-		updateStrategy:       sts.Spec.UpdateStrategy,
+		name:                                 sts.Name,
+		namespace:                            sts.Namespace,
+		labels:                               sts.Labels,
+		finalizers:                           sts.Finalizers,
+		selector:                             selector,
+		podTemplate:                          sts.Spec.Template,
+		serviceName:                          sts.Spec.ServiceName,
+		volumeClaimTemplates:                 sts.Spec.VolumeClaimTemplates,
+		replicas:                             replicas,
+		updateStrategy:                       sts.Spec.UpdateStrategy,
+		persistentVolumeClaimRetentionPolicy: sts.Spec.PersistentVolumeClaimRetentionPolicy,
 	}
 }
 
 // StatefulSetDeepEqual judge two statefulset equal or not, and it will not change the statefulset instance.
-// This function will always return new hash value of the expected statefulset
+// This function will always return a new hash value of the expected statefulset
 func StatefulSetDeepEqual(expect *appsv1.StatefulSet, actual *appsv1.StatefulSet) (string, bool) {
 	var newHashv, oldHashv string
 
@@ -76,9 +77,9 @@ func StatefulSetDeepEqual(expect *appsv1.StatefulSet, actual *appsv1.StatefulSet
 		newHashv = hash.HashObject(newHso)
 	}
 
-	// the hash value calculated from statefulset instance in k8s may will never equal to the hash value from
-	// starrocks cluster. Because statefulset may be updated by k8s controller manager.
-	// Every time you update the statefulset, a new reconcile will be triggered.
+	// The hash value calculated from a statefulset instance in k8s may never equal to the hash value from
+	// the starrocks cluster. Because statefulset may be updated by k8s controller manager.
+	// Every time you update the statefulset, a new reconciling will be triggered.
 	if _, ok := actual.Annotations[srapi.ComponentResourceHash]; ok {
 		oldHashv = actual.Annotations[srapi.ComponentResourceHash]
 	} else {

--- a/pkg/common/resource_utils/statefulset_test.go
+++ b/pkg/common/resource_utils/statefulset_test.go
@@ -43,11 +43,12 @@ func TestStatefulSetDeepEqual(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test",
 					},
+					Spec: appsv1.StatefulSetSpec{},
 				},
 				actual: &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
-							v1.ComponentResourceHash: "300056134",
+							v1.ComponentResourceHash: "3376346675",
 						},
 					},
 				},


### PR DESCRIPTION
# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.