### PR TITLE
[Feature] Add waitForTabletBalance for safer BE rolling updates

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -4495,6 +4495,15 @@ spec:
                           Default is RollingUpdate.
                         type: string
                     type: object
+                  waitForTabletBalance:
+                    description: |-
+                      WaitForTabletBalance controls rolling update behavior for BE pods.
+                      When enabled, the operator queries the FE for tablet balance status
+                      (pending_tablets and running_tablets) before allowing the next BE pod
+                      to be updated during a rolling restart. This prevents write errors
+                      caused by under-replicated tablets during rolling upgrades.
+                      Defaults to false.
+                    type: boolean
                 type: object
               starRocksCnSpec:
                 description: StarRocksCnSpec define cn configuration for start cn

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -2109,6 +2109,8 @@ spec:
                       type:
                         type: string
                     type: object
+                  waitForTabletBalance:
+                    type: boolean
                 type: object
               starRocksCnSpec:
                 properties:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -473,6 +473,9 @@ spec:
     readinessProbeFailureSeconds: {{ .Values.starrocksBeSpec.readinessProbeFailureSeconds }}
     {{- end }}
     minReadySeconds: {{ .Values.starrocksBeSpec.minReadySeconds }}
+    {{- if .Values.starrocksBeSpec.waitForTabletBalance }}
+    waitForTabletBalance: {{ .Values.starrocksBeSpec.waitForTabletBalance }}
+    {{- end }}
     podManagementPolicy: {{ .Values.starrocksBeSpec.podManagementPolicy }}
     {{- if .Values.starrocksBeSpec.lifecycle }}
     lifecycle:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -1161,6 +1161,10 @@ starrocksBeSpec:
   #       updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy',
   #       'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
   podManagementPolicy: Parallel
+  # waitForTabletBalance controls rolling update behavior for BE pods.
+  # When enabled, the operator checks tablet balance (pending_tablets, running_tablets) before restarting
+  # the next BE pod during a rolling update. This prevents write errors caused by under-replicated tablets.
+  waitForTabletBalance: false
   # Lifecycle describes actions that the management system should take in response to container lifecycle events.
   # By default, Operator will add corresponding preStop hooks for different components. For example, the preStop
   # script for the FE Component is /opt/starrocks/fe_prestop.sh, for the BE Component is /opt/starrocks/be_prestop.sh,

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -1287,6 +1287,10 @@ starrocks:
     #       updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy',
     #       'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
     podManagementPolicy: Parallel
+    # waitForTabletBalance controls rolling update behavior for BE pods.
+    # When enabled, the operator checks tablet balance (pending_tablets, running_tablets) before restarting
+    # the next BE pod during a rolling update. This prevents write errors caused by under-replicated tablets.
+    waitForTabletBalance: false
     # Lifecycle describes actions that the management system should take in response to container lifecycle events.
     # By default, Operator will add corresponding preStop hooks for different components. For example, the preStop
     # script for the FE Component is /opt/starrocks/fe_prestop.sh, for the BE Component is /opt/starrocks/be_prestop.sh,

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -170,6 +170,15 @@ type StarRocksBeSpec struct {
 	// +optional
 	// beEnvVars is a slice of environment variables that are added to the pods, the default is empty.
 	BeEnvVars []corev1.EnvVar `json:"beEnvVars,omitempty"`
+
+	// +optional
+	// WaitForTabletBalance controls rolling update behavior for BE pods.
+	// When enabled, the operator queries the FE for tablet balance status
+	// (pending_tablets and running_tablets) before allowing the next BE pod
+	// to be updated during a rolling restart. This prevents write errors
+	// caused by under-replicated tablets during rolling upgrades.
+	// Defaults to false.
+	WaitForTabletBalance bool `json:"waitForTabletBalance,omitempty"`
 }
 
 // StarRocksCnSpec defines the desired state of cn.

--- a/pkg/controllers/starrockscluster_controller.go
+++ b/pkg/controllers/starrockscluster_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -92,6 +93,11 @@ func (r *StarRocksClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		kvs := []interface{}{"subController", rc.GetControllerName()}
 		logger.Info("sub controller sync spec", kvs...)
 		if err = rc.SyncCluster(ctx, src); err != nil {
+			var requeueErr *subcontrollers.RequeueAfterError
+			if errors.As(err, &requeueErr) {
+				logger.Info(requeueErr.Reason, kvs...)
+				return ctrl.Result{RequeueAfter: requeueErr.After}, nil
+			}
 			logger.Error(err, "sub controller reconciles spec failed", kvs...)
 			handleSyncClusterError(src, rc, err)
 			if updateError := r.UpdateStarRocksClusterStatus(ctx, src); updateError != nil {

--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -143,8 +143,6 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 		return err
 	}
 
-	be.manageBERollout(ctx, src, beSpec, st.Name, logger)
-
 	if err = k8sutils.ApplyService(ctx, be.Client, internalService, rutils.ServiceDeepEqual); err != nil {
 		logger.Error(err, "apply internal service failed", "internalService", internalService)
 		return err
@@ -155,7 +153,7 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 		return err
 	}
 
-	return err
+	return be.manageBERollout(ctx, src, beSpec, st.Name)
 }
 
 // UpdateClusterStatus update the all resource status about be.
@@ -264,13 +262,11 @@ func (be *BeController) ClearCluster(ctx context.Context, src *srapi.StarRocksCl
 }
 
 func (be *BeController) manageBERollout(ctx context.Context, src *srapi.StarRocksCluster,
-	beSpec *srapi.StarRocksBeSpec, stsName string, logger logr.Logger) {
+	beSpec *srapi.StarRocksBeSpec, stsName string) error {
 	if !beSpec.WaitForTabletBalance {
-		return
+		return nil
 	}
-	if err := be.manageOnDeleteRollout(ctx, src, stsName); err != nil {
-		logger.Error(err, "managed rollout step failed")
-	}
+	return be.manageOnDeleteRollout(ctx, src, stsName)
 }
 
 func (be *BeController) validating(beSpec *srapi.StarRocksBeSpec) error {

--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -129,11 +129,21 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 	}
 	st := statefulset.MakeStatefulset(object.NewFromCluster(src), beSpec, podTemplateSpec)
 
+	// When waitForTabletBalance is enabled, use OnDelete strategy so the operator
+	// controls pod-by-pod restarts after verifying tablet balance.
+	if beSpec.WaitForTabletBalance {
+		st.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
+			Type: appsv1.OnDeleteStatefulSetStrategyType,
+		}
+	}
+
 	// update the statefulset if feSpec be updated.
 	if err = k8sutils.ApplyStatefulSet(ctx, be.Client, &st, true, rutils.StatefulSetDeepEqual); err != nil {
 		logger.Error(err, "apply statefulset failed")
 		return err
 	}
+
+	be.manageBERollout(ctx, src, beSpec, st.Name, logger)
 
 	if err = k8sutils.ApplyService(ctx, be.Client, internalService, rutils.ServiceDeepEqual); err != nil {
 		logger.Error(err, "apply internal service failed", "internalService", internalService)
@@ -251,6 +261,16 @@ func (be *BeController) ClearCluster(ctx context.Context, src *srapi.StarRocksCl
 	}
 
 	return nil
+}
+
+func (be *BeController) manageBERollout(ctx context.Context, src *srapi.StarRocksCluster,
+	beSpec *srapi.StarRocksBeSpec, stsName string, logger logr.Logger) {
+	if !beSpec.WaitForTabletBalance {
+		return
+	}
+	if err := be.manageOnDeleteRollout(ctx, src, stsName); err != nil {
+		logger.Error(err, "managed rollout step failed")
+	}
 }
 
 func (be *BeController) validating(beSpec *srapi.StarRocksBeSpec) error {

--- a/pkg/subcontrollers/be/be_tablet_balance.go
+++ b/pkg/subcontrollers/be/be_tablet_balance.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	_ "github.com/go-sql-driver/mysql" // import mysql driver
@@ -17,7 +18,10 @@ import (
 	srapi "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils/load"
+	subc "github.com/StarRocks/starrocks-kubernetes-operator/pkg/subcontrollers"
 )
+
+const tabletBalanceCheckInterval = 30 * time.Second
 
 // manageOnDeleteRollout implements a controlled rolling update for BE pods.
 // With OnDelete strategy, the StatefulSet controller does not automatically
@@ -56,18 +60,27 @@ func (be *BeController) manageOnDeleteRollout(
 		logger.Info("waiting for all BE pods to be ready",
 			"readyReplicas", actual.Status.ReadyReplicas,
 			"replicas", replicas)
-		return nil
+		return &subc.RequeueAfterError{
+			After:  tabletBalanceCheckInterval,
+			Reason: "waiting for BE pods to be ready",
+		}
 	}
 
 	// Check tablet balance via FE.
 	balanced, err := be.checkTabletBalance(ctx, src.Namespace, stsName)
 	if err != nil {
 		logger.Error(err, "tablet balance check failed, holding rollout")
-		return nil
+		return &subc.RequeueAfterError{
+			After:  tabletBalanceCheckInterval,
+			Reason: "tablet balance check failed, will retry",
+		}
 	}
 	if !balanced {
 		logger.Info("tablets not balanced, holding BE rollout")
-		return nil
+		return &subc.RequeueAfterError{
+			After:  tabletBalanceCheckInterval,
+			Reason: "waiting for tablet balance before next BE pod restart",
+		}
 	}
 
 	// Find the next pod to delete: highest ordinal still at the old revision.

--- a/pkg/subcontrollers/be/be_tablet_balance.go
+++ b/pkg/subcontrollers/be/be_tablet_balance.go
@@ -1,0 +1,225 @@
+package be
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	_ "github.com/go-sql-driver/mysql" // import mysql driver
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	srapi "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
+	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils"
+	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils/load"
+)
+
+// manageOnDeleteRollout implements a controlled rolling update for BE pods.
+// With OnDelete strategy, the StatefulSet controller does not automatically
+// restart pods when the spec changes. This method deletes one pod at a time
+// (highest ordinal first) only after verifying that all tablets are balanced.
+func (be *BeController) manageOnDeleteRollout(
+	ctx context.Context, src *srapi.StarRocksCluster, stsName string,
+) error {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	var actual appsv1.StatefulSet
+	if err := be.Client.Get(ctx, types.NamespacedName{
+		Namespace: src.Namespace,
+		Name:      stsName,
+	}, &actual); err != nil {
+		return fmt.Errorf("get BE statefulset: %w", err)
+	}
+
+	// No update pending.
+	if actual.Status.UpdateRevision == actual.Status.CurrentRevision {
+		return nil
+	}
+
+	replicas := int32(1)
+	if actual.Spec.Replicas != nil {
+		replicas = *actual.Spec.Replicas
+	}
+
+	// All pods already at target revision.
+	if actual.Status.UpdatedReplicas >= replicas {
+		return nil
+	}
+
+	// Wait for all existing pods to be ready before deleting the next one.
+	if actual.Status.ReadyReplicas < replicas {
+		logger.Info("waiting for all BE pods to be ready",
+			"readyReplicas", actual.Status.ReadyReplicas,
+			"replicas", replicas)
+		return nil
+	}
+
+	// Check tablet balance via FE.
+	balanced, err := be.checkTabletBalance(ctx, src.Namespace, stsName)
+	if err != nil {
+		logger.Error(err, "tablet balance check failed, holding rollout")
+		return nil
+	}
+	if !balanced {
+		logger.Info("tablets not balanced, holding BE rollout")
+		return nil
+	}
+
+	// Find the next pod to delete: highest ordinal still at the old revision.
+	podToDelete, err := be.findNextPodToUpdate(
+		ctx, src, stsName, actual.Status.UpdateRevision)
+	if err != nil {
+		return err
+	}
+	if podToDelete == nil {
+		return nil
+	}
+
+	logger.Info("deleting BE pod for controlled rollout",
+		"pod", podToDelete.Name,
+		"targetRevision", actual.Status.UpdateRevision)
+
+	return be.Client.Delete(ctx, podToDelete)
+}
+
+// findNextPodToUpdate lists BE pods and returns the one with the highest
+// ordinal that is not yet at the target revision.
+func (be *BeController) findNextPodToUpdate(
+	ctx context.Context, src *srapi.StarRocksCluster,
+	stsName, targetRevision string,
+) (*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+	if err := be.Client.List(ctx, podList,
+		client.InNamespace(src.Namespace),
+		client.MatchingLabels(
+			load.Selector(src.Name, src.Spec.StarRocksBeSpec)),
+	); err != nil {
+		return nil, fmt.Errorf("list BE pods: %w", err)
+	}
+
+	var candidate *corev1.Pod
+	highestOrdinal := int32(-1)
+
+	prefix := stsName + "-"
+	for i := range podList.Items {
+		p := &podList.Items[i]
+		if p.Labels[appsv1.ControllerRevisionHashLabelKey] == targetRevision {
+			continue // already updated
+		}
+		ordinalStr := strings.TrimPrefix(p.Name, prefix)
+		ordinal, err := strconv.ParseInt(ordinalStr, 10, 32)
+		if err != nil {
+			continue
+		}
+		if int32(ordinal) > highestOrdinal {
+			highestOrdinal = int32(ordinal)
+			candidate = p
+		}
+	}
+
+	return candidate, nil
+}
+
+// checkTabletBalance connects to the FE via MySQL and checks if tablet
+// rebalancing is complete. Returns true when both pending_tablets and
+// running_tablets are 0.
+func (be *BeController) checkTabletBalance(
+	ctx context.Context, namespace, stsName string,
+) (bool, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	var sts appsv1.StatefulSet
+	if err := be.Client.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      stsName,
+	}, &sts); err != nil {
+		return false, fmt.Errorf("get BE statefulset: %w", err)
+	}
+
+	rootPassword, feServiceName, feServicePort, err :=
+		be.extractFEConnectionInfo(ctx, namespace, &sts)
+	if err != nil {
+		return false, err
+	}
+
+	if !strings.Contains(feServiceName, ".") {
+		feServiceName = feServiceName + "." + namespace
+	}
+
+	dsn := fmt.Sprintf("root:%s@tcp(%s:%s)/",
+		rootPassword, feServiceName, feServicePort)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return false, fmt.Errorf("open mysql connection: %w", err)
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, "SHOW PROC '/cluster_balance'")
+	if err != nil {
+		return false, fmt.Errorf("query cluster_balance: %w", err)
+	}
+	defer rows.Close()
+
+	var pendingTablets, runningTablets int64
+	for rows.Next() {
+		var item, number string
+		if err := rows.Scan(&item, &number); err != nil {
+			return false, fmt.Errorf("scan row: %w", err)
+		}
+		switch item {
+		case "pending_tablets":
+			pendingTablets, _ = strconv.ParseInt(number, 10, 64)
+		case "running_tablets":
+			runningTablets, _ = strconv.ParseInt(number, 10, 64)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("iterate rows: %w", err)
+	}
+
+	logger.Info("tablet balance status",
+		"pendingTablets", pendingTablets,
+		"runningTablets", runningTablets)
+
+	return pendingTablets == 0 && runningTablets == 0, nil
+}
+
+// extractFEConnectionInfo reads FE_SERVICE_NAME, FE_QUERY_PORT, and
+// MYSQL_PWD from the BE StatefulSet's container env vars.
+func (be *BeController) extractFEConnectionInfo(
+	ctx context.Context, namespace string, sts *appsv1.StatefulSet,
+) (rootPassword, feServiceName, feServicePort string, err error) {
+	for _, envVar := range sts.Spec.Template.Spec.Containers[0].Env {
+		switch envVar.Name {
+		case "MYSQL_PWD":
+			rootPassword, _ = k8sutils.GetEnvVarValue(
+				ctx, be.Client, namespace, envVar)
+		case "FE_SERVICE_NAME":
+			feServiceName, err = k8sutils.GetEnvVarValue(
+				ctx, be.Client, namespace, envVar)
+			if err != nil {
+				return "", "", "",
+					fmt.Errorf("get FE_SERVICE_NAME: %w", err)
+			}
+		case "FE_QUERY_PORT":
+			feServicePort, err = k8sutils.GetEnvVarValue(
+				ctx, be.Client, namespace, envVar)
+			if err != nil {
+				return "", "", "",
+					fmt.Errorf("get FE_QUERY_PORT: %w", err)
+			}
+		}
+	}
+
+	if feServiceName == "" || feServicePort == "" {
+		return "", "", "", fmt.Errorf(
+			"FE_SERVICE_NAME or FE_QUERY_PORT not found in BE env vars")
+	}
+
+	return rootPassword, feServiceName, feServicePort, nil
+}

--- a/pkg/subcontrollers/subcontroller.go
+++ b/pkg/subcontrollers/subcontroller.go
@@ -20,6 +20,7 @@ package subcontrollers
 
 import (
 	"context"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,6 +49,16 @@ type ClusterSubController interface {
 }
 
 type GetEventRecorderForFunc func(name string) record.EventRecorder
+
+// RequeueAfterError signals that the reconcile should be requeued after a
+// delay. It is not a real failure — the main controller should not set the
+// cluster status to Failed when it receives this error.
+type RequeueAfterError struct {
+	After  time.Duration
+	Reason string
+}
+
+func (e *RequeueAfterError) Error() string { return e.Reason }
 
 type WarehouseSubController interface {
 	// ClearWarehouse will clear all resource about warehouse.


### PR DESCRIPTION
Closes https://github.com/StarRocks/starrocks-kubernetes-operator/issues/416

## Summary

- Adds `waitForTabletBalance` field to `StarRocksBeSpec` that enables controlled BE rolling updates
- When enabled, the operator uses `OnDelete` StatefulSet strategy and manages pod-by-pod restarts, only deleting the next pod after verifying all tablets are balanced via `SHOW PROC '/cluster_balance'`
- Introduces `RequeueAfterError` type so the reconciler re-checks tablet balance every 30 seconds without marking the cluster as Failed

## How it works

1. When `waitForTabletBalance: true`, the StatefulSet update strategy is set to `OnDelete` so Kubernetes does not automatically restart pods
2. After applying the StatefulSet, the operator checks if a rolling update is pending (UpdateRevision != CurrentRevision)
3. It waits for all pods to be Ready, then connects to FE via MySQL to check `pending_tablets` and `running_tablets`
4. Only when both are 0 does it delete the next pod (highest ordinal first) to trigger an update
5. The `RequeueAfterError` mechanism causes the controller to re-check every 30 seconds until the full rollout completes