### PR TITLE
[Feature] Add `cluster` and `group` metric labels to ServiceMonitor relabelings

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/servicemonitor.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/servicemonitor.yaml
@@ -34,6 +34,11 @@ spec:
           targetLabel: app_starrocks_ownerreference_name
         - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
           targetLabel: app_kubernetes_io_component
+        - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+          targetLabel: group
+        - action: replace
+          replacement: {{ template "starrockscluster.name" . }}
+          targetLabel: cluster
   namespaceSelector:
     matchNames:
       - {{ template "starrockscluster.namespace" . }}
@@ -66,6 +71,11 @@ spec:
           targetLabel: app_starrocks_ownerreference_name
         - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
           targetLabel: app_kubernetes_io_component
+        - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+          targetLabel: group
+        - action: replace
+          replacement: {{ template "starrockscluster.name" . }}
+          targetLabel: cluster
   namespaceSelector:
     matchNames:
       - {{ template "starrockscluster.namespace" . }}
@@ -100,6 +110,11 @@ spec:
           targetLabel: app_starrocks_ownerreference_name
         - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
           targetLabel: app_kubernetes_io_component
+        - sourceLabels: [__meta_kubernetes_service_label_app_kubernetes_io_component]
+          targetLabel: group
+        - action: replace
+          replacement: {{ template "starrockscluster.name" . }}
+          targetLabel: cluster
   namespaceSelector:
     matchNames:
       - {{ template "starrockscluster.namespace" . }}


### PR DESCRIPTION

# Description

This PR only changes the starrocks helm chart.

Each ServiceMonitor endpoint now injects two static labels into all scraped metrics via relabelings:
- `cluster`: set to the StarRocksCluster name => allows to separate metrics from one cluster to another. Although you can sort-of do it with the ownerreference label, semantically I find `cluster` to have a lot more meaning, and it remains the same for BE/FE/CNs whereas ownerreference changes for each subcomponent.
- `group`: set to "fe", "be", or "cn" depending on the component

This makes it straightforward to filter and aggregate metrics by cluster or component group in Prometheus/Grafana queries. 

Also, and more importantly, the official Dashboards use the "group" label to function: https://docs.starrocks.io/docs/administration/management/monitoring/Monitor_and_Alert/#125-configure-dashboard

This eases the importation of the official dashboards in a K8S cluster. It is not sufficient though, the dashboards still need work to be easily importable, notably due to the "cluster" discovery where I think we should only show the actual starrocks clsuters instead of the entirety of `up{}` workloads. With these `cluster` & `group` labels, I think we can have a more easy to understand Dashboard (and then alerts).

Disclosure: some part of the commit was helped with claude. I manually reviewed his changes though.

# Related Issue(s)

This issue might be related: https://github.com/StarRocks/starrocks-kubernetes-operator/issues/730 

But I can't read Chinese so I don't really know.

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

=> didn't do that, because there was no change in CRDs or Golang code.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).

Also, I tested the changes on my own local cluster and the metrics are correcly showing them.
