### PR TITLE
feat(helm): expose waitForFullRollout in kube-starrocks chart

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- toYaml .Values.starrocksCluster.annotations | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.starrocksCluster.waitForFullRollout }}
+  waitForFullRollout: {{ .Values.starrocksCluster.waitForFullRollout }}
+  {{- end }}
   {{- if .Values.starrocksCluster.disasterRecovery }}
   disasterRecovery:
     {{- toYaml .Values.starrocksCluster.disasterRecovery | nindent 4 }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -111,6 +111,10 @@ starrocksCluster:
   # specify the BE/CN deployment or not.
   enabledBe: true
   enabledCn: false
+  # When true, the operator waits for the FE StatefulSet to be fully rolled out (all replicas ready
+  # and at the same revision) before updating BE/CN. This prevents a bad FE rollout from cascading
+  # to BE/CN. Defaults to false for backward compatibility.
+  waitForFullRollout: false
   # Disaster recovery configuration. If you want to enable disaster recovery, you need to set the enabled field to true.
   # Note:
   #  1. If you are using an existing StarRocks cluster, you need to clean up the meta of the FE component and the data of the CN

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -237,6 +237,10 @@ starrocks:
     # specify the BE/CN deployment or not.
     enabledBe: true
     enabledCn: false
+    # When true, the operator waits for the FE StatefulSet to be fully rolled out (all replicas ready
+    # and at the same revision) before updating BE/CN. This prevents a bad FE rollout from cascading
+    # to BE/CN. Defaults to false for backward compatibility.
+    waitForFullRollout: false
     # Disaster recovery configuration. If you want to enable disaster recovery, you need to set the enabled field to true.
     # Note:
     #  1. If you are using an existing StarRocks cluster, you need to clean up the meta of the FE component and the data of the CN


### PR DESCRIPTION
## Describe the bug

`waitForFullRollout` was added to the CRD, Go types, and FE/BE/CN controllers in #739, and the
operator honors it — but the Helm chart never exposed it: the `starrockscluster.yaml` template did
not render `spec.waitForFullRollout` and there was no `values.yaml` knob. Helm users therefore
could not enable the feature without manually patching the CR.

## What this changes

- Render `spec.waitForFullRollout` onto the `StarRocksCluster` (guarded, same style as `disasterRecovery`).
- Add `waitForFullRollout: false` under `starrocksCluster` in both the `starrocks` subchart values
  and the parent `kube-starrocks` values, with a doc comment.

The chart's bundled CRD already includes the field, so no CRD change is needed.

## Verification

- `helm template … --set starrocks.starrocksCluster.waitForFullRollout=true` renders `spec.waitForFullRollout: true`; default render omits it.
- Live: setting the value via the chart applies to the `StarRocksCluster` CR (CRD accepts the field).
- `helm lint` + `helm template` pass.
