### PR TITLE
chore(helm): bump chart to 1.11.5 and StarRocks default to 4.1-latest

### DIFF
--- a/helm-charts/charts/kube-starrocks/Chart.yaml
+++ b/helm-charts/charts/kube-starrocks/Chart.yaml
@@ -25,13 +25,13 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.4
+version: 1.11.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 3.5-latest
+appVersion: 4.1-latest
 
 kubeVersion: ">=1.23.0-0"
 
@@ -43,10 +43,10 @@ keywords:
 
 dependencies:
   - name: operator
-    version: 1.11.4
+    version: 1.11.5
     repository: "file://charts/operator"
   - name: starrocks
-    version: 1.11.4
+    version: 1.11.5
     repository: "file://charts/starrocks"
 
 sources:

--- a/helm-charts/charts/kube-starrocks/charts/operator/Chart.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.4
+version: 1.11.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/Chart.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/Chart.yaml
@@ -25,13 +25,13 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.4
+version: 1.11.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 3.5-latest
+appVersion: 4.1-latest
 
 kubeVersion: ">=1.23.0-0"
 

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -127,7 +127,7 @@ starrocksCluster:
   #   2. The values in their own spec will replace all the values in this field, not merge.
   componentValues:
     image:
-      tag: "3.5-latest"
+      tag: "4.1-latest"
     # hostAliases allows adding entries to /etc/hosts inside the containers.
     hostAliases: []
       # - ip: "127.0.0.1"

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -243,7 +243,7 @@ starrocks:
     #   2. The values in their own spec will replace all the values in this field, not merge.
     componentValues:
       image:
-        tag: "3.5-latest"
+        tag: "4.1-latest"
       # hostAliases allows adding entries to /etc/hosts inside the containers.
       hostAliases: []
         # - ip: "127.0.0.1"

--- a/helm-charts/charts/warehouse/Chart.yaml
+++ b/helm-charts/charts/warehouse/Chart.yaml
@@ -23,13 +23,13 @@ maintainers:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.4
+version: 1.11.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 3.5-latest
+appVersion: 4.1-latest
 
 kubeVersion: ">=1.23.0-0"
 

--- a/helm-charts/charts/warehouse/values.yaml
+++ b/helm-charts/charts/warehouse/values.yaml
@@ -35,7 +35,7 @@ spec:
     # image sliced by "repository:tag"
     repository: starrocks/cn-ubuntu
     # Note: the image tag must be greater than or equal to 3.2.0
-    tag: 3.5-latest
+    tag: 4.1-latest
   # serviceAccount for pod access cloud service.
   serviceAccount: ""
   # add annotations for pods. for example, if you want to config monitor for datadog, you can config the annotations.


### PR DESCRIPTION
Bump Helm chart version to 1.11.5 across kube-starrocks, operator, starrocks and warehouse charts, and update the default StarRocks image to 4.1-latest. The operator app version and CR definitions are unchanged.

# Description

Please provide a detailed description of the changes you have made. Include the motivation for these changes, and any
additional context that may be important.
> the PR should include helm chart changes and operator changes.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [ ] run `make generate` to generate the code.
- [ ] run `golangci-lint run` to check the code style.
- [ ] run `make test` to run UT.
- [ ] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ ] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [ ] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
