### PR TITLE
fix(cn): clarify ClearCluster semantics when StarRocksCnSpec is nil

### DIFF
--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -440,15 +440,25 @@ func (cc *CnController) deleteAutoScaler(ctx context.Context, object object.Star
 	return nil
 }
 
-// ClearResources clear the deployed resource about cn. statefulset, services, hpa.
+// ClearCluster clears the deployed resources about cn (statefulset, services, hpa)
+// when StarRocksCnSpec has been removed from the StarRocksCluster spec.
+//
+// As a defensive guard, return early if the user still declares the CN spec, so
+// that we never accidentally delete a CN that is still expected to be running.
 func (cc *CnController) ClearCluster(ctx context.Context, src *srapi.StarRocksCluster) error {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	if src.Spec.StarRocksCnSpec != nil {
+		// CN is still declared in the spec, nothing to clear.
 		return nil
 	}
 
-	cnSpec := src.Spec.StarRocksCnSpec
+	// At this point cnSpec is guaranteed to be nil. Pass a typed nil pointer to
+	// the load/service helpers so the resource name is computed from the
+	// *srapi.StarRocksCnSpec type (the helpers are nil-safe). This makes the
+	// intent explicit and avoids the misleading
+	// `cnSpec := src.Spec.StarRocksCnSpec` placeholder variable.
+	var cnSpec *srapi.StarRocksCnSpec
 	statefulSetName := load.Name(src.Name, cnSpec)
 	err := k8sutils.DeleteStatefulset(ctx, cc.k8sClient, src.Namespace, statefulSetName)
 	if err != nil && !apierrors.IsNotFound(err) {


### PR DESCRIPTION
# Description

ClearCluster previously contained a confusing pattern that read like a logic bug:

    if src.Spec.StarRocksCnSpec != nil {
        return nil
    }
    cnSpec := src.Spec.StarRocksCnSpec  // always nil here
    statefulSetName := load.Name(src.Name, cnSpec)

The early-return guard was actually correct (ClearCluster is invoked by SyncCluster only when StarRocksCnSpec is nil, and the guard prevents accidental deletion if a future caller violates that contract). However the subsequent local variable cnSpec was guaranteed to be nil and only served as a placeholder, which obscured the intent and caused readers to suspect an inverted condition.

This commit:
  * Renames the stale 'ClearResources' doc comment to match the actual function name 'ClearCluster' and documents the defensive nil guard.
  * Replaces the misleading placeholder assignment with an explicit typed nil declaration (var cnSpec *srapi.StarRocksCnSpec), making it obvious that the load/service helpers rely on the type, not the value, of cnSpec to derive resource names.
  * Adds an inline comment explaining that load.Name / SearchServiceName / ExternalServiceName are nil-safe by design.

No behavioural change; this is a readability and maintainability fix.

# Related Issue(s)

[Please list any related issues and link them here.](https://github.com/StarRocks/starrocks-kubernetes-operator/issues/765)

# Checklist

For operator, please complete the following checklist:

- [ X] run `make generate` to generate the code.
- [ X] run `golangci-lint run` to check the code style.
- [ X] run `make test` to run UT.
- [ x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ X] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ X] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
