### PR TITLE
[BugFix] Rename the short name for warehouse

### DIFF
--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: StarRocksWarehouseList
     plural: starrockswarehouses
     shortNames:
-    - warehouse
+    - warehouses
     singular: starrockswarehouse
   scope: Namespaced
   versions:

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: StarRocksWarehouseList
     plural: starrockswarehouses
     shortNames:
-    - warehouse
+    - warehouses
     singular: starrockswarehouse
   scope: Namespaced
   versions:

--- a/pkg/apis/starrocks/v1/starrockswarehouse_types.go
+++ b/pkg/apis/starrocks/v1/starrockswarehouse_types.go
@@ -65,7 +65,7 @@ type StarRocksWarehouseStatus struct {
 // StarRocksWarehouse defines a starrocks warehouse.
 // +kubebuilder:object:root=true
 // +kubebuilder:metadata:annotations="version=v1.10.2"
-// +kubebuilder:resource:shortName=warehouse
+// +kubebuilder:resource:shortName=warehouses
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.template.replicas,statuspath=.status.replicas,selectorpath=.status.selector


### PR DESCRIPTION
# Description

Rename the short name for warehouse, so that we can do like this:
```
➜  kubectl get warehouses
NAME   STATUS    REASON
wh-1   running
```
# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.