### PR TITLE
fix(helm): quote feProxy resolver so empty value renders "" not null

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -893,7 +893,7 @@ spec:
     {{- end }}
     replicas: {{ .Values.starrocksFeProxySpec.replicas }}
     imagePullPolicy: {{ .Values.starrocksFeProxySpec.imagePullPolicy }}
-    resolver: {{ .Values.starrocksFeProxySpec.resolver }}
+    resolver: "{{ .Values.starrocksFeProxySpec.resolver }}"
     {{- if .Values.starrocksFeProxySpec.resources }}
       {{- toYaml .Values.starrocksFeProxySpec.resources | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Problem

`starrocksFeProxySpec.resolver` was rendered unquoted in `starrockscluster.yaml`:

```
resolver: {{ .Values.starrocksFeProxySpec.resolver }}
```

With the default empty value this renders `resolver: ` → YAML `null` in the `StarRocksCluster` CR.
The CRD defines `resolver` as `type: string` (non-nullable), so admission rejects the object
(`... must be of type string: "null"`). The operator's Go-side kube-dns default never runs because
the CR is rejected before it reaches the operator. Net effect: feProxy cannot be enabled via Helm
with default values.

## Fix

Quote the value so an empty value renders a valid empty string:

```
resolver: "{{ .Values.starrocksFeProxySpec.resolver }}"
```

`resolver: ""` passes CRD validation, and the operator substitutes its `kube-dns.kube-system.<suffix>`
default for the empty string.

## Verification

- `helm template … --set starrocks.starrocksFeProxySpec.enabled=true` → `resolver: ""` (was `resolver: ` / null).
- With a value set → `resolver: "kube-dns.kube-system.svc.cluster.local"`.
- `helm lint` + `helm template` pass.
