### PR TITLE
[BugFix] explicit content-length clear if proxy_pass_request_body is off

### DIFF
--- a/pkg/subcontrollers/feproxy/feproxy_configmap.go
+++ b/pkg/subcontrollers/feproxy/feproxy_configmap.go
@@ -97,6 +97,7 @@ http {
       set $fe_service "%[2]s";
       proxy_pass $fe_service;
       proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
       proxy_set_header Expect $http_expect;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -108,6 +109,7 @@ http {
       set $fe_service "%[2]s";
       proxy_pass $fe_service;
       proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
       proxy_set_header Expect $http_expect;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -129,6 +131,7 @@ http {
       proxy_pass $redirect_uri;
       proxy_set_header Expect $http_expect;
       proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
# Description

Please provide a detailed description of the changes you have made. Include the motivation for these changes, and any
additional context that may be important.
> the PR should include helm chart changes and operator changes.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ ] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ ] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
