### PR TITLE
fix(helm): add missing annotations field for FE Proxy pods

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -946,6 +946,10 @@ spec:
       mountPath: {{ .mountPath }}
     {{- end }}
     {{- end }}
+    {{- if .Values.starrocksFeProxySpec.annotations }}
+    annotations:
+      {{- toYaml .Values.starrocksFeProxySpec.annotations | nindent 6 }}
+    {{- end }}
     {{- if .Values.starrocksFeProxySpec.podLabels }}
     podLabels:
       {{- toYaml .Values.starrocksFeProxySpec.podLabels | nindent 6 }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -1335,5 +1335,7 @@ starrocksFeProxySpec:
       # e.g., mount an emptyDir volume to /tmp
       # - name: tmp-data
       #   mountPath: /tmp
+  # add annotations for FE proxy pods.
+  annotations: {}
   # the pod labels for user select or classify pods.
   podLabels: {}

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -1461,5 +1461,7 @@ starrocks:
         # e.g., mount an emptyDir volume to /tmp
         # - name: tmp-data
         #   mountPath: /tmp
+    # add annotations for FE proxy pods.
+    annotations: {}
     # the pod labels for user select or classify pods.
     podLabels: {}


### PR DESCRIPTION
## Summary
- The helm chart template for FE Proxy was missing the `annotations` field for pod annotations, unlike FE, BE, and CN which all have it
- Added the `annotations` rendering block in the starrockscluster template and the `annotations: {}` default in both child and parent values.yaml

Closes #750