### PR TITLE
[Feature] Expose controller-runtime manager options via helm

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,11 +32,15 @@ import (
 )
 
 var (
-	_metricsAddr          string
-	_enableLeaderElection bool
-	_probeAddr            string
-	_namespace            string
-	_denyList             string
+	_metricsAddr             string
+	_enableLeaderElection    bool
+	_probeAddr               string
+	_namespace               string
+	_denyList                string
+	_maxConcurrentReconciles int
+	_kubeAPIQPS              float64
+	_kubeAPIBurst            int
+	_syncPeriod              time.Duration
 )
 
 func main() {
@@ -50,6 +54,16 @@ func main() {
 	flag.StringVar(&config.DNSDomainSuffix, "dns-domain-suffix", "cluster.local", "The suffix of the dns domain in k8s")
 	flag.BoolVar(&config.VolumeNameWithHash, "volume-name-with-hash", true, "Add a hash to the volume name")
 	flag.StringVar(&_denyList, "deny-list", "", "Comma-separated list of namespaces to exclude from reconciliation")
+	flag.IntVar(&_maxConcurrentReconciles, "max-concurrent-reconciles", 1,
+		"Maximum number of concurrent reconciles for the StarRocksCluster controller.")
+	flag.Float64Var(&_kubeAPIQPS, "kube-api-qps", 0,
+		"QPS to use while talking with the kubernetes API server. "+
+			"If unset (0), the controller-runtime default is used (20).")
+	flag.IntVar(&_kubeAPIBurst, "kube-api-burst", 0,
+		"Burst to use while talking with the kubernetes API server. "+
+			"If unset (0), the controller-runtime default is used (30).")
+	flag.DurationVar(&_syncPeriod, "sync-period", 2*time.Minute,
+		"The minimum interval at which watched resources are reconciled.")
 
 	// Set up logger.
 	opts := zap.Options{}
@@ -61,12 +75,24 @@ func main() {
 	// Register CRD to SchemeBuilder
 	srapi.Register()
 
-	duration := 2 * time.Minute
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	// Only override when explicitly set; otherwise let controller-runtime apply its
+	// saner defaults (QPS=20, Burst=30) inside GetConfigOrDie.
+	if _kubeAPIQPS > 0 {
+		restConfig.QPS = float32(_kubeAPIQPS)
+	}
+	if _kubeAPIBurst > 0 {
+		restConfig.Burst = _kubeAPIBurst
+	}
+
+	// NOTE: ctrl.Options.SyncPeriod is deprecated in controller-runtime v0.15+
+	// in favor of cache.Options.SyncPeriod. Migrate when the controller-runtime
+	// dependency is upgraded past v0.14.
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 srapi.Scheme,
 		MetricsBindAddress:     _metricsAddr,
 		Port:                   9443,
-		SyncPeriod:             &duration,
+		SyncPeriod:             &_syncPeriod,
 		HealthProbeBindAddress: _probeAddr,
 		LeaderElection:         _enableLeaderElection,
 		LeaderElectionID:       "c6c79638.starrocks.com",
@@ -78,7 +104,7 @@ func main() {
 	}
 
 	// setup all reconciles
-	if err := controllers.SetupClusterReconciler(mgr, _denyList); err != nil {
+	if err := controllers.SetupClusterReconciler(mgr, _denyList, _maxConcurrentReconciles); err != nil {
 		logger.Error(err, "unable to set up cluster reconciler")
 		os.Exit(1)
 	}

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -47,6 +47,18 @@ spec:
         {{- if .Values.starrocksOperator.denyList }}
         - --deny-list={{ .Values.starrocksOperator.denyList }}
         {{- end }}
+        {{- if .Values.starrocksOperator.maxConcurrentReconciles }}
+        - --max-concurrent-reconciles={{ .Values.starrocksOperator.maxConcurrentReconciles }}
+        {{- end }}
+        {{- if .Values.starrocksOperator.kubeAPIQPS }}
+        - --kube-api-qps={{ .Values.starrocksOperator.kubeAPIQPS }}
+        {{- end }}
+        {{- if .Values.starrocksOperator.kubeAPIBurst }}
+        - --kube-api-burst={{ .Values.starrocksOperator.kubeAPIBurst }}
+        {{- end }}
+        {{- if .Values.starrocksOperator.syncPeriod }}
+        - --sync-period={{ .Values.starrocksOperator.syncPeriod }}
+        {{- end }}
         env:
         - name: TZ
           value: {{ .Values.timeZone }}

--- a/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
@@ -115,3 +115,24 @@ starrocksOperator:
   # If users plan to use a sidecar or init container to mount the same volume, it will be challenging to get the volume name.
   # In this situation, you can set this value to false.
   volumeNameWithHash: true
+  # Maximum number of concurrent reconciles for the StarRocksCluster controller.
+  # Increase this value to improve throughput when many StarRocksCluster resources exist in the cluster.
+  # Defaults to 1 (controller-runtime default).
+  # Note: applies only to the StarRocksCluster controller. The StarRocksWarehouse
+  # controller (optional CRD) is intentionally left at the controller-runtime default of 1.
+  maxConcurrentReconciles: 1
+  # QPS to use while talking with the kubernetes API server.
+  # Leave empty to use the controller-runtime default (20).
+  # Increase for large clusters where the operator is rate-limited by the API server.
+  # Note: setting this to 0 has no effect via helm (treated the same as empty).
+  # The "unlimited QPS" mode of client-go is intentionally not exposed.
+  kubeAPIQPS: ""
+  # Burst to use while talking with the kubernetes API server.
+  # Leave empty to use the controller-runtime default (30).
+  # Should be set together with kubeAPIQPS.
+  kubeAPIBurst: ""
+  # The minimum interval at which watched resources are reconciled.
+  # Set to a longer value (e.g. 10m) to reduce reconcile overhead on stable clusters,
+  # or shorter (e.g. 30s) when faster drift correction is needed.
+  # Accepts any value parseable by time.ParseDuration (e.g. "30s", "2m", "1h"). Defaults to "2m".
+  syncPeriod: 2m

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -122,6 +122,27 @@ operator:
     # If users plan to use a sidecar or init container to mount the same volume, it will be challenging to get the volume name.
     # In this situation, you can set this value to false.
     volumeNameWithHash: true
+    # Maximum number of concurrent reconciles for the StarRocksCluster controller.
+    # Increase this value to improve throughput when many StarRocksCluster resources exist in the cluster.
+    # Defaults to 1 (controller-runtime default).
+    # Note: applies only to the StarRocksCluster controller. The StarRocksWarehouse
+    # controller (optional CRD) is intentionally left at the controller-runtime default of 1.
+    maxConcurrentReconciles: 1
+    # QPS to use while talking with the kubernetes API server.
+    # Leave empty to use the controller-runtime default (20).
+    # Increase for large clusters where the operator is rate-limited by the API server.
+    # Note: setting this to 0 has no effect via helm (treated the same as empty).
+    # The "unlimited QPS" mode of client-go is intentionally not exposed.
+    kubeAPIQPS: ""
+    # Burst to use while talking with the kubernetes API server.
+    # Leave empty to use the controller-runtime default (30).
+    # Should be set together with kubeAPIQPS.
+    kubeAPIBurst: ""
+    # The minimum interval at which watched resources are reconciled.
+    # Set to a longer value (e.g. 10m) to reduce reconcile overhead on stable clusters,
+    # or shorter (e.g. 30s) when faster drift correction is needed.
+    # Accepts any value parseable by time.ParseDuration (e.g. "30s", "2m", "1h"). Defaults to "2m".
+    syncPeriod: 2m
 
 starrocks:
   # set the nameOverride values for creating the same resources with the parent chart.

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	srapi "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/predicates"
@@ -18,7 +19,11 @@ import (
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/subcontrollers/feproxy"
 )
 
-func SetupClusterReconciler(mgr ctrl.Manager, denyList string) error {
+// SetupClusterReconciler wires the StarRocksCluster controller into mgr.
+// maxConcurrentReconciles applies only to this controller; the Warehouse
+// reconciler (an optional CRD) is intentionally left at the controller-runtime
+// default of 1.
+func SetupClusterReconciler(mgr ctrl.Manager, denyList string, maxConcurrentReconciles int) error {
 	feController := fe.New(mgr.GetClient(), mgr.GetEventRecorderFor)
 	beController := be.New(mgr.GetClient(), mgr.GetEventRecorderFor)
 	cnController := cn.New(mgr.GetClient(), mgr.GetEventRecorderFor)
@@ -28,10 +33,11 @@ func SetupClusterReconciler(mgr ctrl.Manager, denyList string) error {
 	}
 
 	reconciler := &StarRocksClusterReconciler{
-		Client:   mgr.GetClient(),
-		Recorder: mgr.GetEventRecorderFor("starrockscluster-controller"),
-		Scs:      subcs,
-		denyList: denyList,
+		Client:                  mgr.GetClient(),
+		Recorder:                mgr.GetEventRecorderFor("starrockscluster-controller"),
+		Scs:                     subcs,
+		denyList:                denyList,
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}
 
 	if err := reconciler.SetupWithManager(mgr); err != nil {
@@ -52,6 +58,7 @@ func (r *StarRocksClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
 		WithEventFilter(predicates.NewGenericPredicates(r.denyList)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Complete(r)
 }
 

--- a/pkg/controllers/controllers_test.go
+++ b/pkg/controllers/controllers_test.go
@@ -42,7 +42,7 @@ func TestSetupClusterReconciler(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := SetupClusterReconciler(tt.args.mgr, ""); (err != nil) != tt.wantErr {
+			if err := SetupClusterReconciler(tt.args.mgr, "", 1); (err != nil) != tt.wantErr {
 				t.Errorf("SetupClusterReconciler() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/controllers/starrockscluster_controller.go
+++ b/pkg/controllers/starrockscluster_controller.go
@@ -40,9 +40,10 @@ import (
 // StarRocksClusterReconciler reconciles a StarRocksCluster object
 type StarRocksClusterReconciler struct {
 	client.Client
-	Recorder record.EventRecorder
-	Scs      []subcontrollers.ClusterSubController
-	denyList string
+	Recorder                record.EventRecorder
+	Scs                     []subcontrollers.ClusterSubController
+	denyList                string
+	MaxConcurrentReconciles int
 }
 
 // +kubebuilder:rbac:groups=starrocks.com,resources=starrocksclusters,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
# Description

Expose four previously-hardcoded controller-runtime manager options as operator flags and helm values, so users running large clusters can tune the operator without rebuilding the image.

The new knobs:
- `--max-concurrent-reconciles` (default: 1) — StarRocksCluster controller concurrency. Warehouse controller intentionally left at the controller-runtime default; can be exposed in a follow-up if requested.
- `--kube-api-qps` (default: 0 → sentinel; falls through to controller-runtime's GetConfig default of 20). Setting to 0 via helm is treated the same as unset, so client-go's "unlimited QPS" mode is intentionally not reachable from helm.
- `--kube-api-burst` (default: 0 → 30 via the same mechanism)
- `--sync-period` (default: 2m, identical to the previously-hardcoded value)

**Backward compatibility**: A default `helm install` produces operator **behavior** identical to the previous release. The two always-rendered new flags (`--max-concurrent-reconciles=1`, `--sync-period=2m`) carry values that match the previously implicit defaults, and the QPS/Burst flags are omitted from the args entirely unless the user sets them. Upgrading the operator image without re-rendering the helm chart is also safe: omitted flags fall back to Go flag defaults that match prior behavior.

# Related Issue(s)

None — proactive enhancement for large-cluster operators that hit API-server rate limits.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [ ] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
  > N/A — this PR only modifies the **operator** subchart, not the **starrocks** subchart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
