### PR TITLE
feat(helm): add enableMultilineLogParsing flag to Datadog logs 

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -738,6 +738,39 @@ Get the value of podLabels field in the starrocksBeSpec
 {{- end -}}
 
 {{/*
+Build the Datadog log annotation value for a given component.
+Arguments (passed as a dict via "call"):
+  . = root context (has .Values)
+  $component = "fe", "be", or "cn"
+  $multilinePattern = regex pattern string for multi_line rule
+  $multilineName = name for the multi_line rule
+Usage: include "starrockscluster.datadog.log.annotation" (dict "root" . "component" "fe" "multilinePattern" "..." "multilineName" "...")
+*/}}
+{{- define "starrockscluster.datadog.log.annotation" -}}
+{{- $root := .root -}}
+{{- $component := .component -}}
+{{- $multilinePattern := .multilinePattern -}}
+{{- $multilineName := .multilineName -}}
+{{- $logConfig := $root.Values.datadog.log.logConfig -}}
+{{- $base := dict "service" "starrocks" "source" $component -}}
+{{- if eq (kindOf $logConfig) "map" -}}
+  {{- $base = merge $base $logConfig -}}
+{{- else if eq (kindOf $logConfig) "string" -}}
+  {{- if ne (trimAll " {}" $logConfig) "" -}}
+    {{- $extra := fromJson $logConfig -}}
+    {{- $base = merge $base $extra -}}
+  {{- end -}}
+{{- end -}}
+{{- if $root.Values.datadog.log.enableMultilineLogParsing -}}
+  {{- if not (hasKey $base "log_processing_rules") -}}
+    {{- $rule := dict "name" $multilineName "pattern" $multilinePattern "type" "multi_line" -}}
+    {{- $_ := set $base "log_processing_rules" (list $rule) -}}
+  {{- end -}}
+{{- end -}}
+{{- list $base | toJson | squote -}}
+{{- end -}}
+
+{{/*
 Get the value of podLabels field in the starrocksCnSpec
 */}}
 {{- define "starrockscluster.cn.podLabels" -}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/_helpers.tpl
@@ -739,11 +739,11 @@ Get the value of podLabels field in the starrocksBeSpec
 
 {{/*
 Build the Datadog log annotation value for a given component.
-Arguments (passed as a dict via "call"):
-  . = root context (has .Values)
-  $component = "fe", "be", or "cn"
-  $multilinePattern = regex pattern string for multi_line rule
-  $multilineName = name for the multi_line rule
+Arguments (passed as a dict via "include"):
+  .root = root context (has .Values)
+  .component = "fe", "be", or "cn"
+  .multilinePattern = regex pattern string for multi_line rule
+  .multilineName = name for the multi_line rule
 Usage: include "starrockscluster.datadog.log.annotation" (dict "root" . "component" "fe" "multilinePattern" "..." "multilineName" "...")
 */}}
 {{- define "starrockscluster.datadog.log.annotation" -}}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -77,11 +77,7 @@ spec:
     annotations:
       app.starrocks.io/fe-config-hash: "{{template "starrockscluster.fe.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
-      {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
-      ad.datadoghq.com/fe.logs: '[{"service":"starrocks","source":"fe"}]'
-      {{- else }}
-      ad.datadoghq.com/fe.logs: {{ printf "[%s]" (printf "{%s, \"source\": \"fe\", \"service\": \"starrocks\"}" (trimAll " {}" .Values.datadog.log.logConfig) | fromJson | toJson) | squote }}
-      {{- end }}
+      ad.datadoghq.com/fe.logs: {{ include "starrockscluster.datadog.log.annotation" (dict "root" . "component" "fe" "multilinePattern" "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d+" "multilineName" "log_start_with_timestamp") }}
       {{- end }}
       {{- if .Values.starrocksFESpec.entrypoint }}
       app.starrocks.io/fe-entrypoint-hash: "{{ template "starrockscluster.fe.entrypoint.script.hash" . }}"
@@ -347,11 +343,7 @@ spec:
     annotations:
       app.starrocks.io/be-config-hash: "{{template "starrockscluster.be.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
-      {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
-      ad.datadoghq.com/be.logs: '[{"service":"starrocks","source":"be"}]'
-      {{- else }}
-      ad.datadoghq.com/be.logs: {{ printf "[%s]" (printf "{%s, \"source\": \"be\", \"service\": \"starrocks\"}" (trimAll " {}" .Values.datadog.log.logConfig) | fromJson | toJson) | squote }}
-      {{- end }}
+      ad.datadoghq.com/be.logs: {{ include "starrockscluster.datadog.log.annotation" (dict "root" . "component" "be" "multilinePattern" "[IWEF]\\d{8}\\s+\\d{2}:\\d{2}:\\d{2}\\.\\d+" "multilineName" "log_start_with_timestamp") }}
       {{- end }}
       {{- if .Values.starrocksBeSpec.annotations }}
       {{- toYaml .Values.starrocksBeSpec.annotations | nindent 6 }}
@@ -792,11 +784,7 @@ spec:
     annotations:
       app.starrocks.io/cn-config-hash: "{{template "starrockscluster.cn.config.hash" . }}"
       {{- if .Values.datadog.log.enabled }}
-      {{- if eq (trimAll " {}" .Values.datadog.log.logConfig) "" }}
-      ad.datadoghq.com/cn.logs: '[{"service":"starrocks","source":"cn"}]'
-      {{- else }}
-      ad.datadoghq.com/cn.logs: {{ printf "[%s]" (printf "{%s, \"source\": \"cn\", \"service\": \"starrocks\"}" (trimAll " {}" .Values.datadog.log.logConfig) | fromJson | toJson) | squote }}
-      {{- end }}
+      ad.datadoghq.com/cn.logs: {{ include "starrockscluster.datadog.log.annotation" (dict "root" . "component" "cn" "multilinePattern" "[IWEF]\\d{8}\\s+\\d{2}:\\d{2}:\\d{2}\\.\\d+" "multilineName" "log_start_with_timestamp") }}
       {{- end }}
       {{- if .Values.starrocksCnSpec.annotations }}
       {{- toYaml .Values.starrocksCnSpec.annotations | nindent 6 }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -51,6 +51,11 @@ datadog:
     # besides the attributes you added, the chart will append "source" and "service" attributes to the log config.
     # see https://docs.datadoghq.com/containers/kubernetes/log/?tab=operator for more details.
     logConfig: '{}' # e.g., '{"app": "starrocks", "tags": ["aa", "bb"]}'
+    # Enable multiline log parsing rules compatible with the Datadog agent.
+    # When true, a log_processing_rules entry of type "multi_line" is added to the log annotation.
+    # FE nodes use a Java (log4j) timestamp pattern; BE and CN nodes use a C++ glog timestamp pattern.
+    # If logConfig already contains "log_processing_rules", it takes priority and this flag is ignored.
+    enableMultilineLogParsing: false
   metrics:
     enabled: false
   profiling:

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -177,6 +177,11 @@ starrocks:
       # besides the attributes you added, the chart will append "source" and "service" attributes to the log config.
       # see https://docs.datadoghq.com/containers/kubernetes/log/?tab=operator for more details.
       logConfig: '{}' # e.g., '{"app": "starrocks", "tags": ["aa", "bb"]}'
+      # Enable multiline log parsing rules compatible with the Datadog agent.
+      # When true, a log_processing_rules entry of type "multi_line" is added to the log annotation.
+      # FE nodes use a Java (log4j) timestamp pattern; BE and CN nodes use a C++ glog timestamp pattern.
+      # If logConfig already contains "log_processing_rules", it takes priority and this flag is ignored.
+      enableMultilineLogParsing: false
     metrics:
       enabled: false
     profiling:


### PR DESCRIPTION
Add enableMultilineLogParsing boolean to datadog.log in both the starrocks subchart and the parent kube-starrocks chart values.



# Description

When enabled, a log_processing_rules multi_line entry is injected into the Datadog log annotation for each component: Java/log4j timestamp pattern for FE, C++/glog timestamp pattern for BE and CN. User-provided log_processing_rules in logConfig always take priority over the template default.

# Related Issue(s)

None

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [X] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [X] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
