### PR TITLE
[Feature] Support cross-namespace StarRocksWarehouse deployment

### DIFF
--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -54,6 +54,12 @@ spec:
                 description: StarRocksCluster is the name of a StarRocksCluster which
                   the warehouse belongs to.
                 type: string
+              starRocksClusterNamespace:
+                description: |-
+                  StarRocksClusterNamespace is the namespace of the StarRocksCluster.
+                  If empty, the warehouse's own namespace is used (backward-compatible default).
+                  Set this when deploying the warehouse in a different namespace from the cluster.
+                type: string
               template:
                 description: Template define component configuration.
                 properties:

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -38,6 +38,8 @@ spec:
             properties:
               starRocksCluster:
                 type: string
+              starRocksClusterNamespace:
+                type: string
               template:
                 properties:
                   affinity:

--- a/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
+++ b/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "starrockswarehouse.labels" . | nindent 4 }}
 spec:
   starRocksCluster: {{ .Values.spec.starRocksClusterName }}
+  {{- if .Values.spec.starRocksClusterNamespace }}
+  starRocksClusterNamespace: {{ .Values.spec.starRocksClusterNamespace }}
+  {{- end }}
   template:
     image: "{{ .Values.spec.image.repository }}:{{ .Values.spec.image.tag }}"
     {{- if .Values.spec.replicas }}

--- a/helm-charts/charts/warehouse/values.yaml
+++ b/helm-charts/charts/warehouse/values.yaml
@@ -21,6 +21,10 @@ spec:
   #   3. The starrocks cluster must run in shared-data mode.
   starRocksClusterName:
 
+  # The namespace of the StarRocksCluster. If empty, the warehouse's own namespace is used.
+  # Set this when deploying the warehouse in a different namespace from the cluster.
+  starRocksClusterNamespace: ""
+
   # Number of replicas to deploy.
   # In the implementation of the operator: Even when both the replicas and autoScalingPolicy are set in the spec
   # field, the replicas field of the statefulset created by the operator will be set to null. This ensures that the replicas

--- a/pkg/apis/starrocks/v1/starrockswarehouse_types.go
+++ b/pkg/apis/starrocks/v1/starrockswarehouse_types.go
@@ -29,6 +29,12 @@ type StarRocksWarehouseSpec struct {
 	// StarRocksCluster is the name of a StarRocksCluster which the warehouse belongs to.
 	StarRocksCluster string `json:"starRocksCluster"`
 
+	// StarRocksClusterNamespace is the namespace of the StarRocksCluster.
+	// If empty, the warehouse's own namespace is used (backward-compatible default).
+	// Set this when deploying the warehouse in a different namespace from the cluster.
+	// +optional
+	StarRocksClusterNamespace string `json:"starRocksClusterNamespace,omitempty"`
+
 	// Template define component configuration.
 	Template *WarehouseComponentSpec `json:"template"`
 }

--- a/pkg/k8sutils/templates/object/meta.go
+++ b/pkg/k8sutils/templates/object/meta.go
@@ -22,6 +22,10 @@ type StarRocksObject struct {
 	// ClusterName is the name of StarRocksCluster.
 	ClusterName string
 
+	// ClusterNamespace is the namespace of the StarRocksCluster. This may differ from
+	// Namespace when a StarRocksWarehouse is deployed in a different namespace.
+	ClusterNamespace string
+
 	// Kind is StarRocksCluster or StarRocksWarehouse.
 	// The reason why we need this field is that we can't make sure ObjectMeta.Kind is filled.
 	Kind string
@@ -40,6 +44,7 @@ func NewFromCluster(cluster *srapi.StarRocksCluster) StarRocksObject {
 		TypeMeta:              &cluster.TypeMeta,
 		ObjectMeta:            &cluster.ObjectMeta,
 		ClusterName:           cluster.Name,
+		ClusterNamespace:      cluster.Namespace,
 		Kind:                  StarRocksClusterKind,
 		SubResourcePrefixName: cluster.Name,
 		IsWarehouseObject:     false,
@@ -47,10 +52,15 @@ func NewFromCluster(cluster *srapi.StarRocksCluster) StarRocksObject {
 }
 
 func NewFromWarehouse(warehouse *srapi.StarRocksWarehouse) StarRocksObject {
+	clusterNamespace := warehouse.Namespace
+	if warehouse.Spec.StarRocksClusterNamespace != "" {
+		clusterNamespace = warehouse.Spec.StarRocksClusterNamespace
+	}
 	return StarRocksObject{
 		TypeMeta:              &warehouse.TypeMeta,
 		ObjectMeta:            &warehouse.ObjectMeta,
 		ClusterName:           warehouse.Spec.StarRocksCluster,
+		ClusterNamespace:      clusterNamespace,
 		Kind:                  StarRocksWarehouseKind,
 		SubResourcePrefixName: GetPrefixNameForWarehouse(warehouse.Name),
 		IsWarehouseObject:     true,

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -85,8 +85,13 @@ func (cc *CnController) SyncWarehouse(ctx context.Context, warehouse *srapi.Star
 		return ErrWarehouseNameIsNotAllowed
 	}
 
+	clusterNamespace := warehouse.Namespace
+	if warehouse.Spec.StarRocksClusterNamespace != "" {
+		clusterNamespace = warehouse.Spec.StarRocksClusterNamespace
+	}
+
 	logger.Info("get StarRocksCluster CR from kubernetes")
-	_, err := cc.getStarRocksCluster(ctx, warehouse.Namespace, warehouse.Spec.StarRocksCluster)
+	_, err := cc.getStarRocksCluster(ctx, clusterNamespace, warehouse.Spec.StarRocksCluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return ErrStarRocksClusterIsMissing
@@ -95,7 +100,7 @@ func (cc *CnController) SyncWarehouse(ctx context.Context, warehouse *srapi.Star
 	}
 
 	logger.Info("get fe config to make sure StarRocks run in shared_data mode")
-	feConfig, err := cc.getFeConfig(ctx, warehouse.Namespace, warehouse.Spec.StarRocksCluster)
+	feConfig, err := cc.getFeConfig(ctx, clusterNamespace, warehouse.Spec.StarRocksCluster)
 	if err != nil {
 		return err
 	}
@@ -103,7 +108,7 @@ func (cc *CnController) SyncWarehouse(ctx context.Context, warehouse *srapi.Star
 		return ErrShouldRunInSharedDataMode
 	}
 
-	if !fe.CheckFEReady(ctx, cc.k8sClient, warehouse.Namespace, warehouse.Spec.StarRocksCluster) {
+	if !fe.CheckFEReady(ctx, cc.k8sClient, clusterNamespace, warehouse.Spec.StarRocksCluster) {
 		return ErrFeIsNotReady
 	}
 
@@ -174,7 +179,7 @@ func (cc *CnController) SyncCnSpec(ctx context.Context, object object.StarRocksO
 		return err
 	}
 	logger.V(log.DebugLevel).Info("get fe config to resolve ports", "ConfigMapInfo", cnSpec.ConfigMapInfo)
-	feconfig, err := cc.getFeConfig(ctx, object.Namespace, object.ClusterName)
+	feconfig, err := cc.getFeConfig(ctx, object.ClusterNamespace, object.ClusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/subcontrollers/cn/cn_mysql.go
+++ b/pkg/subcontrollers/cn/cn_mysql.go
@@ -72,10 +72,18 @@ func NewSQLExecutor(ctx context.Context, k8sClient client.Client, namespace, cnS
 		}
 	}
 
+	// If FE_SERVICE_NAME includes a namespace suffix (e.g. "svc-name.other-ns" for cross-namespace
+	// warehouses), extract it so that the MySQL DSN resolves to the correct FE service.
+	feServiceNamespace := namespace
+	if idx := strings.Index(feServiceName, "."); idx > 0 {
+		feServiceNamespace = feServiceName[idx+1:]
+		feServiceName = feServiceName[:idx]
+	}
+
 	return &SQLExecutor{
 		RootPassword:       rootPassword,
 		FeServiceName:      feServiceName,
-		FeServiceNamespace: namespace,
+		FeServiceNamespace: feServiceNamespace,
 		FeServicePort:      feServicePort,
 	}, nil
 }

--- a/pkg/subcontrollers/cn/cn_pod.go
+++ b/pkg/subcontrollers/cn/cn_pod.go
@@ -59,10 +59,18 @@ func (cc *CnController) buildPodTemplate(ctx context.Context, object srobject.St
 	}
 
 	feExternalServiceName := service.ExternalServiceName(object.ClusterName, (*srapi.StarRocksFeSpec)(nil))
-	envs := pod.Envs(cnSpec, config, feExternalServiceName, object.Namespace, cnSpec.CnEnvVars)
+	// When the warehouse is in a different namespace from the cluster, include the cluster
+	// namespace so that DNS resolution reaches the FE service across namespaces.
+	feExternalServiceNameForEnv := feExternalServiceName
+	if object.ClusterNamespace != object.Namespace {
+		feExternalServiceNameForEnv = feExternalServiceName + "." + object.ClusterNamespace
+	}
+	envs := pod.Envs(cnSpec, config, feExternalServiceNameForEnv, object.Namespace, cnSpec.CnEnvVars)
 	webServerPort := rutils.GetPort(config, rutils.WEBSERVER_PORT)
 	if object.Kind == srobject.StarRocksWarehouseKind {
-		url := fmt.Sprintf("http://%v.%v:%v/api/v2/feature", feExternalServiceName, object.Namespace, rutils.GetPort(config, rutils.HTTP_PORT))
+		httpPort := rutils.GetPort(config, rutils.HTTP_PORT)
+		url := fmt.Sprintf("http://%v.%v:%v/api/v2/feature",
+			feExternalServiceName, object.ClusterNamespace, httpPort)
 		if cc.addEnvForWarehouse || cc.addWarehouseEnv(ctx, url) {
 			envs = append(envs, corev1.EnvVar{
 				Name: "KUBE_STARROCKS_MULTI_WAREHOUSE",


### PR DESCRIPTION
## Summary
- Adds optional `starRocksClusterNamespace` field to `StarRocksWarehouseSpec`, allowing CN warehouse workloads to be deployed in a separate namespace from the FE/BE `StarRocksCluster`
- When set, the operator uses the specified namespace to look up the `StarRocksCluster` CR, FE config, FE readiness endpoints, and constructs cross-namespace DNS names for FE service connectivity
- Fully backward-compatible: when the field is omitted, the warehouse's own namespace is used (existing behavior)

Closes #757

## Changes
- **API**: New optional `starRocksClusterNamespace` field on `StarRocksWarehouseSpec`
- **StarRocksObject**: Added `ClusterNamespace` field to track the cluster's namespace separately from the warehouse namespace
- **CN Controller**: `SyncWarehouse` and `SyncCnSpec` use cluster namespace for FE lookups
- **CN Pod**: Cross-namespace `FE_SERVICE_NAME` env includes cluster namespace for DNS resolution
- **SQL Executor**: Correctly parses `FE_SERVICE_NAME` with embedded namespace suffix
- **Helm chart**: Warehouse chart supports new `starRocksClusterNamespace` value
- **CRDs**: Updated both `config/crd` and `deploy/` CRD manifests