### PR TITLE
[Feature] Add global.image.registry support for custom registry prefix

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -716,6 +716,69 @@ Get the value of tag field in the starrocksCnSpec
 {{- end -}}
 
 {{/*
+Build the full FE image reference, prepending the registry when set.
+Priority (highest wins): component image.registry > componentValues.image.registry > global.image.registry.
+*/}}
+{{- define "starrockscluster.fe.image" -}}
+{{- $registry := coalesce .Values.starrocksFESpec.image.registry .Values.starrocksCluster.componentValues.image.registry .Values.global.image.registry -}}
+{{- $repo := .Values.starrocksFESpec.image.repository -}}
+{{- $tag := include "starrockscluster.fe.image.tag" . -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Build the full BE image reference, prepending the registry when set.
+Priority (highest wins): component image.registry > componentValues.image.registry > global.image.registry.
+*/}}
+{{- define "starrockscluster.be.image" -}}
+{{- $registry := coalesce .Values.starrocksBeSpec.image.registry .Values.starrocksCluster.componentValues.image.registry .Values.global.image.registry -}}
+{{- $repo := .Values.starrocksBeSpec.image.repository -}}
+{{- $tag := include "starrockscluster.be.image.tag" . -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Build the full CN image reference, prepending the registry when set.
+Priority (highest wins): component image.registry > componentValues.image.registry > global.image.registry.
+*/}}
+{{- define "starrockscluster.cn.image" -}}
+{{- $registry := coalesce .Values.starrocksCnSpec.image.registry .Values.starrocksCluster.componentValues.image.registry .Values.global.image.registry -}}
+{{- $repo := .Values.starrocksCnSpec.image.repository -}}
+{{- $tag := include "starrockscluster.cn.image.tag" . -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Build the full FE proxy image reference, prepending the registry when set.
+Only used when starrocksFeProxySpec.image.repository is non-empty; otherwise
+the operator falls back to its built-in default (nginx:1.24.0).
+Priority (highest wins): component image.registry > global.image.registry.
+Note: feproxy is not covered by componentValues.
+*/}}
+{{- define "starrockscluster.feproxy.image" -}}
+{{- $registry := coalesce .Values.starrocksFeProxySpec.image.registry .Values.global.image.registry -}}
+{{- $repo := .Values.starrocksFeProxySpec.image.repository -}}
+{{- $tag := .Values.starrocksFeProxySpec.image.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get the value of podLabels field in the starrocksFESpec
 */}}
 {{- define "starrockscluster.fe.podLabels" -}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/init-pwd/job.yaml
@@ -35,7 +35,7 @@ spec:
         {{- if .Values.initPassword.image }}
         image: {{ .Values.initPassword.image }}
         {{- else }}
-        image: {{ .Values.starrocksFESpec.image.repository }}:{{ include "starrockscluster.fe.image.tag" . }}
+        image: {{ include "starrockscluster.fe.image" . }}
         {{- end }}
         imagePullPolicy: IfNotPresent
         {{- if .Values.initPassword.resources }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -23,7 +23,7 @@ spec:
     {{- if .Values.starrocksFESpec.shareProcessNamespace }}
     shareProcessNamespace: {{ .Values.starrocksFESpec.shareProcessNamespace }}
     {{- end }}
-    image: "{{ .Values.starrocksFESpec.image.repository }}:{{ include "starrockscluster.fe.image.tag" . }}"
+    image: "{{ include "starrockscluster.fe.image" . }}"
     {{- if .Values.starrocksFESpec.entrypoint }}
     command: ["bash", "-c"]
     args:
@@ -293,7 +293,7 @@ spec:
     {{- if .Values.starrocksBeSpec.shareProcessNamespace }}
     shareProcessNamespace: {{ .Values.starrocksBeSpec.shareProcessNamespace }}
     {{- end }}
-    image: "{{ .Values.starrocksBeSpec.image.repository }}:{{ include "starrockscluster.be.image.tag" . }}"
+    image: "{{ include "starrockscluster.be.image" . }}"
     {{- if .Values.starrocksBeSpec.entrypoint }}
     command: ["bash", "-c"]
     args:
@@ -594,7 +594,7 @@ spec:
     {{- if .Values.starrocksCnSpec.shareProcessNamespace }}
     shareProcessNamespace: {{ .Values.starrocksCnSpec.shareProcessNamespace }}
     {{- end }}
-    image: "{{ .Values.starrocksCnSpec.image.repository }}:{{ include "starrockscluster.cn.image.tag" . }}"
+    image: "{{ include "starrockscluster.cn.image" . }}"
     {{- if .Values.starrocksCnSpec.entrypoint }}
     command: ["bash", "-c"]
     args:
@@ -897,7 +897,7 @@ spec:
   {{- if .Values.starrocksFeProxySpec.enabled }}
   starRocksFeProxySpec:
     {{- if .Values.starrocksFeProxySpec.image.repository }}
-    image: "{{ .Values.starrocksFeProxySpec.image.repository }}:{{ .Values.starrocksFeProxySpec.image.tag }}"
+    image: "{{ include "starrockscluster.feproxy.image" . }}"
     {{- end }}
     {{- if .Values.starrocksFeProxySpec.imagePullSecrets }}
     imagePullSecrets:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -5,6 +5,16 @@
 # nameOverride is used to set the prefix of the resources created by starrocks chart.
 nameOverride: "kube-starrocks"
 
+# Global image registry prefix for use by parent charts.
+# When set, it is prepended to every image repository in the chart.
+# For example, setting registry: "my-registry.example.com" transforms
+# "starrocks/fe-ubuntu:tag" into "my-registry.example.com/starrocks/fe-ubuntu:tag".
+# This can be overridden by starrocksCluster.componentValues.image.registry (cluster-wide)
+# or by the individual image.registry fields in each component spec.
+global:
+  image:
+    registry: ""
+
 # This configuration is used to modify the root password during initial deployment.
 # After deployment is completed, it won't take effect to modify the password here and to do a `helm upgrade`.
 # It also supports providing a secret name that contains a password, using the password in the secret instead of the plaintext in the values.yaml.
@@ -128,6 +138,9 @@ starrocksCluster:
   componentValues:
     image:
       tag: "3.5-latest"
+      # registry overrides global.image.registry for all components (FE, BE, CN).
+      # Individual component image.registry fields take priority over this.
+      registry: ""
     # hostAliases allows adding entries to /etc/hosts inside the containers.
     hostAliases: []
       # - ip: "127.0.0.1"
@@ -199,6 +212,8 @@ starrocksFESpec:
     # image sliced by "repository:tag"
     repository: starrocks/fe-ubuntu
     tag: ""
+    # registry overrides the global image.registry for this component only.
+    registry: ""
   imagePullPolicy: IfNotPresent
   # Specify the entrypoint for FE.
   # By default, the operator will use '/opt/starrocks/fe_entrypoint.sh' as a command and use '$(FE_SERVICE_NAME)' as args in the container spec.
@@ -386,7 +401,7 @@ starrocksFESpec:
     #   mountPath: /tmp
   # persistentVolumeClaimRetentionPolicy specifies the retention policy for PersistentVolumeClaims associated with the component.
   # The whenDeleted field is supported for all components, and it determines whether to delete PVCs when the StatefulSet is deleted.
-  #	The whenScaled field is only supported for the CN component.
+  # The whenScaled field is only supported for the CN component.
   persistentVolumeClaimRetentionPolicy:
     # whenDeleted: Delete
   # the config for start fe. the base information as follows.
@@ -526,6 +541,8 @@ starrocksCnSpec:
     # image sliced by "repository:tag"
     repository: starrocks/cn-ubuntu
     tag: ""
+    # registry overrides the global image.registry for this component only.
+    registry: ""
   imagePullPolicy: IfNotPresent
   # Specify the entrypoint for CN.
   # By default, the operator will use '/opt/starrocks/cn_entrypoint.sh' as command, and use '$(FE_SERVICE_NAME)' as args in container spec.
@@ -891,6 +908,8 @@ starrocksBeSpec:
     # image sliced by "repository:tag"
     repository: starrocks/be-ubuntu
     tag: ""
+    # registry overrides the global image.registry for this component only.
+    registry: ""
   imagePullPolicy: IfNotPresent
   # Specify the entrypoint for BE.
   # By default, the operator will use '/opt/starrocks/be_entrypoint.sh' as command, and use '$(FE_SERVICE_NAME)' as args in the container spec.
@@ -1249,6 +1268,8 @@ starrocksFeProxySpec:
   image:
     repository: ""
     tag: ""
+    # registry overrides the global image.registry for this component only.
+    registry: ""
   resources:
     requests:
       cpu: 1

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -131,6 +131,16 @@ starrocks:
   # nameOverride is used to set the prefix of the resources created by starrocks chart.
   nameOverride: "kube-starrocks"
   
+  # Global image registry prefix for use by parent charts.
+  # When set, it is prepended to every image repository in the chart.
+  # For example, setting registry: "my-registry.example.com" transforms
+  # "starrocks/fe-ubuntu:tag" into "my-registry.example.com/starrocks/fe-ubuntu:tag".
+  # This can be overridden by starrocksCluster.componentValues.image.registry (cluster-wide)
+  # or by the individual image.registry fields in each component spec.
+  global:
+    image:
+      registry: ""
+  
   # This configuration is used to modify the root password during initial deployment.
   # After deployment is completed, it won't take effect to modify the password here and to do a `helm upgrade`.
   # It also supports providing a secret name that contains a password, using the password in the secret instead of the plaintext in the values.yaml.
@@ -254,6 +264,9 @@ starrocks:
     componentValues:
       image:
         tag: "3.5-latest"
+        # registry overrides global.image.registry for all components (FE, BE, CN).
+        # Individual component image.registry fields take priority over this.
+        registry: ""
       # hostAliases allows adding entries to /etc/hosts inside the containers.
       hostAliases: []
         # - ip: "127.0.0.1"
@@ -325,6 +338,8 @@ starrocks:
       # image sliced by "repository:tag"
       repository: starrocks/fe-ubuntu
       tag: ""
+      # registry overrides the global image.registry for this component only.
+      registry: ""
     imagePullPolicy: IfNotPresent
     # Specify the entrypoint for FE.
     # By default, the operator will use '/opt/starrocks/fe_entrypoint.sh' as a command and use '$(FE_SERVICE_NAME)' as args in the container spec.
@@ -512,7 +527,7 @@ starrocks:
       #   mountPath: /tmp
     # persistentVolumeClaimRetentionPolicy specifies the retention policy for PersistentVolumeClaims associated with the component.
     # The whenDeleted field is supported for all components, and it determines whether to delete PVCs when the StatefulSet is deleted.
-    #	The whenScaled field is only supported for the CN component.
+    # The whenScaled field is only supported for the CN component.
     persistentVolumeClaimRetentionPolicy:
       # whenDeleted: Delete
     # the config for start fe. the base information as follows.
@@ -652,6 +667,8 @@ starrocks:
       # image sliced by "repository:tag"
       repository: starrocks/cn-ubuntu
       tag: ""
+      # registry overrides the global image.registry for this component only.
+      registry: ""
     imagePullPolicy: IfNotPresent
     # Specify the entrypoint for CN.
     # By default, the operator will use '/opt/starrocks/cn_entrypoint.sh' as command, and use '$(FE_SERVICE_NAME)' as args in container spec.
@@ -1017,6 +1034,8 @@ starrocks:
       # image sliced by "repository:tag"
       repository: starrocks/be-ubuntu
       tag: ""
+      # registry overrides the global image.registry for this component only.
+      registry: ""
     imagePullPolicy: IfNotPresent
     # Specify the entrypoint for BE.
     # By default, the operator will use '/opt/starrocks/be_entrypoint.sh' as command, and use '$(FE_SERVICE_NAME)' as args in the container spec.
@@ -1375,6 +1394,8 @@ starrocks:
     image:
       repository: ""
       tag: ""
+      # registry overrides the global image.registry for this component only.
+      registry: ""
     resources:
       requests:
         cpu: 1


### PR DESCRIPTION
# Description

This allows to use private registries without having to override the repository. This is how public charts usually work: split between registry, repository and image tag. Bitnami used to work like this.

Adds a global.image.registry value (default: "") that is prepended to all component image repositories. Each component (FE, BE, CN, FE proxy) also exposes its own image.registry field to allow per-component overrides; the component-level value takes priority over the global one.

New helpers (starrockscluster.fe/be/cn/feproxy.image) build the full image reference in one place, keeping templates clean. The init-password job inherits the FE registry automatically.

Priority order (ascending, last wins):
  global.image.registry
  < starrocksCluster.componentValues.image.registry
  < starrocks{FE,BE,CN}Spec.image.registry

The feproxy component is excluded from componentValues (as it already was for image.tag) and resolves directly from its own registry or global.image.registry.

This commit was partially helped with Claude, I added it in the commit Co-Authors.

# Related Issue(s)

None

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
