### PR TITLE
feat (helm): add ingress template

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -15461,6 +15461,15 @@ spec:
                         type: string
                     type: object
                 type: object
+              waitForFullRollout:
+                description: |-
+                  WaitForFullRollout controls rolling upgrade behavior. When set to true, the operator
+                  will wait for FE StatefulSet to be fully rolled out (all replicas ready and at the
+                  same revision) before updating BE/CN components. This prevents cascading failures
+                  if a bad FE version is deployed.
+                  When false (default), BE/CN updates can proceed as soon as any FE pod is ready.
+                  Defaults to false for backward compatibility.
+                type: boolean
             type: object
           status:
             description: Most recent observed status of the starrocks cluster

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -7235,6 +7235,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              waitForFullRollout:
+                type: boolean
             type: object
           status:
             properties:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/ingress.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/ingress.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.ingress.enabled }}
+{{- $defaultIngressName := printf "%s-mysql-ingress" (include "starrockscluster.name" .) }}
+{{- $defaultMysqlServiceName := printf "%s-fe-service" (include "starrockscluster.name" .) }}
+{{- $mysqlServiceName := default (default $defaultMysqlServiceName .Values.ingress.serviceName) .Values.ingress.mysqlServiceName }}
+{{- $mysqlServicePort := default .Values.ingress.servicePort .Values.ingress.mysqlServicePort }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "starrockscluster.name" . }}-ingress
+  name: {{ default $defaultIngressName .Values.ingress.name }}
   namespace: {{ template "starrockscluster.namespace" . }}
   labels:
     cluster: {{ template "starrockscluster.name" . }}
@@ -30,12 +34,12 @@ spec:
             pathType: {{ default "Prefix" .pathType }}
             backend:
               service:
-                name: {{ default (printf "%s-fe-service" (include "starrockscluster.name" $)) $.Values.ingress.serviceName }}
+                name: {{ $mysqlServiceName }}
                 port:
-                  {{- if kindIs "string" $.Values.ingress.servicePort }}
-                  name: {{ $.Values.ingress.servicePort }}
+                  {{- if kindIs "string" $mysqlServicePort }}
+                  name: {{ $mysqlServicePort }}
                   {{- else }}
-                  number: {{ $.Values.ingress.servicePort }}
+                  number: {{ $mysqlServicePort }}
                   {{- end }}
           {{- end }}
     {{- end }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/ingress.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "starrockscluster.name" . }}-ingress
+  namespace: {{ template "starrockscluster.namespace" . }}
+  labels:
+    cluster: {{ template "starrockscluster.name" . }}
+    {{- include "starrockscluster.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - {{- if .host }}
+      host: {{ .host | quote }}
+      {{- end }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ default "Prefix" .pathType }}
+            backend:
+              service:
+                name: {{ default (printf "%s-fe-service" (include "starrockscluster.name" $)) $.Values.ingress.serviceName }}
+                port:
+                  {{- if kindIs "string" $.Values.ingress.servicePort }}
+                  name: {{ $.Values.ingress.servicePort }}
+                  {{- else }}
+                  number: {{ $.Values.ingress.servicePort }}
+                  {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -95,17 +95,19 @@ metrics:
       #      - "all"
       params: {}
 
-# Configure Ingress to expose FE TCP endpoint.
+# Configure Ingress to expose the FE MySQL endpoint.
 ingress:
   enabled: false
+  # Override ingress resource name. If empty, defaults to <cluster-name>-mysql-ingress.
+  name: ""
   # If empty, the cluster default ingress class is used.
   ingressClassName: ""
   annotations: {}
   labels: {}
-  # Override backend service name. If empty, defaults to <cluster-name>-fe-service.
-  serviceName: ""
+  # Override backend MySQL service name. If empty, defaults to <cluster-name>-fe-service.
+  mysqlServiceName: ""
   # Can be an integer port (for example, 9030) or named port (for example, "tcp").
-  servicePort: 9030
+  mysqlServicePort: 9030
   # hosts can define one or more rules.
   hosts:
     - host: ""

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -95,6 +95,30 @@ metrics:
       #      - "all"
       params: {}
 
+# Configure Ingress to expose FE TCP endpoint.
+ingress:
+  enabled: false
+  # If empty, the cluster default ingress class is used.
+  ingressClassName: ""
+  annotations: {}
+  labels: {}
+  # Override backend service name. If empty, defaults to <cluster-name>-fe-service.
+  serviceName: ""
+  # Can be an integer port (for example, 9030) or named port (for example, "tcp").
+  servicePort: 9030
+  # hosts can define one or more rules.
+  hosts:
+    - host: ""
+      paths:
+        - path: /
+          pathType: Prefix
+  # TLS blocks for ingress.
+  # tls:
+  #   - secretName: starrocks-tls
+  #     hosts:
+  #       - starrocks.example.com
+  tls: []
+
 # deploy a starrocks cluster
 starrocksCluster:
   # the name of starrockscluster cluster, if not set, the value of nameOverride fields will be used.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -221,17 +221,19 @@ starrocks:
         #      - "all"
         params: {}
   
-  # Configure Ingress to expose FE TCP endpoint.
+  # Configure Ingress to expose the FE MySQL endpoint.
   ingress:
     enabled: false
+    # Override ingress resource name. If empty, defaults to <cluster-name>-mysql-ingress.
+    name: ""
     # If empty, the cluster default ingress class is used.
     ingressClassName: ""
     annotations: {}
     labels: {}
-    # Override backend service name. If empty, defaults to <cluster-name>-fe-service.
-    serviceName: ""
+    # Override backend MySQL service name. If empty, defaults to <cluster-name>-fe-service.
+    mysqlServiceName: ""
     # Can be an integer port (for example, 9030) or named port (for example, "tcp").
-    servicePort: 9030
+    mysqlServicePort: 9030
     # hosts can define one or more rules.
     hosts:
       - host: ""

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -221,6 +221,30 @@ starrocks:
         #      - "all"
         params: {}
   
+  # Configure Ingress to expose FE TCP endpoint.
+  ingress:
+    enabled: false
+    # If empty, the cluster default ingress class is used.
+    ingressClassName: ""
+    annotations: {}
+    labels: {}
+    # Override backend service name. If empty, defaults to <cluster-name>-fe-service.
+    serviceName: ""
+    # Can be an integer port (for example, 9030) or named port (for example, "tcp").
+    servicePort: 9030
+    # hosts can define one or more rules.
+    hosts:
+      - host: ""
+        paths:
+          - path: /
+            pathType: Prefix
+    # TLS blocks for ingress.
+    # tls:
+    #   - secretName: starrocks-tls
+    #     hosts:
+    #       - starrocks.example.com
+    tls: []
+  
   # deploy a starrocks cluster
   starrocksCluster:
     # the name of starrockscluster cluster, if not set, the value of nameOverride fields will be used.

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -118,6 +118,15 @@ type StarRocksClusterSpec struct {
 	// +optional
 	// DisasterRecovery is used to determine whether to enter disaster recovery mode.
 	DisasterRecovery *DisasterRecovery `json:"disasterRecovery,omitempty"`
+
+	// +optional
+	// WaitForFullRollout controls rolling upgrade behavior. When set to true, the operator
+	// will wait for FE StatefulSet to be fully rolled out (all replicas ready and at the
+	// same revision) before updating BE/CN components. This prevents cascading failures
+	// if a bad FE version is deployed.
+	// When false (default), BE/CN updates can proceed as soon as any FE pod is ready.
+	// Defaults to false for backward compatibility.
+	WaitForFullRollout bool `json:"waitForFullRollout,omitempty"`
 }
 
 // StarRocksClusterStatus defines the observed state of StarRocksCluster.

--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -85,8 +85,17 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 		return err
 	}
 
-	if !fe.CheckFEReady(ctx, be.Client, src.Namespace, src.Name) {
-		return nil
+	// Check FE readiness based on WaitForFullRollout setting
+	if src.Spec.WaitForFullRollout {
+		if !fe.CheckFEFullyRolledOut(ctx, be.Client, src.Namespace, src.Name) {
+			logger.Info("FE StatefulSet is not fully rolled out, skipping BE sync to prevent cascading updates")
+			return nil
+		}
+	} else {
+		if !fe.CheckFEReady(ctx, be.Client, src.Namespace, src.Name) {
+			logger.Info("FE is not ready, skipping BE sync")
+			return nil
+		}
 	}
 
 	feSpec := src.Spec.StarRocksFeSpec

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -121,8 +121,17 @@ func (cc *CnController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 		return nil
 	}
 
-	if !fe.CheckFEReady(ctx, cc.k8sClient, src.Namespace, src.Name) {
-		return nil
+	// Check FE readiness based on WaitForFullRollout setting
+	if src.Spec.WaitForFullRollout {
+		if !fe.CheckFEFullyRolledOut(ctx, cc.k8sClient, src.Namespace, src.Name) {
+			logger.Info("FE StatefulSet is not fully rolled out, skipping CN sync to prevent cascading updates")
+			return nil
+		}
+	} else {
+		if !fe.CheckFEReady(ctx, cc.k8sClient, src.Namespace, src.Name) {
+			logger.Info("FE is not ready, skipping CN sync")
+			return nil
+		}
 	}
 
 	feConfig, err := cc.getFeConfig(ctx, src.Namespace, src.Name)

--- a/pkg/subcontrollers/fe/fe_controller_test.go
+++ b/pkg/subcontrollers/fe/fe_controller_test.go
@@ -246,6 +246,152 @@ func TestCheckFEReady(t *testing.T) {
 	}
 }
 
+func TestCheckFEFullyRolledOut(t *testing.T) {
+	type args struct {
+		ctx              context.Context
+		k8sClient        client.Client
+		clusterNamespace string
+		clusterName      string
+	}
+
+	replicas := int32(3)
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "statefulset not found",
+			args: args{
+				ctx:              context.Background(),
+				k8sClient:        fake.NewFakeClient(srapi.Scheme),
+				clusterNamespace: "default",
+				clusterName:      "kube-starrocks",
+			},
+			want: false,
+		},
+		{
+			name: "statefulset not fully ready - some replicas not ready",
+			args: args{
+				ctx: context.Background(),
+				k8sClient: fake.NewFakeClient(srapi.Scheme, &appsv1.StatefulSet{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-starrocks-fe",
+						Namespace: "default",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: &replicas,
+					},
+					Status: appsv1.StatefulSetStatus{
+						ReadyReplicas:   2,
+						CurrentRevision: "v1",
+						UpdateRevision:  "v1",
+					},
+				}),
+				clusterNamespace: "default",
+				clusterName:      "kube-starrocks",
+			},
+			want: false,
+		},
+		{
+			name: "statefulset rolling update in progress - revision mismatch",
+			args: args{
+				ctx: context.Background(),
+				k8sClient: fake.NewFakeClient(srapi.Scheme, &appsv1.StatefulSet{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-starrocks-fe",
+						Namespace: "default",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: &replicas,
+					},
+					Status: appsv1.StatefulSetStatus{
+						ReadyReplicas:   3,
+						UpdatedReplicas: 1,
+						CurrentRevision: "v1",
+						UpdateRevision:  "v2",
+					},
+				}),
+				clusterNamespace: "default",
+				clusterName:      "kube-starrocks",
+			},
+			want: false,
+		},
+		{
+			name: "statefulset fully rolled out",
+			args: args{
+				ctx: context.Background(),
+				k8sClient: fake.NewFakeClient(srapi.Scheme, &appsv1.StatefulSet{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-starrocks-fe",
+						Namespace: "default",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: &replicas,
+					},
+					Status: appsv1.StatefulSetStatus{
+						ReadyReplicas:   3,
+						UpdatedReplicas: 3,
+						CurrentRevision: "v2",
+						UpdateRevision:  "v2",
+					},
+				}),
+				clusterNamespace: "default",
+				clusterName:      "kube-starrocks",
+			},
+			want: true,
+		},
+		{
+			name: "statefulset with nil replicas - should return true when revisions match",
+			args: args{
+				ctx: context.Background(),
+				k8sClient: fake.NewFakeClient(srapi.Scheme, &appsv1.StatefulSet{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "StatefulSet",
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "kube-starrocks-fe",
+						Namespace: "default",
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas: nil,
+					},
+					Status: appsv1.StatefulSetStatus{
+						ReadyReplicas:   1,
+						UpdatedReplicas: 1,
+						CurrentRevision: "v1",
+						UpdateRevision:  "v1",
+					},
+				}),
+				clusterNamespace: "default",
+				clusterName:      "kube-starrocks",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fe.CheckFEFullyRolledOut(tt.args.ctx, tt.args.k8sClient, tt.args.clusterNamespace, tt.args.clusterName); got != tt.want {
+				t.Errorf("CheckFEFullyRolledOut() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetFeConfig(t *testing.T) {
 	type args struct {
 		ctx       context.Context

--- a/pkg/subcontrollers/feproxy/feproxy_configmap.go
+++ b/pkg/subcontrollers/feproxy/feproxy_configmap.go
@@ -97,6 +97,7 @@ http {
       set $fe_service "%[2]s";
       proxy_pass $fe_service;
       proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
       proxy_set_header Expect $http_expect;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -108,6 +109,7 @@ http {
       set $fe_service "%[2]s";
       proxy_pass $fe_service;
       proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
       proxy_set_header Expect $http_expect;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -129,6 +131,7 @@ http {
       proxy_pass $redirect_uri;
       proxy_set_header Expect $http_expect;
       proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
# Description

Since we are not exposing the service via a LoadBalancer and instead rely on an Ingress controller to route traffic to the StarRocks service, an Ingress template is required.

> This PR includes helm chart changes only. No operator changes are included.

# Related Issue(s)

N/A

# Checklist

For operator, please complete the following checklist:

- N/A - This PR includes Helm chart changes only. No operator code changes.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
