### PR TITLE
[BugFix] Use the complete array format for preStop

### DIFF
--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -33,10 +33,10 @@ const (
 )
 
 // LifeCycle returns a lifecycle.
-func LifeCycle(lifeCycle *corev1.Lifecycle, preStopScriptPath string) *corev1.Lifecycle {
+func LifeCycle(lifeCycle *corev1.Lifecycle, preStopCommand []string) *corev1.Lifecycle {
 	defaultPreStop := &corev1.LifecycleHandler{
 		Exec: &corev1.ExecAction{
-			Command: []string{preStopScriptPath},
+			Command: preStopCommand,
 		},
 	}
 
@@ -379,18 +379,19 @@ func GetConfigDir(spec v1.SpecInterface) string {
 	return ""
 }
 
-func GetPreStopScriptPath(spec v1.SpecInterface) string {
-	// we do not need set --timeout parameter for stop_xx.sh, because the terminationGracePeriodSeconds configuration
+func GetPreStopCommand(spec v1.SpecInterface) []string {
+	command := []string{"/bin/bash", "-c"}
+	// we do not need to set --timeout parameter for stop_xx.sh, because the terminationGracePeriodSeconds configuration
 	// on Pod will take the same effect
 	switch v := spec.(type) {
 	case *v1.StarRocksFeSpec:
-		return fmt.Sprintf("%s/fe/bin/stop_fe.sh -g", GetStarRocksRootPath(v.FeEnvVars))
+		command = append(command, fmt.Sprintf("%s/fe/bin/stop_fe.sh -g", GetStarRocksRootPath(v.FeEnvVars)))
 	case *v1.StarRocksBeSpec:
-		return fmt.Sprintf("%s/be/bin/stop_be.sh -g", GetStarRocksRootPath(v.BeEnvVars))
+		command = append(command, fmt.Sprintf("%s/be/bin/stop_be.sh -g", GetStarRocksRootPath(v.BeEnvVars)))
 	case *v1.StarRocksCnSpec:
-		return fmt.Sprintf("%s/cn/bin/stop_cn.sh -g", GetStarRocksRootPath(v.CnEnvVars))
+		command = append(command, fmt.Sprintf("%s/cn/bin/stop_cn.sh -g", GetStarRocksRootPath(v.CnEnvVars)))
 	}
-	return ""
+	return command
 }
 
 func GetStarRocksDefaultRootPath() string {

--- a/pkg/k8sutils/templates/pod/spec_test.go
+++ b/pkg/k8sutils/templates/pod/spec_test.go
@@ -30,8 +30,8 @@ import (
 
 func TestMakeLifeCycle(t *testing.T) {
 	type args struct {
-		lifeCycle         *corev1.Lifecycle
-		preStopScriptPath string
+		lifeCycle      *corev1.Lifecycle
+		preStopCommand []string
 	}
 	tests := []struct {
 		name string
@@ -41,8 +41,8 @@ func TestMakeLifeCycle(t *testing.T) {
 		{
 			name: "test without lifecycle",
 			args: args{
-				lifeCycle:         nil,
-				preStopScriptPath: "/scripts/pre-stop.sh",
+				lifeCycle:      nil,
+				preStopCommand: []string{"/scripts/pre-stop.sh"},
 			},
 			want: &corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{
@@ -67,7 +67,7 @@ func TestMakeLifeCycle(t *testing.T) {
 						},
 					},
 				},
-				preStopScriptPath: "/scripts/pre-stop.sh",
+				preStopCommand: []string{"/scripts/pre-stop.sh"},
 			},
 			want: &corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{
@@ -92,7 +92,7 @@ func TestMakeLifeCycle(t *testing.T) {
 						},
 					},
 				},
-				preStopScriptPath: "/scripts/pre-stop.sh",
+				preStopCommand: []string{"/scripts/pre-stop.sh"},
 			},
 			want: &corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{
@@ -110,7 +110,7 @@ func TestMakeLifeCycle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := LifeCycle(tt.args.lifeCycle, tt.args.preStopScriptPath)
+			actual := LifeCycle(tt.args.lifeCycle, tt.args.preStopCommand)
 			if !reflect.DeepEqual(actual, tt.want) {
 				t.Errorf("LifeCycle() = %v, want %v", actual, tt.want)
 			}
@@ -625,6 +625,36 @@ func TestGetStarRocksRootPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GetStarRocksRootPath(tt.args.envVars); got != tt.want {
 				t.Errorf("GetStarRocksRootPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPreStopCommand(t *testing.T) {
+	type args struct {
+		spec v1.SpecInterface
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "get pre stop command",
+			args: args{
+				spec: &v1.StarRocksCnSpec{},
+			},
+			want: []string{
+				"/bin/bash",
+				"-c",
+				"/opt/starrocks/cn/bin/stop_cn.sh -g",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetPreStopCommand(tt.args.spec); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPreStopCommand() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/subcontrollers/be/be_pod.go
+++ b/pkg/subcontrollers/be/be_pod.go
@@ -77,7 +77,7 @@ func (be *BeController) buildPodTemplate(src *srapi.StarRocksCluster, config map
 		StartupProbe:    pod.StartupProbe(beSpec.GetStartupProbeFailureSeconds(), webServerPort, pod.HEALTH_API_PATH),
 		LivenessProbe:   pod.LivenessProbe(beSpec.GetLivenessProbeFailureSeconds(), webServerPort, pod.HEALTH_API_PATH),
 		ReadinessProbe:  pod.ReadinessProbe(beSpec.GetReadinessProbeFailureSeconds(), webServerPort, pod.HEALTH_API_PATH),
-		Lifecycle:       pod.LifeCycle(beSpec.GetLifecycle(), pod.GetPreStopScriptPath(beSpec)),
+		Lifecycle:       pod.LifeCycle(beSpec.GetLifecycle(), pod.GetPreStopCommand(beSpec)),
 		SecurityContext: pod.ContainerSecurityContext(beSpec),
 	}
 	if pod.GetStarRocksRootPath(beSpec.BeEnvVars) != pod.GetStarRocksDefaultRootPath() {

--- a/pkg/subcontrollers/cn/cn_pod.go
+++ b/pkg/subcontrollers/cn/cn_pod.go
@@ -87,7 +87,7 @@ func (cc *CnController) buildPodTemplate(ctx context.Context, object srobject.St
 		StartupProbe:    pod.StartupProbe(cnSpec.GetStartupProbeFailureSeconds(), webServerPort, pod.HEALTH_API_PATH),
 		LivenessProbe:   pod.LivenessProbe(cnSpec.GetLivenessProbeFailureSeconds(), webServerPort, pod.HEALTH_API_PATH),
 		ReadinessProbe:  pod.ReadinessProbe(cnSpec.GetReadinessProbeFailureSeconds(), webServerPort, pod.HEALTH_API_PATH),
-		Lifecycle:       pod.LifeCycle(cnSpec.GetLifecycle(), pod.GetPreStopScriptPath(cnSpec)),
+		Lifecycle:       pod.LifeCycle(cnSpec.GetLifecycle(), pod.GetPreStopCommand(cnSpec)),
 		SecurityContext: pod.ContainerSecurityContext(cnSpec),
 	}
 	if pod.GetStarRocksRootPath(cnSpec.CnEnvVars) != pod.GetStarRocksDefaultRootPath() {

--- a/pkg/subcontrollers/fe/fe_pod.go
+++ b/pkg/subcontrollers/fe/fe_pod.go
@@ -72,7 +72,7 @@ func (fc *FeController) buildPodTemplate(src *srapi.StarRocksCluster, config map
 		StartupProbe:    pod.StartupProbe(feSpec.GetStartupProbeFailureSeconds(), httpPort, pod.HEALTH_API_PATH),
 		LivenessProbe:   pod.LivenessProbe(feSpec.GetLivenessProbeFailureSeconds(), httpPort, pod.HEALTH_API_PATH),
 		ReadinessProbe:  pod.ReadinessProbe(feSpec.GetReadinessProbeFailureSeconds(), httpPort, pod.HEALTH_API_PATH),
-		Lifecycle:       pod.LifeCycle(feSpec.GetLifecycle(), pod.GetPreStopScriptPath(feSpec)),
+		Lifecycle:       pod.LifeCycle(feSpec.GetLifecycle(), pod.GetPreStopCommand(feSpec)),
 		SecurityContext: pod.ContainerSecurityContext(feSpec),
 	}
 	if pod.GetStarRocksRootPath(feSpec.FeEnvVars) != pod.GetStarRocksDefaultRootPath() {


### PR DESCRIPTION
# Description

The current preStop configuration isn't working.
```
Warning  FailedPreStopHook  14s                  kubelet            PreStopHook failed
```

We should use the complete array format for preStop.