### PR TITLE
feat(fe): add declarative observer replica support

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -13601,6 +13601,13 @@ spec:
                     description: (Optional) If specified, the pod's nodeSelector，displayName="Map
                       of nodeSelectors to match when scheduling pods on nodes"
                     type: object
+                  observerReplicas:
+                    description: |-
+                      ObserverReplicas is the number of FE pods that should join as OBSERVER.
+                      The value must be strictly less than replicas to keep at least one FOLLOWER.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   persistentVolumeClaimRetentionPolicy:
                     description: |-
                       PersistentVolumeClaimRetentionPolicy specifies the retention policy for PersistentVolumeClaims associated with the component.

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -6413,6 +6413,10 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  observerReplicas:
+                    format: int32
+                    minimum: 0
+                    type: integer
                   persistentVolumeClaimRetentionPolicy:
                     properties:
                       whenDeleted:

--- a/doc/api.md
+++ b/doc/api.md
@@ -1704,6 +1704,19 @@ StarRocksComponentSpec
 </tr>
 <tr>
 <td>
+<code>observerReplicas</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObserverReplicas is the number of FE pods that should join as OBSERVER.
+The value must be strictly less than replicas to keep at least one FOLLOWER.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>feEnvVars</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#envvar-v1-core">

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -33,6 +33,9 @@ spec:
       - {{template "starrockscluster.entrypoint.mount.path" .}}/{{template "starrockscluster.entrypoint.script.name" .}}
     {{- end }}
     replicas: {{ .Values.starrocksFESpec.replicas }}
+    {{- if .Values.starrocksFESpec.observerReplicas }}
+    observerReplicas: {{ .Values.starrocksFESpec.observerReplicas }}
+    {{- end }}
     imagePullPolicy: {{ .Values.starrocksFESpec.imagePullPolicy }}
     {{- if .Values.starrocksFESpec.maxUnavailablePods }}
     updateStrategy:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -204,6 +204,9 @@ starrocksCluster:
 starrocksFESpec:
   # number of replicas to deploy for a FE statefulset.
   replicas: 1
+  # number of FE pods to join as OBSERVER.
+  # must be strictly less than replicas to ensure at least one FOLLOWER.
+  observerReplicas: 0
   image:
     # image sliced by "repository:tag"
     repository: starrocks/fe-ubuntu

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -330,6 +330,9 @@ starrocks:
   starrocksFESpec:
     # number of replicas to deploy for a FE statefulset.
     replicas: 1
+    # number of FE pods to join as OBSERVER.
+    # must be strictly less than replicas to ensure at least one FOLLOWER.
+    observerReplicas: 0
     image:
       # image sliced by "repository:tag"
       repository: starrocks/fe-ubuntu

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -158,6 +158,12 @@ type StarRocksClusterStatus struct {
 type StarRocksFeSpec struct {
 	StarRocksComponentSpec `json:",inline"`
 
+	// ObserverReplicas is the number of FE pods that should join as OBSERVER.
+	// The value must be strictly less than replicas to keep at least one FOLLOWER.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	ObserverReplicas int32 `json:"observerReplicas,omitempty"`
+
 	// +optional
 	// feEnvVars is a slice of environment variables that are added to the pods, the default is empty.
 	FeEnvVars []corev1.EnvVar `json:"feEnvVars,omitempty"`

--- a/pkg/subcontrollers/fe/fe_controller.go
+++ b/pkg/subcontrollers/fe/fe_controller.go
@@ -18,6 +18,7 @@ package fe
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -224,6 +225,18 @@ func (fc *FeController) Validating(feSpec *srapi.StarRocksFeSpec) error {
 			return err
 		}
 	}
+
+	replicas := int32(1)
+	if feSpec.GetReplicas() != nil {
+		replicas = *feSpec.GetReplicas()
+	}
+	if feSpec.ObserverReplicas >= replicas {
+		return fmt.Errorf("observerReplicas (%d) must be less than replicas (%d)", feSpec.ObserverReplicas, replicas)
+	}
+	if feSpec.ObserverReplicas > 0 && (feSpec.GetCommand() != nil || feSpec.GetArgs() != nil) {
+		return fmt.Errorf("observerReplicas requires default FE command and args")
+	}
+
 	if err := srapi.ValidUpdateStrategy(feSpec.UpdateStrategy); err != nil {
 		return err
 	}

--- a/pkg/subcontrollers/fe/fe_controller.go
+++ b/pkg/subcontrollers/fe/fe_controller.go
@@ -230,7 +230,7 @@ func (fc *FeController) Validating(feSpec *srapi.StarRocksFeSpec) error {
 	if feSpec.GetReplicas() != nil {
 		replicas = *feSpec.GetReplicas()
 	}
-	if feSpec.ObserverReplicas >= replicas {
+	if feSpec.ObserverReplicas > 0 && feSpec.ObserverReplicas >= replicas {
 		return fmt.Errorf("observerReplicas (%d) must be less than replicas (%d)", feSpec.ObserverReplicas, replicas)
 	}
 	if feSpec.ObserverReplicas > 0 && (feSpec.GetCommand() != nil || feSpec.GetArgs() != nil) {

--- a/pkg/subcontrollers/fe/fe_controller_test.go
+++ b/pkg/subcontrollers/fe/fe_controller_test.go
@@ -536,6 +536,7 @@ func TestValidatingObserverReplicas(t *testing.T) {
 
 	validReplicas := int32(3)
 	forbiddenReplicas := int32(2)
+	zeroReplicas := int32(0)
 	validSpec := &srapi.StarRocksFeSpec{
 		StarRocksComponentSpec: srapi.StarRocksComponentSpec{
 			StarRocksLoadSpec: srapi.StarRocksLoadSpec{
@@ -566,6 +567,27 @@ func TestValidatingObserverReplicas(t *testing.T) {
 		ObserverReplicas: 1,
 	}
 	require.Error(t, fc.Validating(invalidCommandSpec))
+
+	// Backward compatibility: observerReplicas defaults to 0 when omitted,
+	// and replicas=0 should continue to validate.
+	zeroReplicaSpec := &srapi.StarRocksFeSpec{
+		StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+			StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+				Replicas: &zeroReplicas,
+			},
+		},
+	}
+	require.NoError(t, fc.Validating(zeroReplicaSpec))
+
+	zeroReplicaWithObserverSpec := &srapi.StarRocksFeSpec{
+		StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+			StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+				Replicas: &zeroReplicas,
+			},
+		},
+		ObserverReplicas: 1,
+	}
+	require.Error(t, fc.Validating(zeroReplicaWithObserverSpec))
 }
 
 func TestSyncDeployWithObserverReplicas(t *testing.T) {

--- a/pkg/subcontrollers/fe/fe_controller_test.go
+++ b/pkg/subcontrollers/fe/fe_controller_test.go
@@ -530,3 +530,78 @@ func TestGetFeConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatingObserverReplicas(t *testing.T) {
+	fc := fe.New(fake.NewFakeClient(srapi.Scheme), fake.GetEventRecorderFor(nil))
+
+	validReplicas := int32(3)
+	forbiddenReplicas := int32(2)
+	validSpec := &srapi.StarRocksFeSpec{
+		StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+			StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+				Replicas: &validReplicas,
+			},
+		},
+		ObserverReplicas: 2,
+	}
+	require.NoError(t, fc.Validating(validSpec))
+
+	invalidSpec := &srapi.StarRocksFeSpec{
+		StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+			StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+				Replicas: &forbiddenReplicas,
+			},
+		},
+		ObserverReplicas: 2,
+	}
+	require.Error(t, fc.Validating(invalidSpec))
+
+	invalidCommandSpec := &srapi.StarRocksFeSpec{
+		StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+			StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+				Replicas: &validReplicas,
+			},
+			Command: []string{"/bin/bash"},
+		},
+		ObserverReplicas: 1,
+	}
+	require.Error(t, fc.Validating(invalidCommandSpec))
+}
+
+func TestSyncDeployWithObserverReplicas(t *testing.T) {
+	replicas := int32(4)
+	src := &srapi.StarRocksCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-observer",
+			Namespace: "default",
+		},
+		Spec: srapi.StarRocksClusterSpec{
+			StarRocksFeSpec: &srapi.StarRocksFeSpec{
+				StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+					StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+						Replicas: &replicas,
+						Image:    "starrocks/fe-ubuntu:latest",
+					},
+				},
+				ObserverReplicas: 1,
+			},
+		},
+	}
+
+	fc := fe.New(fake.NewFakeClient(srapi.Scheme, src), fake.GetEventRecorderFor(nil))
+	require.NoError(t, fc.SyncCluster(context.Background(), src))
+
+	var st appsv1.StatefulSet
+	require.NoError(t, fc.Client.Get(context.Background(),
+		types.NamespacedName{Name: load.Name(src.Name, src.Spec.StarRocksFeSpec), Namespace: "default"}, &st))
+
+	require.Equal(t, []string{"/bin/bash", "-c"}, st.Spec.Template.Spec.Containers[0].Command)
+	require.Contains(t, st.Spec.Template.Spec.Containers[0].Args[0], "IS_FE_OBSERVER")
+
+	envMap := map[string]string{}
+	for _, env := range st.Spec.Template.Spec.Containers[0].Env {
+		envMap[env.Name] = env.Value
+	}
+	require.Equal(t, "4", envMap["FE_REPLICAS"])
+	require.Equal(t, "1", envMap["FE_OBSERVER_REPLICAS"])
+}

--- a/pkg/subcontrollers/fe/fe_controller_test.go
+++ b/pkg/subcontrollers/fe/fe_controller_test.go
@@ -618,7 +618,12 @@ func TestSyncDeployWithObserverReplicas(t *testing.T) {
 		types.NamespacedName{Name: load.Name(src.Name, src.Spec.StarRocksFeSpec), Namespace: "default"}, &st))
 
 	require.Equal(t, []string{"/bin/bash", "-c"}, st.Spec.Template.Spec.Containers[0].Command)
-	require.Contains(t, st.Spec.Template.Spec.Containers[0].Args[0], "IS_FE_OBSERVER")
+	observerScript := st.Spec.Template.Spec.Containers[0].Args[0]
+	require.Contains(t, observerScript, "ordinal=\"${POD_NAME##*-}\"")
+	require.Contains(t, observerScript, "follower_replicas=$((FE_REPLICAS-FE_OBSERVER_REPLICAS))")
+	require.Contains(t, observerScript, "export IS_FE_OBSERVER=true")
+	require.Contains(t, observerScript, "export IS_FE_OBSERVER=false")
+	require.Contains(t, observerScript, "exec /opt/starrocks/fe_entrypoint.sh \"${FE_SERVICE_NAME}\"")
 
 	envMap := map[string]string{}
 	for _, env := range st.Spec.Template.Spec.Containers[0].Env {
@@ -626,4 +631,44 @@ func TestSyncDeployWithObserverReplicas(t *testing.T) {
 	}
 	require.Equal(t, "4", envMap["FE_REPLICAS"])
 	require.Equal(t, "1", envMap["FE_OBSERVER_REPLICAS"])
+}
+
+func TestSyncDeployWithoutObserverReplicasUsesDefaultEntrypoint(t *testing.T) {
+	replicas := int32(3)
+	src := &srapi.StarRocksCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-no-observer",
+			Namespace: "default",
+		},
+		Spec: srapi.StarRocksClusterSpec{
+			StarRocksFeSpec: &srapi.StarRocksFeSpec{
+				StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+					StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+						Replicas: &replicas,
+						Image:    "starrocks/fe-ubuntu:latest",
+					},
+				},
+				ObserverReplicas: 0,
+			},
+		},
+	}
+
+	fc := fe.New(fake.NewFakeClient(srapi.Scheme, src), fake.GetEventRecorderFor(nil))
+	require.NoError(t, fc.SyncCluster(context.Background(), src))
+
+	var st appsv1.StatefulSet
+	require.NoError(t, fc.Client.Get(context.Background(),
+		types.NamespacedName{Name: load.Name(src.Name, src.Spec.StarRocksFeSpec), Namespace: "default"}, &st))
+
+	// No observer replicas means default FE entrypoint should be used
+	// (without the observer-aware shell wrapper).
+	require.Equal(t, []string{"/opt/starrocks/fe_entrypoint.sh"}, st.Spec.Template.Spec.Containers[0].Command)
+	require.Equal(t, []string{"$(FE_SERVICE_NAME)"}, st.Spec.Template.Spec.Containers[0].Args)
+
+	envMap := map[string]string{}
+	for _, env := range st.Spec.Template.Spec.Containers[0].Env {
+		envMap[env.Name] = env.Value
+	}
+	require.Equal(t, "3", envMap["FE_REPLICAS"])
+	require.Equal(t, "0", envMap["FE_OBSERVER_REPLICAS"])
 }

--- a/pkg/subcontrollers/fe/fe_pod.go
+++ b/pkg/subcontrollers/fe/fe_pod.go
@@ -17,6 +17,9 @@ limitations under the License.
 package fe
 
 import (
+	"fmt"
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,10 +31,12 @@ import (
 )
 
 const (
-	_metaName             = "fe-meta"
-	_logName              = "fe-log"
-	_feConfigMountPath    = "/etc/starrocks/fe/conf"
-	_envFeConfigMountPath = "CONFIGMAP_MOUNT_PATH"
+	_metaName              = "fe-meta"
+	_logName               = "fe-log"
+	_feConfigMountPath     = "/etc/starrocks/fe/conf"
+	_envFeConfigMountPath  = "CONFIGMAP_MOUNT_PATH"
+	_envFeReplicas         = "FE_REPLICAS"
+	_envFeObserverReplicas = "FE_OBSERVER_REPLICAS"
 )
 
 // buildPodTemplate construct the podTemplate for deploy fe.
@@ -58,12 +63,30 @@ func (fc *FeController) buildPodTemplate(src *srapi.StarRocksCluster, config map
 
 	feExternalServiceName := service.ExternalServiceName(src.Name, feSpec)
 	envs := pod.Envs(src.Spec.StarRocksFeSpec, config, feExternalServiceName, src.Namespace, feSpec.FeEnvVars)
+	replicas := int32(1)
+	if feSpec.GetReplicas() != nil {
+		replicas = *feSpec.GetReplicas()
+	}
+	envs = append(envs, corev1.EnvVar{
+		Name:  _envFeReplicas,
+		Value: strconv.FormatInt(int64(replicas), 10),
+	}, corev1.EnvVar{
+		Name:  _envFeObserverReplicas,
+		Value: strconv.FormatInt(int64(feSpec.ObserverReplicas), 10),
+	})
+
+	command := pod.ContainerCommand(feSpec)
+	args := pod.ContainerArgs(feSpec)
+	if feSpec.ObserverReplicas > 0 {
+		command, args = buildObserverAwareEntrypoint(feSpec)
+	}
+
 	httpPort := rutils.GetPort(config, rutils.HTTP_PORT)
 	feContainer := corev1.Container{
 		Name:            srapi.DEFAULT_FE,
 		Image:           feSpec.Image,
-		Command:         pod.ContainerCommand(feSpec),
-		Args:            pod.ContainerArgs(feSpec),
+		Command:         command,
+		Args:            args,
 		Ports:           pod.Ports(feSpec, config),
 		Env:             envs,
 		Resources:       feSpec.ResourceRequirements,
@@ -98,4 +121,18 @@ func (fc *FeController) buildPodTemplate(src *srapi.StarRocksCluster, config map
 		},
 		Spec: podSpec,
 	}, nil
+}
+
+func buildObserverAwareEntrypoint(feSpec *srapi.StarRocksFeSpec) ([]string, []string) {
+	entrypoint := fmt.Sprintf("%s/fe_entrypoint.sh", pod.GetStarRocksRootPath(feSpec.FeEnvVars))
+	script := fmt.Sprintf(`set -euo pipefail
+ordinal="${POD_NAME##*-}"
+follower_replicas=$((FE_REPLICAS-FE_OBSERVER_REPLICAS))
+if [ "$ordinal" -ge "$follower_replicas" ]; then
+  export IS_FE_OBSERVER=true
+else
+  export IS_FE_OBSERVER=false
+fi
+exec %s "${FE_SERVICE_NAME}"`, entrypoint)
+	return []string{"/bin/bash", "-c"}, []string{script}
 }


### PR DESCRIPTION


# Description

Allow FE topology to be declared as follower plus observer replicas by introducing observerReplicas on StarRocksFeSpec and wiring FE startup to set IS_FE_OBSERVER per pod ordinal. This enforces observerReplicas < replicas to preserve at least one follower, updates Helm and generated CRD/API docs, and adds FE controller coverage for validation and rendered StatefulSet behavior.

# Related Issue(s)

https://github.com/StarRocks/starrocks-kubernetes-operator/issues/767

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `golangci-lint run` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
