### PR TITLE
[BugFix] Add last-applied-configuration annotation when resource is created

### DIFF
--- a/pkg/k8sutils/k8sutils.go
+++ b/pkg/k8sutils/k8sutils.go
@@ -277,6 +277,20 @@ func PatchByThreeWayMerge(ctx context.Context, k8sClient client.Client, expect, 
 }
 
 func CreateClientObject(ctx context.Context, k8sClient client.Client, object client.Object) error {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		object.SetAnnotations(make(map[string]string))
+		annotations = object.GetAnnotations()
+	}
+
+	if annotations[LastAppliedConfigAnnotation] == "" {
+		data, err := json.Marshal(object)
+		if err != nil {
+			return err
+		}
+		annotations[LastAppliedConfigAnnotation] = string(data)
+	}
+
 	if err := k8sClient.Create(ctx, object); err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

When sub-resources are created, `last-applied-configuration` annotation should be added. Otherwise, when user tried to remove some fields from StarRocksCluster CR, they will not be removed from applied resource.

```
starrocks.kubernetes.operator/last-applied-configuration: 'xxx'
```

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.