### PR TITLE
feat(warehouse): support cross-namespace deployment for StarRocksWare…

### DIFF
--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -54,6 +54,11 @@ spec:
                 description: StarRocksCluster is the name of a StarRocksCluster which
                   the warehouse belongs to.
                 type: string
+              starRocksClusterNamespace:
+                description: |-
+                  StarRocksClusterNamespace is the namespace of the StarRocksCluster which the warehouse belongs to.
+                  If empty, defaults to the same namespace as this StarRocksWarehouse.
+                type: string
               template:
                 description: Template define component configuration.
                 properties:

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -38,6 +38,8 @@ spec:
             properties:
               starRocksCluster:
                 type: string
+              starRocksClusterNamespace:
+                type: string
               template:
                 properties:
                   affinity:

--- a/pkg/apis/starrocks/v1/starrockswarehouse_types.go
+++ b/pkg/apis/starrocks/v1/starrockswarehouse_types.go
@@ -29,6 +29,11 @@ type StarRocksWarehouseSpec struct {
 	// StarRocksCluster is the name of a StarRocksCluster which the warehouse belongs to.
 	StarRocksCluster string `json:"starRocksCluster"`
 
+	// StarRocksClusterNamespace is the namespace of the StarRocksCluster which the warehouse belongs to.
+	// If empty, defaults to the same namespace as this StarRocksWarehouse.
+	// +optional
+	StarRocksClusterNamespace string `json:"starRocksClusterNamespace,omitempty"`
+
 	// Template define component configuration.
 	Template *WarehouseComponentSpec `json:"template"`
 }

--- a/pkg/k8sutils/templates/object/meta.go
+++ b/pkg/k8sutils/templates/object/meta.go
@@ -22,6 +22,11 @@ type StarRocksObject struct {
 	// ClusterName is the name of StarRocksCluster.
 	ClusterName string
 
+	// ClusterNamespace is the namespace of StarRocksCluster.
+	// For cross-namespace warehouse deployments, this may differ from ObjectMeta.Namespace.
+	// If empty, it defaults to the same namespace as the warehouse (ObjectMeta.Namespace).
+	ClusterNamespace string
+
 	// Kind is StarRocksCluster or StarRocksWarehouse.
 	// The reason why we need this field is that we can't make sure ObjectMeta.Kind is filled.
 	Kind string
@@ -40,6 +45,7 @@ func NewFromCluster(cluster *srapi.StarRocksCluster) StarRocksObject {
 		TypeMeta:              &cluster.TypeMeta,
 		ObjectMeta:            &cluster.ObjectMeta,
 		ClusterName:           cluster.Name,
+		ClusterNamespace:      cluster.Namespace,
 		Kind:                  StarRocksClusterKind,
 		SubResourcePrefixName: cluster.Name,
 		IsWarehouseObject:     false,
@@ -47,10 +53,15 @@ func NewFromCluster(cluster *srapi.StarRocksCluster) StarRocksObject {
 }
 
 func NewFromWarehouse(warehouse *srapi.StarRocksWarehouse) StarRocksObject {
+	clusterNamespace := warehouse.Namespace
+	if warehouse.Spec.StarRocksClusterNamespace != "" {
+		clusterNamespace = warehouse.Spec.StarRocksClusterNamespace
+	}
 	return StarRocksObject{
 		TypeMeta:              &warehouse.TypeMeta,
 		ObjectMeta:            &warehouse.ObjectMeta,
 		ClusterName:           warehouse.Spec.StarRocksCluster,
+		ClusterNamespace:      clusterNamespace,
 		Kind:                  StarRocksWarehouseKind,
 		SubResourcePrefixName: GetPrefixNameForWarehouse(warehouse.Name),
 		IsWarehouseObject:     true,

--- a/pkg/k8sutils/templates/object/meta_test.go
+++ b/pkg/k8sutils/templates/object/meta_test.go
@@ -42,6 +42,33 @@ func TestNewFromCluster(t *testing.T) {
 				SubResourcePrefixName: "starrocks",
 			},
 		},
+		{
+			name: "NewFromCluster fills ClusterNamespace from cluster.Namespace",
+			args: args{
+				cluster: &srapi.StarRocksCluster{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "StarRocksCluster",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "starrocks",
+						Namespace: "main-ns",
+					},
+				},
+			},
+			want: StarRocksObject{
+				TypeMeta: &metav1.TypeMeta{
+					Kind: "StarRocksCluster",
+				},
+				ObjectMeta: &metav1.ObjectMeta{
+					Name:      "starrocks",
+					Namespace: "main-ns",
+				},
+				ClusterName:           "starrocks",
+				ClusterNamespace:      "main-ns",
+				Kind:                  "StarRocksCluster",
+				SubResourcePrefixName: "starrocks",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -86,6 +113,69 @@ func TestNewFromWarehouse(t *testing.T) {
 				ClusterName:           "starrocks",
 				Kind:                  "StarRocksWarehouse",
 				SubResourcePrefixName: "starrocks-warehouse",
+				IsWarehouseObject:     true,
+			},
+		},
+		{
+			name: "warehouse same namespace falls back to warehouse.Namespace",
+			args: args{
+				warehouse: &srapi.StarRocksWarehouse{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "StarRocksWarehouse",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "wh1",
+						Namespace: "wh-ns",
+					},
+					Spec: srapi.StarRocksWarehouseSpec{
+						StarRocksCluster: "main",
+					},
+				},
+			},
+			want: StarRocksObject{
+				TypeMeta: &metav1.TypeMeta{
+					Kind: "StarRocksWarehouse",
+				},
+				ObjectMeta: &metav1.ObjectMeta{
+					Name:      "wh1",
+					Namespace: "wh-ns",
+				},
+				ClusterName:           "main",
+				ClusterNamespace:      "wh-ns",
+				Kind:                  "StarRocksWarehouse",
+				SubResourcePrefixName: "wh1-warehouse",
+				IsWarehouseObject:     true,
+			},
+		},
+		{
+			name: "warehouse cross namespace uses Spec.StarRocksClusterNamespace",
+			args: args{
+				warehouse: &srapi.StarRocksWarehouse{
+					TypeMeta: metav1.TypeMeta{
+						Kind: "StarRocksWarehouse",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "wh1",
+						Namespace: "wh-ns",
+					},
+					Spec: srapi.StarRocksWarehouseSpec{
+						StarRocksCluster:          "main",
+						StarRocksClusterNamespace: "main-ns",
+					},
+				},
+			},
+			want: StarRocksObject{
+				TypeMeta: &metav1.TypeMeta{
+					Kind: "StarRocksWarehouse",
+				},
+				ObjectMeta: &metav1.ObjectMeta{
+					Name:      "wh1",
+					Namespace: "wh-ns",
+				},
+				ClusterName:           "main",
+				ClusterNamespace:      "main-ns",
+				Kind:                  "StarRocksWarehouse",
+				SubResourcePrefixName: "wh1-warehouse",
 				IsWarehouseObject:     true,
 			},
 		},

--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -164,7 +164,7 @@ func Envs(spec v1.SpecInterface, config map[string]interface{},
 			},
 			{
 				Name:  v1.FE_SERVICE_NAME,
-				Value: feExternalServiceName,
+				Value: feExternalServiceName + "." + namespace,
 			},
 			{
 				Name:  "FE_QUERY_PORT",
@@ -181,7 +181,7 @@ func Envs(spec v1.SpecInterface, config map[string]interface{},
 			},
 			{
 				Name:  v1.FE_SERVICE_NAME,
-				Value: feExternalServiceName,
+				Value: feExternalServiceName + "." + namespace,
 			},
 			{
 				Name:  "FE_QUERY_PORT",

--- a/pkg/k8sutils/templates/pod/spec_test.go
+++ b/pkg/k8sutils/templates/pod/spec_test.go
@@ -254,7 +254,7 @@ func TestEnvs(t *testing.T) {
 				},
 				{
 					Name:  v1.FE_SERVICE_NAME,
-					Value: service.ExternalServiceName("test", &v1.StarRocksFeSpec{}),
+					Value: service.ExternalServiceName("test", &v1.StarRocksFeSpec{}) + "." + "ns",
 				},
 				{
 					Name:  "FE_QUERY_PORT",
@@ -277,7 +277,7 @@ func TestEnvs(t *testing.T) {
 				},
 				{
 					Name:  v1.FE_SERVICE_NAME,
-					Value: service.ExternalServiceName("test", &v1.StarRocksFeSpec{}),
+					Value: service.ExternalServiceName("test", &v1.StarRocksFeSpec{}) + "." + "ns",
 				},
 				{
 					Name:  "FE_QUERY_PORT",
@@ -300,7 +300,7 @@ func TestEnvs(t *testing.T) {
 				},
 				{
 					Name:  v1.FE_SERVICE_NAME,
-					Value: service.ExternalServiceName("test", &v1.StarRocksFeSpec{}),
+					Value: service.ExternalServiceName("test", &v1.StarRocksFeSpec{}) + "." + "ns",
 				},
 				{
 					Name:  "FE_QUERY_PORT",

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -85,8 +85,15 @@ func (cc *CnController) SyncWarehouse(ctx context.Context, warehouse *srapi.Star
 		return ErrWarehouseNameIsNotAllowed
 	}
 
+	// clusterNamespace is the namespace where the StarRocksCluster resides.
+	// It may differ from warehouse.Namespace when cross-namespace deployment is configured.
+	clusterNamespace := warehouse.Namespace
+	if warehouse.Spec.StarRocksClusterNamespace != "" {
+		clusterNamespace = warehouse.Spec.StarRocksClusterNamespace
+	}
+
 	logger.Info("get StarRocksCluster CR from kubernetes")
-	_, err := cc.getStarRocksCluster(ctx, warehouse.Namespace, warehouse.Spec.StarRocksCluster)
+	_, err := cc.getStarRocksCluster(ctx, clusterNamespace, warehouse.Spec.StarRocksCluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return ErrStarRocksClusterIsMissing
@@ -95,7 +102,7 @@ func (cc *CnController) SyncWarehouse(ctx context.Context, warehouse *srapi.Star
 	}
 
 	logger.Info("get fe config to make sure StarRocks run in shared_data mode")
-	feConfig, err := cc.getFeConfig(ctx, warehouse.Namespace, warehouse.Spec.StarRocksCluster)
+	feConfig, err := cc.getFeConfig(ctx, clusterNamespace, warehouse.Spec.StarRocksCluster)
 	if err != nil {
 		return err
 	}
@@ -103,7 +110,7 @@ func (cc *CnController) SyncWarehouse(ctx context.Context, warehouse *srapi.Star
 		return ErrShouldRunInSharedDataMode
 	}
 
-	if !fe.CheckFEReady(ctx, cc.k8sClient, warehouse.Namespace, warehouse.Spec.StarRocksCluster) {
+	if !fe.CheckFEReady(ctx, cc.k8sClient, clusterNamespace, warehouse.Spec.StarRocksCluster) {
 		return ErrFeIsNotReady
 	}
 
@@ -174,7 +181,7 @@ func (cc *CnController) SyncCnSpec(ctx context.Context, object object.StarRocksO
 		return err
 	}
 	logger.V(log.DebugLevel).Info("get fe config to resolve ports", "ConfigMapInfo", cnSpec.ConfigMapInfo)
-	feconfig, err := cc.getFeConfig(ctx, object.Namespace, object.ClusterName)
+	feconfig, err := cc.getFeConfig(ctx, object.ClusterNamespace, object.ClusterName)
 	if err != nil {
 		return err
 	}

--- a/pkg/subcontrollers/cn/cn_controller_test.go
+++ b/pkg/subcontrollers/cn/cn_controller_test.go
@@ -278,6 +278,148 @@ func Test_SyncWarehouse(t *testing.T) {
 	require.Equal(t, "wh1-warehouse-cn", sts.Name)
 }
 
+// Test_SyncWarehouse_CrossNamespace verifies the warehouse can be deployed in a separate namespace
+// from the main StarRocksCluster (FE), with the linkage carried by spec.starRocksClusterNamespace.
+func Test_SyncWarehouse_CrossNamespace(t *testing.T) {
+	const mainNS = "main-ns"
+	const whNS = "wh-ns"
+
+	src := &srapi.StarRocksCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: mainNS,
+		},
+		Spec: srapi.StarRocksClusterSpec{
+			StarRocksFeSpec: &srapi.StarRocksFeSpec{
+				StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+					StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+						ConfigMapInfo: srapi.ConfigMapInfo{
+							ConfigMapName: "fe-configMap",
+							ResolveKey:    "fe.conf",
+						},
+					},
+				},
+			},
+			StarRocksCnSpec: &srapi.StarRocksCnSpec{
+				StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+					StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+						Image:    "test.image",
+						Replicas: rutils.GetInt32Pointer(3),
+					},
+				},
+			},
+		},
+	}
+
+	// fe configMap lives together with the cluster (mainNS).
+	feConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fe-configMap",
+			Namespace: mainNS,
+		},
+		Data: map[string]string{
+			"fe.conf": "run_mode = shared_data",
+		},
+	}
+
+	warehouse := &srapi.StarRocksWarehouse{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wh1",
+			Namespace: whNS, // warehouse lives in a different namespace
+		},
+		Spec: srapi.StarRocksWarehouseSpec{
+			StarRocksCluster:          "test",
+			StarRocksClusterNamespace: mainNS, // cross-namespace pointer
+			Template: &srapi.WarehouseComponentSpec{
+				StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+					StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+						Image:    "test.image",
+						Replicas: rutils.GetInt32Pointer(3),
+					},
+				},
+			},
+		},
+		Status: srapi.StarRocksWarehouseStatus{WarehouseComponentStatus: &srapi.WarehouseComponentStatus{}},
+	}
+
+	// FE endpoint is in mainNS — CheckFEReady looks it up there via clusterNamespace.
+	ep := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-fe-service",
+			Namespace: mainNS,
+		},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP:       "172.0.0.1",
+				Hostname: "test-fe-access-01.cluster.local",
+			}},
+		}},
+	}
+
+	cc := New(fake.NewFakeClient(srapi.Scheme, src, feConfigMap, warehouse, ep), fake.GetEventRecorderFor(nil))
+	cc.addEnvForWarehouse = true
+
+	require.NoError(t, cc.SyncWarehouse(context.Background(), warehouse))
+	require.NoError(t, cc.UpdateWarehouseStatus(context.Background(), warehouse))
+	require.Equal(t, srapi.ComponentReconciling, warehouse.Status.Phase)
+
+	// All warehouse-scoped resources should land in whNS.
+	obj := object.NewFromWarehouse(warehouse)
+	require.Equal(t, mainNS, obj.ClusterNamespace,
+		"NewFromWarehouse should pick up Spec.StarRocksClusterNamespace as ClusterNamespace")
+
+	var externalService corev1.Service
+	require.NoError(t, cc.k8sClient.Get(context.Background(),
+		types.NamespacedName{
+			Name:      service.ExternalServiceName(obj.SubResourcePrefixName, (*srapi.StarRocksCnSpec)(nil)),
+			Namespace: whNS,
+		},
+		&externalService),
+	)
+	require.Equal(t, whNS, externalService.Namespace)
+
+	var sts appsv1.StatefulSet
+	require.NoError(t, cc.k8sClient.Get(context.Background(),
+		types.NamespacedName{
+			Name:      load.Name(obj.SubResourcePrefixName, (*srapi.StarRocksCnSpec)(nil)),
+			Namespace: whNS,
+		},
+		&sts),
+	)
+	require.Equal(t, whNS, sts.Namespace)
+
+	// CN container's FE_SERVICE_NAME should be the FQDN pointing to FE in mainNS.
+	feSvc := service.ExternalServiceName(obj.ClusterName, (*srapi.StarRocksFeSpec)(nil))
+	wantFeServiceName := feSvc + "." + mainNS
+	var foundFeServiceName string
+	require.NotEmpty(t, sts.Spec.Template.Spec.Containers, "expected at least one container in CN sts")
+	for _, env := range sts.Spec.Template.Spec.Containers[0].Env {
+		if env.Name == "FE_SERVICE_NAME" {
+			foundFeServiceName = env.Value
+			break
+		}
+	}
+	require.Equalf(t, wantFeServiceName, foundFeServiceName,
+		"FE_SERVICE_NAME on CN container should be FQDN '<svc>.<mainNS>' for cross-namespace deployment")
+}
+
+// Test_SyncWarehouse_SameNamespaceFallback verifies backward compatibility:
+// when spec.starRocksClusterNamespace is empty, warehouse falls back to the warehouse's own namespace.
+func Test_SyncWarehouse_SameNamespaceFallback(t *testing.T) {
+	warehouse := &srapi.StarRocksWarehouse{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wh1",
+			Namespace: "default",
+		},
+		Spec: srapi.StarRocksWarehouseSpec{
+			StarRocksCluster: "test", // no StarRocksClusterNamespace
+		},
+	}
+	obj := object.NewFromWarehouse(warehouse)
+	require.Equal(t, "default", obj.ClusterNamespace,
+		"empty StarRocksClusterNamespace should fall back to warehouse.Namespace")
+}
+
 func TestCnController_UpdateStatus(t *testing.T) {
 	type fields struct {
 		k8sClient client.Client

--- a/pkg/subcontrollers/cn/cn_mysql.go
+++ b/pkg/subcontrollers/cn/cn_mysql.go
@@ -25,8 +25,12 @@ const (
 // Component CN needs to connect to mysql and execute sql statements. E.g.: When StarRocksWarehouse is deleted, the
 // related 'DROP WAREHOUSE <name>' statement needs to be executed.
 type SQLExecutor struct {
-	RootPassword       string
-	FeServiceName      string
+	RootPassword string
+	// FeServiceName is the FQDN of the FE service, e.g. "<svc>.<namespace>".
+	// It is read from the FE_SERVICE_NAME environment variable of the CN StatefulSet.
+	FeServiceName string
+	// FeServiceNamespace is kept for backward compatibility but is no longer used in connection strings,
+	// since FeServiceName already contains the full FQDN (including namespace).
 	FeServiceNamespace string
 	FeServicePort      string
 }
@@ -85,8 +89,8 @@ func NewSQLExecutor(ctx context.Context, k8sClient client.Client, namespace, cnS
 func (executor *SQLExecutor) ExecuteContext(ctx context.Context, db *sql.DB, statement string) error {
 	var err error
 	if db == nil {
-		db, err = sql.Open("mysql", fmt.Sprintf("root:%s@tcp(%s.%s:%s)/",
-			executor.RootPassword, executor.FeServiceName, executor.FeServiceNamespace, executor.FeServicePort))
+		db, err = sql.Open("mysql", fmt.Sprintf("root:%s@tcp(%s:%s)/",
+			executor.RootPassword, executor.FeServiceName, executor.FeServicePort))
 		if err != nil {
 			return err
 		}
@@ -104,8 +108,8 @@ func (executor *SQLExecutor) ExecuteContext(ctx context.Context, db *sql.DB, sta
 func (executor *SQLExecutor) QueryContext(ctx context.Context, db *sql.DB, statements string) (*sql.Rows, error) {
 	var err error
 	if db == nil {
-		db, err = sql.Open("mysql", fmt.Sprintf("root:%s@tcp(%s.%s:%s)/",
-			executor.RootPassword, executor.FeServiceName, executor.FeServiceNamespace, executor.FeServicePort))
+		db, err = sql.Open("mysql", fmt.Sprintf("root:%s@tcp(%s:%s)/",
+			executor.RootPassword, executor.FeServiceName, executor.FeServicePort))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/subcontrollers/cn/cn_mysql_test.go
+++ b/pkg/subcontrollers/cn/cn_mysql_test.go
@@ -92,6 +92,62 @@ func TestNewSQLExecutor(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 		},
+		{
+			name: "FE_SERVICE_NAME env carries FQDN form (svc.namespace) is preserved",
+			args: args{
+				ctx: context.Background(),
+				k8sClient: fake.NewFakeClient(
+					func() *runtime.Scheme {
+						schema := runtime.NewScheme()
+						_ = clientgoscheme.AddToScheme(schema)
+						return schema
+					}(),
+					&appsv1.StatefulSet{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "StatefulSet",
+							APIVersion: appsv1.SchemeGroupVersion.String(),
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "wh-cn",
+							Namespace: "wh-ns",
+						},
+						Spec: appsv1.StatefulSetSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Env: []corev1.EnvVar{
+												{
+													Name:  "MYSQL_PWD",
+													Value: "pwd",
+												},
+												{
+													Name:  "FE_SERVICE_NAME",
+													Value: "fe-svc.main-ns",
+												},
+												{
+													Name:  "FE_QUERY_PORT",
+													Value: "9030",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				),
+				namespace: "wh-ns",
+				name:      "wh-cn",
+			},
+			want: &SQLExecutor{
+				RootPassword:       "pwd",
+				FeServiceName:      "fe-svc.main-ns",
+				FeServiceNamespace: "wh-ns",
+				FeServicePort:      "9030",
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/subcontrollers/cn/cn_pod.go
+++ b/pkg/subcontrollers/cn/cn_pod.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -59,10 +60,10 @@ func (cc *CnController) buildPodTemplate(ctx context.Context, object srobject.St
 	}
 
 	feExternalServiceName := service.ExternalServiceName(object.ClusterName, (*srapi.StarRocksFeSpec)(nil))
-	envs := pod.Envs(cnSpec, config, feExternalServiceName, object.Namespace, cnSpec.CnEnvVars)
+	envs := pod.Envs(cnSpec, config, feExternalServiceName, object.ClusterNamespace, cnSpec.CnEnvVars)
 	webServerPort := rutils.GetPort(config, rutils.WEBSERVER_PORT)
 	if object.Kind == srobject.StarRocksWarehouseKind {
-		url := fmt.Sprintf("http://%v.%v:%v/api/v2/feature", feExternalServiceName, object.Namespace, rutils.GetPort(config, rutils.HTTP_PORT))
+		url := fmt.Sprintf("http://%v.%v:%v/api/v2/feature", feExternalServiceName, object.ClusterNamespace, rutils.GetPort(config, rutils.HTTP_PORT))
 		if cc.addEnvForWarehouse || cc.addWarehouseEnv(ctx, url) {
 			envs = append(envs, corev1.EnvVar{
 				Name: "KUBE_STARROCKS_MULTI_WAREHOUSE",
@@ -173,8 +174,10 @@ func (cc *CnController) addWarehouseEnv(ctx context.Context, url string) bool {
 	}
 
 	for _, feature := range result.Features {
-		if feature.Name == "multi-warehouse" {
-			logger.Info("FE support multi-warehouse")
+		// Match both "multi-warehouse" (community) and "MULTI_WAREHOUSE" (TBDS/enterprise) formats.
+		normalized := strings.ToLower(strings.ReplaceAll(feature.Name, "_", "-"))
+		if normalized == "multi-warehouse" {
+			logger.Info("FE support multi-warehouse", "featureName", feature.Name)
 			return true
 		}
 	}

--- a/pkg/subcontrollers/cn/cn_pod_test.go
+++ b/pkg/subcontrollers/cn/cn_pod_test.go
@@ -41,6 +41,36 @@ func TestCnController_addWarehouseEnv1(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "FE returns MULTI_WAREHOUSE (uppercase + underscore) is recognized",
+			args: args{
+				ctx: context.Background(),
+				ServerFunc: func(rw http.ResponseWriter, _ *http.Request) {
+					_, _ = rw.Write([]byte(`{"features": [{"name": "MULTI_WAREHOUSE"}], "version": "", "status": "OK"}`))
+				},
+			},
+			want: true,
+		},
+		{
+			name: "FE returns Multi-Warehouse (mixed case) is recognized",
+			args: args{
+				ctx: context.Background(),
+				ServerFunc: func(rw http.ResponseWriter, _ *http.Request) {
+					_, _ = rw.Write([]byte(`{"features": [{"name": "Multi-Warehouse"}], "version": "", "status": "OK"}`))
+				},
+			},
+			want: true,
+		},
+		{
+			name: "FE returns unrelated feature is not recognized",
+			args: args{
+				ctx: context.Background(),
+				ServerFunc: func(rw http.ResponseWriter, _ *http.Request) {
+					_, _ = rw.Write([]byte(`{"features": [{"name": "some-other-feature"}], "version": "", "status": "OK"}`))
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

### Motivation

`StarRocksWarehouse` currently requires the associated `StarRocksCluster` to reside in the **same namespace**. This prevents multi-tenant deployments where warehouses need to be isolated in separate namespaces (e.g., per-team or per-environment), while sharing a single centrally-managed cluster.

This PR introduces an optional `starRocksClusterNamespace` field on `StarRocksWarehouseSpec`, allowing a warehouse to reference a `StarRocksCluster` in a different namespace. When the field is omitted, behavior is fully backward-compatible (same-namespace lookup, identical to today).


### Usage Example

yaml apiVersion: starrocks.com/v1 kind: StarRocksWarehouse metadata: name: my-warehouse namespace: team-a # warehouse lives in team-a spec: starRocksCluster: my-cluster starRocksClusterNamespace: starrocks # cluster lives in starrocks namespace template: ...


When `starRocksClusterNamespace` is omitted, behavior is identical to before (same-namespace lookup) — fully backward-compatible.

### Backward Compatibility

- The new field is **optional**; existing CRs continue to work without modification.
- `FE_SERVICE_NAME` is now an FQDN (`<svc>.<ns>`) instead of a short name. DNS resolution within the same namespace still works correctly, so this does not affect existing deployments.

### Related Issue(s)

https://github.com/StarRocks/starrocks-kubernetes-operator/issues/757

---

## Checklist

### For operator:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

### For helm chart:

- [x] make sure you have updated the `values.yaml` file of starrocks chart.

  > This change adds a new **optional** CRD field only. No new `values.yaml` parameters are introduced; existing deployments are unaffected. CRD files under `helm-charts/charts/warehouse/crds/` have been regenerated accordingly.

- [x] In scripts directory, run `bash create-parent-chart-values.sh` to update the `values.yaml` file of the parent chart (`kube-starrocks` chart).

  > Not applicable — no chart value changes.