### PR TITLE
[BugFix] Fix null pointer error when FE spec is missing

### DIFF
--- a/pkg/controllers/starrockscluster_controller.go
+++ b/pkg/controllers/starrockscluster_controller.go
@@ -141,10 +141,13 @@ func (r *StarRocksClusterReconciler) UpdateStarRocksClusterStatus(ctx context.Co
 func (r *StarRocksClusterReconciler) reconcileStatus(_ context.Context, src *srapi.StarRocksCluster) {
 	src.Status.Phase = srapi.ClusterRunning
 	src.Status.Reason = ""
-	phase := GetPhaseFromComponent(&src.Status.StarRocksFeStatus.StarRocksComponentStatus)
-	if phase != "" {
-		src.Status.Phase = phase
-		return
+	var phase srapi.Phase
+	if src.Status.StarRocksFeStatus != nil {
+		phase = GetPhaseFromComponent(&src.Status.StarRocksFeStatus.StarRocksComponentStatus)
+		if phase != "" {
+			src.Status.Phase = phase
+			return
+		}
 	}
 	if src.Status.StarRocksBeStatus != nil {
 		phase = GetPhaseFromComponent(&src.Status.StarRocksBeStatus.StarRocksComponentStatus)


### PR DESCRIPTION
# Description

When a user provides a wrong StarRocksCluster Object, mainly because it does not contain the FE Spec section, for example:

```
apiVersion: starrocks.com/v1
kind: StarRocksCluster
metadata:
  name: bee
spec:
  starRocksBeSpec:
    image: starrocks/be-ubuntu:3.5.6
    replicas: 1
    requests:
      cpu: 1
      memory: 1Gi
    beEnvVars:
    - name: FE_SERVICE_NAME
      value: 10.244.0.18
    args:
    - "$(FE_SERVICE_NAME)"
```

It will cause the null pointer error which make operator can not work.