### PR TITLE
feat: add dnsConfig and dnsPolicy support to pod specs

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -190,6 +190,18 @@ starrocksCluster:
       #     topologyKey: "kubernetes.io/hostname"
     # the pod labels for user select or classify pods.
     podLabels: {}
+    # DNS configuration for all StarRocks components
+    # dnsPolicy defines how DNS resolution is handle for the pods
+    dnsPolicy: "" # Default: ClusterFirst
+
+    # dnsConfig defines custom DNS parameters for the pods
+    dnsConfig: {}
+    #    nameservers:
+    #      - 8.8.8.8
+    #    searches:
+    #    options:
+    #      - name: ndots
+    #        value: "2"
 
 # spec to deploy fe.
 starrocksFESpec:

--- a/pkg/apis/starrocks/v1/component_type.go
+++ b/pkg/apis/starrocks/v1/component_type.go
@@ -76,6 +76,15 @@ type StarRocksComponentSpec struct {
 	// See https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#Container for how to configure a container.
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
 
+	// DNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.
+	// +optional
+	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+
+	// DNSPolicy defines the DNS policy for the pod.
+	// Defaults to "ClusterFirst".
+	// + optional
+	DNSPolicy corev1.DNSPolicy `json:"dnsPolicy,omitempty"`
+
 	// Entrypoint array. Not executed within a shell.
 	// If this is not provided, it will use default entrypoint for different components:
 	//	1. For FE, it will use /opt/starrocks/fe_entrypoint.sh as the entrypoint.
@@ -224,6 +233,15 @@ func (spec *StarRocksComponentSpec) GetSidecars() []corev1.Container {
 
 func (spec *StarRocksComponentSpec) GetInitContainers() []corev1.Container {
 	return spec.InitContainers
+}
+
+func (spec *StarRocksComponentSpec) GetDNSConfig() *corev1.PodDNSConfig { return spec.DNSConfig }
+
+func (spec *StarRocksComponentSpec) GetDNSPolicy() corev1.DNSPolicy {
+	if spec.DNSPolicy == "" {
+		return corev1.DNSClusterFirst
+	}
+	return spec.DNSPolicy
 }
 
 func (spec *StarRocksComponentSpec) GetCommand() []string {

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -61,6 +61,12 @@ type SpecInterface interface {
 	// Init containers run to completion in order, before the main containers start.
 	GetInitContainers() []corev1.Container
 
+	// GetDNSConfig returns the DNS configuration for the pod.
+	GetDNSConfig() *corev1.PodDNSConfig
+
+	// GetDNSPolicy returns the DNS policy for the pod.
+	GetDNSPolicy() corev1.DNSPolicy
+
 	// IsReadOnlyRootFilesystem returns whether the container's root filesystem should be read-only.
 	// A read-only root filesystem prevents modifications to improve security.
 	IsReadOnlyRootFilesystem() *bool
@@ -281,6 +287,12 @@ func (spec *StarRocksFeProxySpec) GetSidecars() []corev1.Container {
 // that StarRocksFeProxySpec needs to implement SpecInterface interface
 func (spec *StarRocksFeProxySpec) GetInitContainers() []corev1.Container {
 	return nil
+}
+
+func (spec *StarRocksFeProxySpec) GetDNSConfig() *corev1.PodDNSConfig { return nil }
+
+func (spec *StarRocksFeProxySpec) GetDNSPolicy() corev1.DNSPolicy {
+	return corev1.DNSClusterFirst
 }
 
 // GetCommand

--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -273,6 +273,8 @@ func Spec(spec v1.SpecInterface, container corev1.Container, volumes []corev1.Vo
 	podSpec := corev1.PodSpec{
 		InitContainers:                spec.GetInitContainers(),
 		Containers:                    containers,
+		DNSConfig:                     spec.GetDNSConfig(),
+		DNSPolicy:                     spec.GetDNSPolicy(),
 		Volumes:                       volumes,
 		ServiceAccountName:            spec.GetServiceAccount(),
 		TerminationGracePeriodSeconds: spec.GetTerminationGracePeriodSeconds(),


### PR DESCRIPTION
## Description

This PR adds support for `dnsConfig` and `dnsPolicy` fields in pod specs.
Currently, the operator does not allow configuring these fields, which limits DNS customization in certain environments.
The changes include updates to both the operator code and the Helm chart to expose these configurations.

## Use Cases

Custom DNS Servers for corporate networks or air-gapped environments:
```yaml
apiVersion: starrocks.com/v1
kind: StarRocksCluster
spec:
   starRocksFeSpec:
        dnsPolicy: ClusterFirst
        dnsConfig:
           nameservers:
           - 8.8.8.8
           options:
           - name: nodts
              value: "2"

```


## Checklist

For operator, please complete the following checklist:
	•	run make generate to generate the code.
	•	run golangci-lint run to check the code style.
	•	run make test to run UT.
	•	run make manifests to update the yaml files of CRD.

For helm chart, please complete the following checklist:
	•	make sure you have updated the [values.yaml](https://github.com/StarRocks/starrocks-kubernetes-operator/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml) file of starrocks chart.
	•	In scripts directory, run bash create-parent-chart-values.sh to update the values.yaml file of the parent chart (kube-starrocks chart).