### PR TITLE
[BugFix] Use the correct warehouse Name in FE

### DIFF
--- a/pkg/common/resource_utils/service.go
+++ b/pkg/common/resource_utils/service.go
@@ -62,7 +62,7 @@ func BuildExternalService(object object.StarRocksObject, spec srapi.SpecInterfac
 	var srPorts []srapi.StarRocksServicePort
 	svc := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      service.ExternalServiceName(object.AliasName, spec),
+			Name:      service.ExternalServiceName(object.SubResourcePrefixName, spec),
 			Namespace: object.GetNamespace(),
 			Labels:    labels,
 		},

--- a/pkg/controllers/starrockswarehouse_controller.go
+++ b/pkg/controllers/starrockswarehouse_controller.go
@@ -153,7 +153,7 @@ func handleSyncWarehouseError(ctx context.Context, err error, warehouse *srapi.S
 	logger.Error(err, "sub controller reconciles spec failed")
 	warehouse.Status.Phase = srapi.ComponentFailed
 	warehouse.Status.Reason = err.Error()
-	if errors.Is(err, cn.ErrorSpecIsMissing) || errors.Is(err, cn.ErrStarRocksClusterIsMissing) ||
+	if errors.Is(err, cn.ErrSpecIsMissing) || errors.Is(err, cn.ErrStarRocksClusterIsMissing) ||
 		errors.Is(err, cn.ErrFeIsNotReady) || errors.Is(err, cn.ErrFailedToGetFeFeatureList) {
 		return true
 	}

--- a/pkg/k8sutils/templates/object/meta.go
+++ b/pkg/k8sutils/templates/object/meta.go
@@ -26,11 +26,10 @@ type StarRocksObject struct {
 	// The reason why we need this field is that we can't make sure ObjectMeta.Kind is filled.
 	Kind string
 
-	// AliasName represents the prefix of subresource names for cn component. The reason is that when the name of
+	// SubResourcePrefixName represents the prefix of subresource names for cn component. The reason is that when the name of
 	// StarRocksWarehouse is the same as the name of StarRocksCluster, operator should avoid to create the same name
 	// StatefulSet, Service, etc.
-	// todo(ydx): it is not a good name, will rename it to SubResourcePrefixName in another PR
-	AliasName string
+	SubResourcePrefixName string
 
 	// IsWarehouseObject indicates whether this object is a StarRocksWarehouse object.
 	IsWarehouseObject bool
@@ -38,23 +37,23 @@ type StarRocksObject struct {
 
 func NewFromCluster(cluster *srapi.StarRocksCluster) StarRocksObject {
 	return StarRocksObject{
-		TypeMeta:          &cluster.TypeMeta,
-		ObjectMeta:        &cluster.ObjectMeta,
-		ClusterName:       cluster.Name,
-		Kind:              StarRocksClusterKind,
-		AliasName:         cluster.Name,
-		IsWarehouseObject: false,
+		TypeMeta:              &cluster.TypeMeta,
+		ObjectMeta:            &cluster.ObjectMeta,
+		ClusterName:           cluster.Name,
+		Kind:                  StarRocksClusterKind,
+		SubResourcePrefixName: cluster.Name,
+		IsWarehouseObject:     false,
 	}
 }
 
 func NewFromWarehouse(warehouse *srapi.StarRocksWarehouse) StarRocksObject {
 	return StarRocksObject{
-		TypeMeta:          &warehouse.TypeMeta,
-		ObjectMeta:        &warehouse.ObjectMeta,
-		ClusterName:       warehouse.Spec.StarRocksCluster,
-		Kind:              StarRocksWarehouseKind,
-		AliasName:         GetPrefixNameForWarehouse(warehouse.Name),
-		IsWarehouseObject: true,
+		TypeMeta:              &warehouse.TypeMeta,
+		ObjectMeta:            &warehouse.ObjectMeta,
+		ClusterName:           warehouse.Spec.StarRocksCluster,
+		Kind:                  StarRocksWarehouseKind,
+		SubResourcePrefixName: GetPrefixNameForWarehouse(warehouse.Name),
+		IsWarehouseObject:     true,
 	}
 }
 
@@ -63,13 +62,13 @@ func GetPrefixNameForWarehouse(warehouseName string) string {
 }
 
 // Name The reason why we need this method is that we don't want user to use object.Name directly.
-// In warehouse situation, most of the time you should use AliasName, not Name.
+// In a warehouse situation, most of the time you should use SubResourcePrefixName, not Name.
 func (object *StarRocksObject) Name() string {
 	return object.ObjectMeta.Name
 }
 
 func (object *StarRocksObject) GetCNStatefulSetName() string {
-	return load.Name(object.AliasName, (*srapi.StarRocksCnSpec)(nil))
+	return load.Name(object.SubResourcePrefixName, (*srapi.StarRocksCnSpec)(nil))
 }
 
 func (object *StarRocksObject) GetWarehouseNameInFE() string {

--- a/pkg/k8sutils/templates/object/meta_test.go
+++ b/pkg/k8sutils/templates/object/meta_test.go
@@ -37,9 +37,9 @@ func TestNewFromCluster(t *testing.T) {
 				ObjectMeta: &metav1.ObjectMeta{
 					Name: "starrocks",
 				},
-				ClusterName: "starrocks",
-				Kind:        "StarRocksCluster",
-				AliasName:   "starrocks",
+				ClusterName:           "starrocks",
+				Kind:                  "StarRocksCluster",
+				SubResourcePrefixName: "starrocks",
 			},
 		},
 	}
@@ -83,10 +83,10 @@ func TestNewFromWarehouse(t *testing.T) {
 				ObjectMeta: &metav1.ObjectMeta{
 					Name: "starrocks",
 				},
-				ClusterName:       "starrocks",
-				Kind:              "StarRocksWarehouse",
-				AliasName:         "starrocks-warehouse",
-				IsWarehouseObject: true,
+				ClusterName:           "starrocks",
+				Kind:                  "StarRocksWarehouse",
+				SubResourcePrefixName: "starrocks-warehouse",
+				IsWarehouseObject:     true,
 			},
 		},
 	}
@@ -135,10 +135,10 @@ func TestStarRocksObject_GetCNStatefulSetName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			object := &StarRocksObject{
-				ClusterName:       tt.fields.ClusterName,
-				Kind:              tt.fields.Kind,
-				AliasName:         tt.fields.AliasName,
-				IsWarehouseObject: tt.fields.IsWarehouseObject,
+				ClusterName:           tt.fields.ClusterName,
+				Kind:                  tt.fields.Kind,
+				SubResourcePrefixName: tt.fields.AliasName,
+				IsWarehouseObject:     tt.fields.IsWarehouseObject,
 			}
 			if got := object.GetCNStatefulSetName(); got != tt.want {
 				t.Errorf("GetCNStatefulSetName() = %v, want %v", got, tt.want)
@@ -176,11 +176,11 @@ func TestStarRocksObject_GetWarehouseNameInFE(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			object := &StarRocksObject{
-				ObjectMeta:        tt.fields.ObjectMeta,
-				ClusterName:       tt.fields.ClusterName,
-				Kind:              tt.fields.Kind,
-				AliasName:         tt.fields.AliasName,
-				IsWarehouseObject: tt.fields.IsWarehouseObject,
+				ObjectMeta:            tt.fields.ObjectMeta,
+				ClusterName:           tt.fields.ClusterName,
+				Kind:                  tt.fields.Kind,
+				SubResourcePrefixName: tt.fields.AliasName,
+				IsWarehouseObject:     tt.fields.IsWarehouseObject,
 			}
 			if got := object.GetWarehouseNameInFE(); got != tt.want {
 				t.Errorf("GetWarehouseNameInFE() = %v, want %v", got, tt.want)

--- a/pkg/k8sutils/templates/statefulset/spec.go
+++ b/pkg/k8sutils/templates/statefulset/spec.go
@@ -66,20 +66,20 @@ func MakeStatefulset(object srobject.StarRocksObject, spec v1.SpecInterface, pod
 	or := metav1.NewControllerRef(object, object.GroupVersionKind())
 	expectSTS := appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            load.Name(object.AliasName, spec),
+			Name:            load.Name(object.SubResourcePrefixName, spec),
 			Namespace:       object.Namespace,
 			Annotations:     load.Annotations(),
-			Labels:          load.Labels(object.AliasName, spec),
+			Labels:          load.Labels(object.SubResourcePrefixName, spec),
 			OwnerReferences: []metav1.OwnerReference{*or},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: spec.GetReplicas(),
 			Selector: &metav1.LabelSelector{
-				MatchLabels: load.Selector(object.AliasName, spec),
+				MatchLabels: load.Selector(object.SubResourcePrefixName, spec),
 			},
 			UpdateStrategy:       *spec.GetUpdateStrategy(),
 			Template:             *podTemplateSpec,
-			ServiceName:          service.SearchServiceName(object.AliasName, spec),
+			ServiceName:          service.SearchServiceName(object.SubResourcePrefixName, spec),
 			VolumeClaimTemplates: PVCList(spec.GetStorageVolumes()),
 			PodManagementPolicy:  appsv1.ParallelPodManagement,
 		},

--- a/pkg/subcontrollers/cn/cn_controller_test.go
+++ b/pkg/subcontrollers/cn/cn_controller_test.go
@@ -253,7 +253,7 @@ func Test_SyncWarehouse(t *testing.T) {
 	object := object.NewFromWarehouse(warehouse)
 	require.NoError(t, cc.k8sClient.Get(context.Background(),
 		types.NamespacedName{
-			Name:      service.ExternalServiceName(object.AliasName, (*srapi.StarRocksCnSpec)(nil)),
+			Name:      service.ExternalServiceName(object.SubResourcePrefixName, (*srapi.StarRocksCnSpec)(nil)),
 			Namespace: "default",
 		},
 		&externalService),
@@ -262,7 +262,7 @@ func Test_SyncWarehouse(t *testing.T) {
 
 	require.NoError(t, cc.k8sClient.Get(context.Background(),
 		types.NamespacedName{
-			Name:      service.SearchServiceName(object.AliasName, (*srapi.StarRocksCnSpec)(nil)),
+			Name:      service.SearchServiceName(object.SubResourcePrefixName, (*srapi.StarRocksCnSpec)(nil)),
 			Namespace: "default"},
 		&searchService),
 	)
@@ -270,7 +270,7 @@ func Test_SyncWarehouse(t *testing.T) {
 
 	require.NoError(t, cc.k8sClient.Get(context.Background(),
 		types.NamespacedName{
-			Name:      load.Name(object.AliasName, (*srapi.StarRocksCnSpec)(nil)),
+			Name:      load.Name(object.SubResourcePrefixName, (*srapi.StarRocksCnSpec)(nil)),
 			Namespace: "default"},
 		&sts),
 	)
@@ -326,9 +326,9 @@ func TestCnController_UpdateStatus(t *testing.T) {
 						Name:      "test",
 						Namespace: "default",
 					},
-					ClusterName: "test",
-					Kind:        object.StarRocksClusterKind,
-					AliasName:   "test",
+					ClusterName:           "test",
+					Kind:                  object.StarRocksClusterKind,
+					SubResourcePrefixName: "test",
 				},
 				cnSpec:   &srapi.StarRocksCnSpec{},
 				cnStatus: &srapi.StarRocksCnStatus{},
@@ -819,9 +819,9 @@ func TestCnController_SyncComputeNodesInFE(t *testing.T) {
 						Name:      "wh1",
 						Namespace: "default",
 					},
-					ClusterName:       "cluster",
-					AliasName:         "wh1-warehouse",
-					IsWarehouseObject: true,
+					ClusterName:           "cluster",
+					SubResourcePrefixName: "wh1-warehouse",
+					IsWarehouseObject:     true,
 				},
 				expectSTS: &appsv1.StatefulSet{
 					TypeMeta: metav1.TypeMeta{

--- a/pkg/subcontrollers/cn/cn_pod.go
+++ b/pkg/subcontrollers/cn/cn_pod.go
@@ -66,7 +66,7 @@ func (cc *CnController) buildPodTemplate(ctx context.Context, object srobject.St
 		if cc.addEnvForWarehouse || cc.addWarehouseEnv(ctx, url) {
 			envs = append(envs, corev1.EnvVar{
 				Name: "KUBE_STARROCKS_MULTI_WAREHOUSE",
-				// the cn_entrypoint.sh in container will use this env to create warehouse. Because of '-' character
+				// the cn_entrypoint.sh in container will use this env to create a warehouse. Because of '-' character
 				// is not allowed in Warehouse SQL, so we replace it with '_'.
 				Value: object.GetWarehouseNameInFE(),
 			})
@@ -108,7 +108,7 @@ func (cc *CnController) buildPodTemplate(ctx context.Context, object srobject.St
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: annotations,
 			Namespace:   object.Namespace,
-			Labels:      pod.Labels(object.AliasName, cnSpec),
+			Labels:      pod.Labels(object.SubResourcePrefixName, cnSpec),
 		},
 		Spec: podSpec,
 	}, nil


### PR DESCRIPTION
# Description

1. rename field. AliasName is not a good name, and rename it to SubResourcePrefixName.
2. Use the correct warehouse name in FE(should replace - to _)

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.