### PR TITLE
Fix-738 add waitForFullRollout option for safer rolling upgrades

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -15461,6 +15461,15 @@ spec:
                         type: string
                     type: object
                 type: object
+              waitForFullRollout:
+                description: |-
+                  WaitForFullRollout controls rolling upgrade behavior. When set to true, the operator
+                  will wait for FE StatefulSet to be fully rolled out (all replicas ready and at the
+                  same revision) before updating BE/CN components. This prevents cascading failures
+                  if a bad FE version is deployed.
+                  When false (default), BE/CN updates can proceed as soon as any FE pod is ready.
+                  Defaults to false for backward compatibility.
+                type: boolean
             type: object
           status:
             description: Most recent observed status of the starrocks cluster

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -7235,6 +7235,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              waitForFullRollout:
+                type: boolean
             type: object
           status:
             properties:

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -118,6 +118,15 @@ type StarRocksClusterSpec struct {
 	// +optional
 	// DisasterRecovery is used to determine whether to enter disaster recovery mode.
 	DisasterRecovery *DisasterRecovery `json:"disasterRecovery,omitempty"`
+
+	// +optional
+	// WaitForFullRollout controls rolling upgrade behavior. When set to true, the operator
+	// will wait for FE StatefulSet to be fully rolled out (all replicas ready and at the
+	// same revision) before updating BE/CN components. This prevents cascading failures
+	// if a bad FE version is deployed.
+	// When false (default), BE/CN updates can proceed as soon as any FE pod is ready.
+	// Defaults to false for backward compatibility.
+	WaitForFullRollout bool `json:"waitForFullRollout,omitempty"`
 }
 
 // StarRocksClusterStatus defines the observed state of StarRocksCluster.

--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -93,6 +93,7 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 		}
 	} else {
 		if !fe.CheckFEReady(ctx, be.Client, src.Namespace, src.Name) {
+			logger.Info("FE is not ready, skipping BE sync")
 			return nil
 		}
 	}

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -129,6 +129,7 @@ func (cc *CnController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 		}
 	} else {
 		if !fe.CheckFEReady(ctx, cc.k8sClient, src.Namespace, src.Name) {
+			logger.Info("FE is not ready, skipping CN sync")
 			return nil
 		}
 	}

--- a/pkg/subcontrollers/fe/fe_controller_test.go
+++ b/pkg/subcontrollers/fe/fe_controller_test.go
@@ -354,6 +354,34 @@ func TestCheckFEFullyRolledOut(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "statefulset with nil replicas - should return true when revisions match",
+			args: args{
+				ctx: context.Background(),
+				k8sClient: fake.NewFakeClient(srapi.Scheme, &appsv1.StatefulSet{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-starrocks-fe",
+						Namespace: "default",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: nil,
+					},
+					Status: appsv1.StatefulSetStatus{
+						ReadyReplicas:   1,
+						UpdatedReplicas: 1,
+						CurrentRevision: "v1",
+						UpdateRevision:  "v1",
+					},
+				}),
+				clusterNamespace: "default",
+				clusterName:      "kube-starrocks",
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

#738 
> the PR should include helm chart changes and operator changes.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ ] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ ] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
