### PR TITLE
[BugFix]: respect user-configured ServiceAccount by enabling token automount(#758)

### DIFF
--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -270,6 +270,23 @@ func Spec(spec v1.SpecInterface, container corev1.Container, volumes []corev1.Vo
 	if len(spec.GetSidecars()) > 0 {
 		containers = append(containers, spec.GetSidecars()...)
 	}
+
+	// AutomountServiceAccountToken policy:
+	//   - Without an explicit ServiceAccount the original behavior is kept:
+	//     hard-disable token mounting so the cluster's "default" SA token
+	//     is never auto-injected into FE/BE/CN/FeProxy pods.
+	//   - When the user explicitly assigns a ServiceAccount via the CR field
+	//     spec.<role>.serviceAccount, automount is left to the K8s default
+	//     (true) so the SA token is projected to
+	//     /var/run/secrets/kubernetes.io/serviceaccount/, which is required
+	//     by in-cluster clients running inside the main / sidecar containers
+	//     (e.g. components calling rest.InClusterConfig).
+	var automount *bool
+	if spec.GetServiceAccount() == "" {
+		b := false
+		automount = &b
+	}
+
 	podSpec := corev1.PodSpec{
 		InitContainers:                spec.GetInitContainers(),
 		Containers:                    containers,
@@ -283,7 +300,7 @@ func Spec(spec v1.SpecInterface, container corev1.Container, volumes []corev1.Vo
 		NodeSelector:                  spec.GetNodeSelector(),
 		HostAliases:                   spec.GetHostAliases(),
 		SchedulerName:                 spec.GetSchedulerName(),
-		AutomountServiceAccountToken:  func() *bool { b := false; return &b }(),
+		AutomountServiceAccountToken:  automount,
 		ShareProcessNamespace:         spec.GetShareProcessNamespace(),
 	}
 	return podSpec

--- a/pkg/k8sutils/templates/pod/spec_test.go
+++ b/pkg/k8sutils/templates/pod/spec_test.go
@@ -362,7 +362,7 @@ func TestSpec(t *testing.T) {
 				Containers:                    []corev1.Container{{}},
 				ServiceAccountName:            "test",
 				TerminationGracePeriodSeconds: rutils.GetInt64ptr(int64(120)),
-				AutomountServiceAccountToken:  func() *bool { b := false; return &b }(),
+				AutomountServiceAccountToken:  nil,
 			},
 		},
 		{


### PR DESCRIPTION
…tomount(#758)

# Description

Motivation
Previously, AutomountServiceAccountToken was hard-coded to false for all FE/BE/CN/FeProxy pods, regardless of whether the user had explicitly configured a ServiceAccount in the CR. This caused a subtle but critical issue: even when a user set spec.<role>.serviceAccount to a custom SA, the SA token was never projected into the pod's filesystem (/var/run/secrets/kubernetes.io/serviceaccount/), breaking any in-cluster client running inside the main container or sidecars (e.g. components calling rest.InClusterConfig()).

# Related Issue(s)

https://github.com/StarRocks/starrocks-kubernetes-operator/issues/758

# Checklist

For operator, please complete the following checklist:

- [ X] run `make generate` to generate the code.
- [ X] run `golangci-lint run` to check the code style.
- [ X] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ ] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ ] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
