### PR TITLE
[BugFix] Remove -g parameter for some lower SR versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ gen-crd-api-reference-docs-master/
 
 temp/
 cmd/cmd
+
+CLAUDE.md

--- a/pkg/apis/starrocks/v1/load_type.go
+++ b/pkg/apis/starrocks/v1/load_type.go
@@ -57,6 +57,9 @@ type loadInterface interface {
 
 	// GetImagePullPolicy returns the image pull policy for containers
 	GetImagePullPolicy() corev1.PullPolicy
+
+	// GetImage returns the container image to use
+	GetImage() string
 }
 
 var _ loadInterface = &StarRocksLoadSpec{}
@@ -200,6 +203,10 @@ type StarRocksLoadSpec struct {
 	// Optional: Default to false.
 	// +optional
 	ShareProcessNamespace *bool `json:"shareProcessNamespace,omitempty"`
+}
+
+func (spec *StarRocksLoadSpec) GetImage() string {
+	return spec.Image
 }
 
 // StarRocksService defines external service for starrocks component.

--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -387,9 +387,21 @@ func GetPreStopCommand(spec v1.SpecInterface) []string {
 	case *v1.StarRocksFeSpec:
 		command = append(command, fmt.Sprintf("%s/fe/bin/stop_fe.sh -g", GetStarRocksRootPath(v.FeEnvVars)))
 	case *v1.StarRocksBeSpec:
-		command = append(command, fmt.Sprintf("%s/be/bin/stop_be.sh -g", GetStarRocksRootPath(v.BeEnvVars)))
+		imageVersion := GetImageVersion(spec.GetImage())
+		b, err := IsLowerThanAny(imageVersion, []string{"3.3.19", "3.4.8", "3.5.6"})
+		if err == nil || b {
+			command = append(command, fmt.Sprintf("%s/be/bin/stop_be.sh", GetStarRocksRootPath(v.BeEnvVars)))
+		} else {
+			command = append(command, fmt.Sprintf("%s/be/bin/stop_be.sh -g", GetStarRocksRootPath(v.BeEnvVars)))
+		}
 	case *v1.StarRocksCnSpec:
-		command = append(command, fmt.Sprintf("%s/cn/bin/stop_cn.sh -g", GetStarRocksRootPath(v.CnEnvVars)))
+		imageVersion := GetImageVersion(spec.GetImage())
+		b, err := IsLowerThanAny(imageVersion, []string{"3.3.17", "3.4.6", "3.5.2"})
+		if err == nil || b {
+			command = append(command, fmt.Sprintf("%s/cn/bin/stop_cn.sh", GetStarRocksRootPath(v.CnEnvVars)))
+		} else {
+			command = append(command, fmt.Sprintf("%s/cn/bin/stop_cn.sh -g", GetStarRocksRootPath(v.CnEnvVars)))
+		}
 	}
 	return command
 }

--- a/pkg/k8sutils/templates/pod/version_compare.go
+++ b/pkg/k8sutils/templates/pod/version_compare.go
@@ -1,7 +1,6 @@
 package pod
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -39,7 +38,7 @@ func IsLowerThanAny(checkVersion string, targetVersions []string) (bool, error) 
 		}
 	}
 
-	return false, errors.New(fmt.Sprintf("version %s not in target versions", checkVersion))
+	return false, fmt.Errorf("version %s not in target versions", checkVersion)
 }
 
 // for version formats like "3.3-latest", it will return invalid format error

--- a/pkg/k8sutils/templates/pod/version_compare.go
+++ b/pkg/k8sutils/templates/pod/version_compare.go
@@ -1,0 +1,82 @@
+package pod
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func IsLowerThanAny(checkVersion string, targetVersions []string) (bool, error) {
+	if strings.Contains(checkVersion, "latest") {
+		return false, nil
+	}
+
+	checkVer, err := parseVersion(checkVersion)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse check version %s: %w", checkVersion, err)
+	}
+
+	for _, targetVersion := range targetVersions {
+		targetVer, err := parseVersion(targetVersion)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse target version %s: %w", targetVersion, err)
+		}
+
+		// check whether the major and minor versions are the same
+		if checkVer.Major == targetVer.Major && checkVer.Minor == targetVer.Minor {
+			// In the same major and minor version, compare the patch version
+			if checkVer.Patch < targetVer.Patch {
+				return true, nil
+			}
+			return false, nil
+		}
+	}
+
+	return false, errors.New(fmt.Sprintf("version %s not in target versions", checkVersion))
+}
+
+// for version formats like "3.3-latest", it will return invalid format error
+func parseVersion(versionStr string) (Version, error) {
+	// handle non-standard formats, remove the part after the hyphen
+	parts := strings.Split(versionStr, "-")
+	versionCore := parts[0]
+
+	// parse the core version part
+	versionParts := strings.Split(versionCore, ".")
+	if len(versionParts) != 3 {
+		return Version{}, fmt.Errorf("invalid version format: %s", versionStr)
+	}
+
+	major, err := strconv.Atoi(versionParts[0])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid major version: %s", versionParts[0])
+	}
+
+	minor, err := strconv.Atoi(versionParts[1])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid minor version: %s", versionParts[1])
+	}
+
+	patch, err := strconv.Atoi(versionParts[2])
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid patch version: %s", versionParts[2])
+	}
+
+	return Version{
+		Major: major,
+		Minor: minor,
+		Patch: patch,
+	}, nil
+}
+
+func GetImageVersion(image string) string {
+	parts := strings.LastIndex(image, ":")
+	return image[parts+1:]
+}

--- a/pkg/k8sutils/templates/pod/version_compare_test.go
+++ b/pkg/k8sutils/templates/pod/version_compare_test.go
@@ -1,0 +1,337 @@
+package pod
+
+import (
+	"testing"
+)
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Version
+		hasError bool
+	}{
+		{
+			name:     "valid standard version",
+			input:    "3.3.17",
+			expected: Version{Major: 3, Minor: 3, Patch: 17},
+			hasError: false,
+		},
+		{
+			name:     "valid version with suffix",
+			input:    "3.3.17-rc1",
+			expected: Version{Major: 3, Minor: 3, Patch: 17},
+			hasError: false,
+		},
+		{
+			name:     "valid version with complex suffix",
+			input:    "3.4.6-alpha.1.beta",
+			expected: Version{Major: 3, Minor: 4, Patch: 6},
+			hasError: false,
+		},
+		{
+			name:     "invalid format - missing patch",
+			input:    "3.3",
+			expected: Version{},
+			hasError: true,
+		},
+		{
+			name:     "invalid format - too many parts",
+			input:    "3.3.17.1",
+			expected: Version{},
+			hasError: true,
+		},
+		{
+			name:     "invalid major version",
+			input:    "a.3.17",
+			expected: Version{},
+			hasError: true,
+		},
+		{
+			name:     "invalid minor version",
+			input:    "3.b.17",
+			expected: Version{},
+			hasError: true,
+		},
+		{
+			name:     "invalid patch version",
+			input:    "3.3.c",
+			expected: Version{},
+			hasError: true,
+		},
+		{
+			name:     "invalid patch version",
+			input:    "3.3-latest",
+			expected: Version{},
+			hasError: true,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: Version{},
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseVersion(tt.input)
+			if tt.hasError {
+				if err == nil {
+					t.Errorf("expected error for input %s, but got none", tt.input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for input %s: %v", tt.input, err)
+				}
+				if result != tt.expected {
+					t.Errorf("for input %s, expected %+v, got %+v", tt.input, tt.expected, result)
+				}
+			}
+		})
+	}
+}
+
+func TestIsLowerThanAny(t *testing.T) {
+	targetVersions := []string{"3.3.17", "3.4.6", "3.5.2"}
+
+	tests := []struct {
+		name         string
+		checkVersion string
+		expected     bool
+		hasError     bool
+	}{
+		{
+			name:         "lower than 3.3.17",
+			checkVersion: "3.3.9",
+			expected:     true,
+			hasError:     false,
+		},
+		{
+			name:         "lower than 3.3.17",
+			checkVersion: "3.3.9-ee",
+			expected:     true,
+			hasError:     false,
+		},
+		{
+			name:         "lower than 3.3.17",
+			checkVersion: "3.3.16",
+			expected:     true,
+			hasError:     false,
+		},
+		{
+			name:         "lower than 3.3.17",
+			checkVersion: "3.3.16-ee",
+			expected:     true,
+			hasError:     false,
+		},
+		{
+			name:         "lower than 3.3.17",
+			checkVersion: "3.3-latest",
+			expected:     false,
+			hasError:     false,
+		},
+		{
+			name:         "equal to 3.3.17",
+			checkVersion: "3.3.17",
+			expected:     false,
+			hasError:     false,
+		},
+		{
+			name:         "equal to 3.3.17",
+			checkVersion: "3.3.17-ee",
+			expected:     false,
+			hasError:     false,
+		},
+		{
+			name:         "higher than 3.3.17",
+			checkVersion: "3.3.18",
+			expected:     false,
+			hasError:     false,
+		},
+		{
+			name:         "higher than 3.3.17",
+			checkVersion: "3.3.18-ee",
+			expected:     false,
+			hasError:     false,
+		},
+		{
+			name:         "lower than 3.4.6",
+			checkVersion: "3.4.5",
+			expected:     true,
+			hasError:     false,
+		},
+		{
+			name:         "lower than 3.5.2",
+			checkVersion: "3.5.1",
+			expected:     true,
+			hasError:     false,
+		},
+		{
+			name:         "higher than 3.5.2",
+			checkVersion: "3.5.10",
+			expected:     false,
+			hasError:     false,
+		},
+		{
+			name:         "higher than 3.5.2  -2",
+			checkVersion: "4.0.0",
+			expected:     false,
+			hasError:     true,
+		},
+		{
+			name:         "different major.minor - 3.2.x",
+			checkVersion: "3.2.20",
+			expected:     false,
+			hasError:     true,
+		},
+		{
+			name:         "different major.minor - 3.6.x",
+			checkVersion: "3.6.1",
+			expected:     false,
+			hasError:     true,
+		},
+		{
+			name:         "different major version",
+			checkVersion: "4.3.16",
+			expected:     false,
+			hasError:     true,
+		},
+		{
+			name:         "version with suffix - lower",
+			checkVersion: "3.3.16-rc1",
+			expected:     true,
+			hasError:     false,
+		},
+		{
+			name:         "version with suffix - equal",
+			checkVersion: "3.3.17-beta",
+			expected:     false,
+			hasError:     false,
+		},
+		{
+			name:         "version with suffix - higher",
+			checkVersion: "3.3.18-alpha",
+			expected:     false,
+			hasError:     false,
+		},
+		{
+			name:         "invalid check version format",
+			checkVersion: "3.3",
+			expected:     false,
+			hasError:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := IsLowerThanAny(tt.checkVersion, targetVersions)
+			if tt.hasError {
+				if err == nil {
+					t.Errorf("expected error for checkVersion %s, but got none", tt.checkVersion)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for checkVersion %s: %v", tt.checkVersion, err)
+				}
+				if result != tt.expected {
+					t.Errorf("IsLowerThanAny(%s, %v) = %t, expected %t", tt.checkVersion, targetVersions, result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestIsLowerThanAnyWithInvalidTargetVersions(t *testing.T) {
+	tests := []struct {
+		name           string
+		checkVersion   string
+		targetVersions []string
+		hasError       bool
+	}{
+		{
+			name:           "empty target versions",
+			checkVersion:   "3.3.16",
+			targetVersions: []string{},
+			hasError:       true,
+		},
+		{
+			name:           "all valid versions",
+			checkVersion:   "3.3.16",
+			targetVersions: []string{"3.3.17", "3.4.6", "3.5.2"},
+			hasError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := IsLowerThanAny(tt.checkVersion, tt.targetVersions)
+			if tt.hasError {
+				if err == nil {
+					t.Errorf("expected error for targetVersions %v, but got none", tt.targetVersions)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for targetVersions %v: %v", tt.targetVersions, err)
+				}
+			}
+		})
+	}
+}
+
+func TestIsLowerThanAnyEdgeCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		checkVersion   string
+		targetVersions []string
+		expected       bool
+		hasError       bool
+	}{
+		{
+			name:           "multiple matching major.minor versions",
+			checkVersion:   "3.3.15",
+			targetVersions: []string{"3.3.16", "3.3.17", "3.3.18"},
+			expected:       true,
+			hasError:       false,
+		},
+		{
+			name:           "check version higher than all targets in same major.minor",
+			checkVersion:   "3.3.20",
+			targetVersions: []string{"3.3.16", "3.3.17", "3.3.18"},
+			expected:       false,
+			hasError:       false,
+		},
+		{
+			name:           "single target version - lower",
+			checkVersion:   "3.3.16",
+			targetVersions: []string{"3.3.17"},
+			expected:       true,
+			hasError:       false,
+		},
+		{
+			name:           "single target version - higher",
+			checkVersion:   "3.3.18",
+			targetVersions: []string{"3.3.17"},
+			expected:       false,
+			hasError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := IsLowerThanAny(tt.checkVersion, tt.targetVersions)
+			if tt.hasError {
+				if err == nil {
+					t.Errorf("expected error, but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("IsLowerThanAny(%s, %v) = %t, expected %t", tt.checkVersion, tt.targetVersions, result, tt.expected)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

If users are using older versions of the BE/CN Image, data loss may occur if the container is restarted (for example, upgrading the container image or changing environment variables) during parallel data import. This error is caused by the graceful shutdown parameter `-g` added in `stop_cn.sh` or `stop_be.sh`. Therefore, we have modified the default preStop configuration. The strategy is as follows:
1. For shared-data mode: versions lower than 3.3.17, 3.4.6, and 3.5.2.
2. For shared-nothing mode: versions lower than 3.3.19, 3.4.8, and 3.5.6.

When users use these older versions, the `-g` parameter will no longer be added to the default preStop parameters.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.