### PR TITLE
[Enhancement] Use Three way merge patch to update sub resources

### DIFF
--- a/pkg/common/resource_utils/service.go
+++ b/pkg/common/resource_utils/service.go
@@ -267,7 +267,7 @@ func getExternalServiceLabels(svc *srapi.StarRocksService) map[string]string {
 	return map[string]string{}
 }
 
-func ServiceDeepEqual(expectSvc, actualSvc *corev1.Service) bool {
+func ServiceDeepEqual(expectSvc, actualSvc *corev1.Service) (string, bool) {
 	var expectHashValue string
 	if _, ok := expectSvc.Annotations[srapi.ComponentResourceHash]; ok {
 		expectHashValue = expectSvc.Annotations[srapi.ComponentResourceHash]
@@ -284,7 +284,7 @@ func ServiceDeepEqual(expectSvc, actualSvc *corev1.Service) bool {
 		actualHashValue = hash.HashObject(serviceHashObject(actualSvc))
 	}
 
-	return expectHashValue == actualHashValue && expectSvc.Namespace == actualSvc.Namespace
+	return expectHashValue, expectHashValue == actualHashValue && expectSvc.Namespace == actualSvc.Namespace
 }
 
 func serviceHashObject(svc *corev1.Service) hashService {

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -599,7 +599,7 @@ func getConfigFromConfigMaps(ctx context.Context, k8sClient client.Client,
 // BuildNodeSelectorPatch builds a JSON patch that sets keys to new values
 // and sets keys that exist in actual but missing in expect to null.
 func BuildNodeSelectorPatch(expectSel, actualSel map[string]string) ([]byte, error) {
-	if expectSel == nil && actualSel == nil || reflect.DeepEqual(expectSel, actualSel) {
+	if (expectSel == nil && actualSel == nil) || reflect.DeepEqual(expectSel, actualSel) {
 		return nil, nil
 	}
 

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -45,7 +45,7 @@ import (
 )
 
 // ServiceEqual judges two services equal or not in some fields. developer can custom the function.
-type ServiceEqual func(expect *corev1.Service, actual *corev1.Service) bool
+type ServiceEqual func(expect *corev1.Service, actual *corev1.Service) (string, bool)
 
 // StatefulSetEqual judges two statefulset equal or not in some fields. developer can custom the function.
 type StatefulSetEqual func(expect *appsv1.StatefulSet, actual *appsv1.StatefulSet) (string, bool)
@@ -67,13 +67,18 @@ func ApplyService(ctx context.Context, k8sClient client.Client, expectSvc *corev
 		return err
 	}
 
-	if equal(expectSvc, &actualSvc) {
+	newHashValue, b := equal(expectSvc, &actualSvc)
+	if b {
 		logger.Info("expectHash == actualHash, no need to update service resource")
 		return nil
 	}
 
 	expectSvc.ResourceVersion = actualSvc.ResourceVersion
-	return k8sClient.Patch(ctx, expectSvc, client.Merge)
+	if expectSvc.Annotations == nil {
+		expectSvc.Annotations = map[string]string{}
+	}
+	expectSvc.Annotations[srapi.ComponentResourceHash] = newHashValue
+	return PatchByThreeWayMerge(ctx, k8sClient, expectSvc, &actualSvc)
 }
 
 func ApplyDeployment(ctx context.Context, k8sClient client.Client, deploy *appsv1.Deployment) error {
@@ -110,7 +115,8 @@ func ApplyDeployment(ctx context.Context, k8sClient client.Client, deploy *appsv
 		deploy.Annotations = map[string]string{}
 	}
 	deploy.Annotations[srapi.ComponentResourceHash] = expectHash
-	return k8sClient.Patch(ctx, deploy, client.Merge)
+
+	return PatchByThreeWayMerge(ctx, k8sClient, deploy, &actual)
 }
 
 func ApplyConfigMap(ctx context.Context, k8sClient client.Client, configmap *corev1.ConfigMap) error {
@@ -192,26 +198,29 @@ func ApplyStatefulSet(ctx context.Context, k8sClient client.Client, expect *apps
 	return PatchByThreeWayMerge(ctx, k8sClient, expect, &actual)
 }
 
-// PatchByThreeWayMerge Use Client-Side Three-Way Merge
+// PatchByThreeWayMerge applies a client-side three-way merge patch to any Kubernetes object.
+// Supports both map and list merging/deletion, based on last applied configuration.
 // The reason why we use Three-Way Merge Patch is that:
 //   1. avoid the fields managed by other controllers being overwritten.
 //   2. allow users to delete some fields they set in the previous reconciliation, e.g., nodeSelector, tolerations, etc.
 // First we changed the method from Update to Patch, and used the json merge patch strategy. But json merge patch does not
-// support removing fields from map, also it use a complete new list to replace the old list.
-// So we changed to use Strategic Merge Patch, which supports removing fields from map, and merging lists based on the
-// last applied configuration, expected state, and actual state.
-func PatchByThreeWayMerge(ctx context.Context, k8sClient client.Client, expect, actual *appsv1.StatefulSet) error {
+// support removing fields from map, also it use a complete new list to replace the old list. So we changed to use
+// Strategic Merge Patch, which supports removing fields from map, and merging lists based on the last applied
+// configuration, expected state, and actual state.
+func PatchByThreeWayMerge(ctx context.Context, k8sClient client.Client, expect, actual client.Object) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
-	// 1. Get the last applied configuration
+	// 1. Get last applied configuration
 	// If there is no last applied configuration, we let it be an empty JSON object, which means all fields in the
 	// actual statefulset are user-modified, but not operator-modified.
 	var lastAppliedBytes []byte
-	if lastAppliedConfig, ok := actual.Annotations[LastAppliedConfigAnnotation]; ok {
-		lastAppliedBytes = []byte(lastAppliedConfig)
+	if actual.GetAnnotations() != nil {
+		if lastAppliedConfig, ok := actual.GetAnnotations()[LastAppliedConfigAnnotation]; ok {
+			lastAppliedBytes = []byte(lastAppliedConfig)
+		}
 	}
 
-	// 2. Marshal the expected state, and actual state
+	// 2. Marshal expected and actual objects
 	expectBytes, err := json.Marshal(expect)
 	if err != nil {
 		return fmt.Errorf("failed to marshal expected state: %w", err)
@@ -221,42 +230,48 @@ func PatchByThreeWayMerge(ctx context.Context, k8sClient client.Client, expect, 
 		return fmt.Errorf("failed to marshal actual state: %w", err)
 	}
 
-	// 3. calculate the strategic merge patch
-	schema, err := strategicpatch.NewPatchMetaFromStruct(&appsv1.StatefulSet{})
+	// 3. Determine patch meta based on object's Go type
+	if actual.GetAnnotations() == nil {
+		actual.SetAnnotations(make(map[string]string))
+	}
+	actual.GetAnnotations()[LastAppliedConfigAnnotation] = string(expectBytes)
+	patchMeta, err := strategicpatch.NewPatchMetaFromStruct(expect)
 	if err != nil {
 		return fmt.Errorf("failed to create patch meta: %w", err)
 	}
+
+	// 4. Create three-way merge patch
 	// If overwrite is true, the fields in expectBytes will overwrite the fields in actualBytes.
 	// This means that operator-defined fields (from expectBytes) will always take precedence over any user modifications
 	// made directly to the resource. In other words, user changes to these fields will be overwritten by the operator,
 	// which is a critical behavioral difference from the default (overwrite=false), where user modifications are preserved
 	// unless explicitly changed by the operator.
-	patchBytes, err := strategicpatch.CreateThreeWayMergePatch(lastAppliedBytes, expectBytes, actualBytes, schema, true)
+	patchBytes, err := strategicpatch.CreateThreeWayMergePatch(lastAppliedBytes, expectBytes, actualBytes, patchMeta, true)
 	if err != nil {
 		return fmt.Errorf("failed to create merge patch: %w", err)
 	}
 	if string(patchBytes) == "{}" {
-		logger.Info("no changes detected, skipping update")
+		logger.Info("no changes detected, skipping patch", "name", expect.GetName(), "namespace", expect.GetNamespace())
 		return nil
 	}
 
-	// 4. apply patch. Note: we need to use RawPatch and StrategicMergePatchType here
+	// 5. Apply patch
 	if err := k8sClient.Patch(ctx, actual, client.RawPatch(types.StrategicMergePatchType, patchBytes)); err != nil {
-		return fmt.Errorf("failed to patch statefulset: %w", err)
+		return fmt.Errorf("failed to apply merge patch: %w", err)
 	}
 
-	// 5. update annotation only
+	// 6. Update last applied annotation
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: expect.Namespace, Name: expect.Name}, actual); err != nil {
-			return fmt.Errorf("failed to get statefulset for annotation update: %w", err)
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(expect), actual); err != nil {
+			return fmt.Errorf("failed to get object for annotation update: %w", err)
 		}
-		if actual.Annotations == nil {
-			actual.Annotations = make(map[string]string)
+		if actual.GetAnnotations() == nil {
+			actual.SetAnnotations(make(map[string]string))
 		}
-		actual.Annotations[LastAppliedConfigAnnotation] = string(expectBytes)
+		actual.GetAnnotations()[LastAppliedConfigAnnotation] = string(expectBytes)
 		return k8sClient.Update(ctx, actual)
 	}); err != nil {
-		return fmt.Errorf("failed to update annotation for statefulset: %w", err)
+		return fmt.Errorf("failed to update last applied annotation: %w", err)
 	}
 
 	return nil

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -198,6 +198,7 @@ func ApplyStatefulSet(ctx context.Context, k8sClient client.Client, expect *apps
 		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: expect.Namespace, Name: expect.Name}, &actual); err != nil {
 			return err
 		}
+		expect.ResourceVersion = actual.ResourceVersion
 	}
 	return k8sClient.Patch(ctx, expect, client.Merge)
 }

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -232,7 +232,9 @@ func ApplyStatefulSet(ctx context.Context, k8sClient client.Client, expect *apps
 
 	// 5. update annotation only
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		k8sClient.Get(ctx, types.NamespacedName{Namespace: expect.Namespace, Name: expect.Name}, &actual)
+		if err := k8sClient.Get(ctx, types.NamespacedName{Namespace: expect.Namespace, Name: expect.Name}, &actual); err != nil {
+			return fmt.Errorf("failed to get statefulset for annotation update: %w", err)
+		}
 		if actual.Annotations == nil {
 			actual.Annotations = make(map[string]string)
 		}

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -200,9 +200,8 @@ func ApplyStatefulSet(ctx context.Context, k8sClient client.Client, expect *apps
 
 // PatchByThreeWayMerge applies a client-side three-way merge patch to any Kubernetes object.
 // Supports both map and list merging/deletion, based on last applied configuration.
-// The reason why we use Three-Way Merge Patch is that:
-//   1. avoid the fields managed by other controllers being overwritten.
-//   2. allow users to delete some fields they set in the previous reconciliation, e.g., nodeSelector, tolerations, etc.
+// The reason why we use Three-Way Merge Patch is that: 1. avoid the fields managed by other controllers being
+// overwritten. 2. allow users to delete some fields they set in the previous reconciliation, e.g., nodeSelector etc.
 // First we changed the method from Update to Patch, and used the json merge patch strategy. But json merge patch does not
 // support removing fields from map, also it use a complete new list to replace the old list. So we changed to use
 // Strategic Merge Patch, which supports removing fields from map, and merging lists based on the last applied

--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -215,7 +215,11 @@ func ApplyStatefulSet(ctx context.Context, k8sClient client.Client, expect *apps
 	if err != nil {
 		return fmt.Errorf("failed to create patch meta: %w", err)
 	}
-	// if overwrite is true, the fields in expectBytes will overwrite the fields in actualBytes
+	// If overwrite is true, the fields in expectBytes will overwrite the fields in actualBytes.
+	// This means that operator-defined fields (from expectBytes) will always take precedence over any user modifications
+	// made directly to the resource. In other words, user changes to these fields will be overwritten by the operator,
+	// which is a critical behavioral difference from the default (overwrite=false), where user modifications are preserved
+	// unless explicitly changed by the operator.
 	patchBytes, err := strategicpatch.CreateThreeWayMergePatch(lastAppliedBytes, expectBytes, actualBytes, schema, true)
 	if err != nil {
 		return fmt.Errorf("failed to create merge patch: %w", err)


### PR DESCRIPTION
# Description

PatchByThreeWayMerge applies a client-side three-way merge patch to any Kubernetes object. Supports both map and list merging/deletion, based on last applied configuration. 

The reason why we use Three-Way Merge Patch is that: 
1. avoid the fields managed by other controllers being overwritten.
2. allow users to delete some fields they set in the previous reconciliation, e.g., nodeSelector etc.

First we changed the method from Update to Patch, and used the json merge patch strategy. But json merge patch does not support removing fields from map, also it use a complete new list to replace the old list. So we changed to use Three way Merge Patch, which supports removing fields from map, and merging lists based on the last applied configuration, expected state, and actual state.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

