### PR TITLE
[Feature] Support externalTrafficPolicy in the component service spec

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -2761,6 +2761,20 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      externalTrafficPolicy:
+                        description: |-
+                          ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
+                          Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                          "Local" preserves the client source IP and avoids a second hop, but risks unbalanced traffic spreading.
+                          "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good
+                          overall load-spreading.
+                          Kubernetes only allows this field when type is NodePort or LoadBalancer; if it is set for a service of
+                          another type, reconciliation fails and the error is reported in the cluster status.
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string
@@ -7800,6 +7814,20 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      externalTrafficPolicy:
+                        description: |-
+                          ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
+                          Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                          "Local" preserves the client source IP and avoids a second hop, but risks unbalanced traffic spreading.
+                          "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good
+                          overall load-spreading.
+                          Kubernetes only allows this field when type is NodePort or LoadBalancer; if it is set for a service of
+                          another type, reconciliation fails and the error is reported in the cluster status.
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string
@@ -10657,6 +10685,20 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      externalTrafficPolicy:
+                        description: |-
+                          ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
+                          Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                          "Local" preserves the client source IP and avoids a second hop, but risks unbalanced traffic spreading.
+                          "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good
+                          overall load-spreading.
+                          Kubernetes only allows this field when type is NodePort or LoadBalancer; if it is set for a service of
+                          another type, reconciliation fails and the error is reported in the cluster status.
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string
@@ -13726,6 +13768,20 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      externalTrafficPolicy:
+                        description: |-
+                          ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
+                          Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                          "Local" preserves the client source IP and avoids a second hop, but risks unbalanced traffic spreading.
+                          "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good
+                          overall load-spreading.
+                          Kubernetes only allows this field when type is NodePort or LoadBalancer; if it is set for a service of
+                          another type, reconciliation fails and the error is reported in the cluster status.
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string

--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -3357,6 +3357,20 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      externalTrafficPolicy:
+                        description: |-
+                          ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
+                          Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                          "Local" preserves the client source IP and avoids a second hop, but risks unbalanced traffic spreading.
+                          "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good
+                          overall load-spreading.
+                          Kubernetes only allows this field when type is NodePort or LoadBalancer; if it is set for a service of
+                          another type, reconciliation fails and the error is reported in the cluster status.
+                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -1340,6 +1340,11 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      externalTrafficPolicy:
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string
@@ -3726,6 +3731,11 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      externalTrafficPolicy:
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string
@@ -5046,6 +5056,11 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      externalTrafficPolicy:
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string
@@ -6465,6 +6480,11 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      externalTrafficPolicy:
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -1654,6 +1654,11 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      externalTrafficPolicy:
+                        enum:
+                        - Cluster
+                        - Local
+                        type: string
                       labels:
                         additionalProperties:
                           type: string

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -57,6 +57,9 @@ spec:
       loadBalancerSourceRanges:
         {{- toYaml .Values.starrocksFESpec.service.loadBalancerSourceRanges | nindent 8 }}
       {{- end }}
+      {{- if and (or (eq "LoadBalancer" .Values.starrocksFESpec.service.type) (eq "NodePort" .Values.starrocksFESpec.service.type)) .Values.starrocksFESpec.service.externalTrafficPolicy }}
+      externalTrafficPolicy: {{ .Values.starrocksFESpec.service.externalTrafficPolicy }}
+      {{- end }}
       {{- if .Values.starrocksFESpec.service.ports }}
       ports:
         {{- toYaml .Values.starrocksFESpec.service.ports | nindent 8 }}
@@ -322,6 +325,9 @@ spec:
       {{- if and (eq "LoadBalancer" .Values.starrocksBeSpec.service.type) .Values.starrocksBeSpec.service.loadBalancerSourceRanges}}
       loadBalancerSourceRanges:
         {{- toYaml .Values.starrocksBeSpec.service.loadBalancerSourceRanges | nindent 8 }}
+      {{- end }}
+      {{- if and (or (eq "LoadBalancer" .Values.starrocksBeSpec.service.type) (eq "NodePort" .Values.starrocksBeSpec.service.type)) .Values.starrocksBeSpec.service.externalTrafficPolicy }}
+      externalTrafficPolicy: {{ .Values.starrocksBeSpec.service.externalTrafficPolicy }}
       {{- end }}
       {{- if .Values.starrocksBeSpec.service.ports }}
       ports:
@@ -764,6 +770,9 @@ spec:
       loadBalancerSourceRanges:
         {{- toYaml .Values.starrocksCnSpec.service.loadBalancerSourceRanges | nindent 8 }}
       {{- end }}
+      {{- if and (or (eq "LoadBalancer" .Values.starrocksCnSpec.service.type) (eq "NodePort" .Values.starrocksCnSpec.service.type)) .Values.starrocksCnSpec.service.externalTrafficPolicy }}
+      externalTrafficPolicy: {{ .Values.starrocksCnSpec.service.externalTrafficPolicy }}
+      {{- end }}
       {{- if .Values.starrocksCnSpec.service.ports }}
       ports:
         {{- toYaml .Values.starrocksCnSpec.service.ports | nindent 8 }}
@@ -917,6 +926,9 @@ spec:
       {{- if and (eq "LoadBalancer" .Values.starrocksFeProxySpec.service.type) .Values.starrocksFeProxySpec.service.loadBalancerSourceRanges}}
       loadBalancerSourceRanges:
         {{- toYaml .Values.starrocksFeProxySpec.service.loadBalancerSourceRanges | nindent 8 }}
+      {{- end }}
+      {{- if and (or (eq "LoadBalancer" .Values.starrocksFeProxySpec.service.type) (eq "NodePort" .Values.starrocksFeProxySpec.service.type)) .Values.starrocksFeProxySpec.service.externalTrafficPolicy }}
+      externalTrafficPolicy: {{ .Values.starrocksFeProxySpec.service.externalTrafficPolicy }}
       {{- end }}
       {{- if .Values.starrocksFeProxySpec.service.ports }}
       ports:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -265,6 +265,9 @@ starrocksFESpec:
     # specifies the source IP ranges for the load balancer when the type=LoadBalancer.
     loadBalancerSourceRanges: []
       # - 10.0.0.0/8
+    # specifies how nodes distribute service traffic. Possible values: Cluster, Local.
+    # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+    externalTrafficPolicy: ""
   # imagePullSecrets allows you to use secrets to pull images for pods.
   imagePullSecrets: []
     # - name: "image-pull-secret"
@@ -594,6 +597,9 @@ starrocksCnSpec:
     # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
     loadBalancerSourceRanges: []
       # - 10.0.0.0/8
+    # Specify how nodes distribute service traffic. Possible values: Cluster, Local.
+    # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+    externalTrafficPolicy: ""
   # imagePullSecrets allows you to use secrets for pulling images for your pods.
   imagePullSecrets: []
     # - name: "image-pull-secret"
@@ -959,6 +965,9 @@ starrocksBeSpec:
     # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
     loadBalancerSourceRanges: []
       # - 10.0.0.0/8
+    # Specify how nodes distribute service traffic. Possible values: Cluster, Local.
+    # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+    externalTrafficPolicy: ""
   # imagePullSecrets allows you to use secrets to pull images for pods.
   imagePullSecrets: []
     # - name: "image-pull-secret"
@@ -1288,6 +1297,9 @@ starrocksFeProxySpec:
     # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
     loadBalancerSourceRanges: []
       # - 10.0.0.0/8
+    # Specify how nodes distribute service traffic. Possible values: Cluster, Local.
+    # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+    externalTrafficPolicy: ""
   # imagePullSecrets allows you to use secrets for pulling images for your pods.
   imagePullSecrets: []
   # - name: "image-pull-secret"

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -391,6 +391,9 @@ starrocks:
       # specifies the source IP ranges for the load balancer when the type=LoadBalancer.
       loadBalancerSourceRanges: []
         # - 10.0.0.0/8
+      # specifies how nodes distribute service traffic. Possible values: Cluster, Local.
+      # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+      externalTrafficPolicy: ""
     # imagePullSecrets allows you to use secrets to pull images for pods.
     imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -720,6 +723,9 @@ starrocks:
       # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
       loadBalancerSourceRanges: []
         # - 10.0.0.0/8
+      # Specify how nodes distribute service traffic. Possible values: Cluster, Local.
+      # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+      externalTrafficPolicy: ""
     # imagePullSecrets allows you to use secrets for pulling images for your pods.
     imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -1085,6 +1091,9 @@ starrocks:
       # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
       loadBalancerSourceRanges: []
         # - 10.0.0.0/8
+      # Specify how nodes distribute service traffic. Possible values: Cluster, Local.
+      # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+      externalTrafficPolicy: ""
     # imagePullSecrets allows you to use secrets to pull images for pods.
     imagePullSecrets: []
       # - name: "image-pull-secret"
@@ -1414,6 +1423,9 @@ starrocks:
       # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
       loadBalancerSourceRanges: []
         # - 10.0.0.0/8
+      # Specify how nodes distribute service traffic. Possible values: Cluster, Local.
+      # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+      externalTrafficPolicy: ""
     # imagePullSecrets allows you to use secrets for pulling images for your pods.
     imagePullSecrets: []
     # - name: "image-pull-secret"

--- a/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
+++ b/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
@@ -64,6 +64,9 @@ spec:
       {{- if and (eq "LoadBalancer" .Values.spec.service.type) .Values.spec.service.loadbalancerIP }}
       loadBalancerIP: {{ .Values.spec.service.loadbalancerIP }}
       {{- end }}
+      {{- if and (or (eq "LoadBalancer" .Values.spec.service.type) (eq "NodePort" .Values.spec.service.type)) .Values.spec.service.externalTrafficPolicy }}
+      externalTrafficPolicy: {{ .Values.spec.service.externalTrafficPolicy }}
+      {{- end }}
       {{- if .Values.spec.service.ports }}
       ports:
         {{- toYaml .Values.spec.service.ports | nindent 8 }}

--- a/helm-charts/charts/warehouse/values.yaml
+++ b/helm-charts/charts/warehouse/values.yaml
@@ -63,6 +63,9 @@ spec:
       #   nodePort: 30040 # The range of valid ports is 30000-32767
       #   containerPort: 8040 # The port on the container to expose
       #   port: 8040 # The port to expose on the service
+    # Specify how nodes distribute service traffic. Possible values: Cluster, Local.
+    # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
+    externalTrafficPolicy: ""
   # imagePullSecrets allows you to use secrets for pulling images for your pods.
   imagePullSecrets: []
     # - name: "image-pull-secret"

--- a/pkg/apis/starrocks/v1/load_type.go
+++ b/pkg/apis/starrocks/v1/load_type.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -250,6 +252,38 @@ type StarRocksService struct {
 	// More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
 	// +optional
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
+
+	// ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
+	// Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+	// "Local" preserves the client source IP and avoids a second hop, but risks unbalanced traffic spreading.
+	// "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good
+	// overall load-spreading.
+	// Kubernetes only allows this field when type is NodePort or LoadBalancer; if it is set for a service of
+	// another type, reconciliation fails and the error is reported in the cluster status.
+	// More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+	// +kubebuilder:validation:Enum=Cluster;Local
+	// +optional
+	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicyType `json:"externalTrafficPolicy,omitempty"`
+}
+
+// Validate checks constraints that the Kubernetes API server enforces on the Service object built
+// from this spec, so that every controller can reject an invalid spec up front with a clear
+// message instead of failing when the Service is applied.
+func (svc *StarRocksService) Validate() error {
+	if svc == nil {
+		return nil
+	}
+	if svc.ExternalTrafficPolicy != "" {
+		serviceType := svc.Type
+		if serviceType == "" {
+			serviceType = corev1.ServiceTypeClusterIP
+		}
+		if serviceType != corev1.ServiceTypeNodePort && serviceType != corev1.ServiceTypeLoadBalancer {
+			return fmt.Errorf("service: externalTrafficPolicy %s may only be set when the service type is "+
+				"NodePort or LoadBalancer, but the type is %s", svc.ExternalTrafficPolicy, serviceType)
+		}
+	}
+	return nil
 }
 
 // StarRocksServicePort defines the port that will be exposed by this service.

--- a/pkg/apis/starrocks/v1/load_type_test.go
+++ b/pkg/apis/starrocks/v1/load_type_test.go
@@ -1,0 +1,80 @@
+// Copyright 2021-present, StarRocks Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestStarRocksService_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		svc     *StarRocksService
+		wantErr bool
+	}{
+		{
+			name: "nil service is valid",
+			svc:  nil,
+		},
+		{
+			name: "empty service is valid",
+			svc:  &StarRocksService{},
+		},
+		{
+			name: "LoadBalancer with Local policy is valid",
+			svc: &StarRocksService{
+				Type:                  corev1.ServiceTypeLoadBalancer,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+			},
+		},
+		{
+			name: "NodePort with Cluster policy is valid",
+			svc: &StarRocksService{
+				Type:                  corev1.ServiceTypeNodePort,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+			},
+		},
+		{
+			name: "explicit ClusterIP with policy is invalid",
+			svc: &StarRocksService{
+				Type:                  corev1.ServiceTypeClusterIP,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+			},
+			wantErr: true,
+		},
+		{
+			name: "default ClusterIP with policy is invalid",
+			svc: &StarRocksService{
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+			},
+			wantErr: true,
+		},
+		{
+			name: "ClusterIP without policy is valid",
+			svc: &StarRocksService{
+				Type: corev1.ServiceTypeClusterIP,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.svc.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/common/resource_utils/service.go
+++ b/pkg/common/resource_utils/service.go
@@ -56,6 +56,7 @@ type hashService struct {
 	labels                   map[string]string
 	annotations              map[string]string
 	loadBalancerSourceRanges []string
+	externalTrafficPolicy    corev1.ServiceExternalTrafficPolicyType
 }
 
 // BuildExternalService build the external service. not have selector
@@ -208,6 +209,14 @@ func setServiceType(svc *srapi.StarRocksService, service *corev1.Service) {
 	if service.Spec.Type == corev1.ServiceTypeLoadBalancer && svc.LoadBalancerIP != "" {
 		service.Spec.LoadBalancerIP = svc.LoadBalancerIP
 	}
+
+	// The spec is validated up front by StarRocksService.Validate; the type guard here only keeps an
+	// invalid combination from reaching the API server, which rejects externalTrafficPolicy on
+	// service types other than NodePort and LoadBalancer.
+	if svc != nil && svc.ExternalTrafficPolicy != "" &&
+		(service.Spec.Type == corev1.ServiceTypeLoadBalancer || service.Spec.Type == corev1.ServiceTypeNodePort) {
+		service.Spec.ExternalTrafficPolicy = svc.ExternalTrafficPolicy
+	}
 }
 
 func mergePort(service *srapi.StarRocksService, defaultPort srapi.StarRocksServicePort) srapi.StarRocksServicePort {
@@ -298,6 +307,7 @@ func serviceHashObject(svc *corev1.Service) hashService {
 		serviceType:              svc.Spec.Type,
 		labels:                   svc.Labels,
 		annotations:              svc.Annotations,
+		externalTrafficPolicy:    svc.Spec.ExternalTrafficPolicy,
 	}
 }
 

--- a/pkg/common/resource_utils/service_test.go
+++ b/pkg/common/resource_utils/service_test.go
@@ -140,7 +140,7 @@ func TestBuildExternalService_ForStarRocksWarehouse(t *testing.T) {
 					Name:      "test-warehouse-cn-service",
 					Namespace: "default",
 					Annotations: map[string]string{
-						srapi.ComponentResourceHash: "2811429284",
+						srapi.ComponentResourceHash: "817368047",
 					},
 					OwnerReferences: func() []metav1.OwnerReference {
 						ref := metav1.NewControllerRef(warehouse, warehouse.GroupVersionKind())
@@ -264,7 +264,7 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 					Name:      "test-fe-service",
 					Namespace: "default",
 					Annotations: map[string]string{
-						srapi.ComponentResourceHash: "2323011486",
+						srapi.ComponentResourceHash: "1344577517",
 					},
 					Labels: map[string]string{
 						"starrocks_default_label": "test",
@@ -304,7 +304,7 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 					Name:      "test-be-service",
 					Namespace: "default",
 					Annotations: map[string]string{
-						srapi.ComponentResourceHash: "2811174334",
+						srapi.ComponentResourceHash: "2400127693",
 					},
 					Labels: map[string]string{
 						"starrocks_default_label": "test",
@@ -341,7 +341,7 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 					Name:      "test-cn-service",
 					Namespace: "default",
 					Annotations: map[string]string{
-						srapi.ComponentResourceHash: "4173513860",
+						srapi.ComponentResourceHash: "187143055",
 					},
 					Labels: map[string]string{
 						"starrocks_default_label": "test",
@@ -755,5 +755,126 @@ func Test_mergePort(t *testing.T) {
 				t.Errorf("mergePort() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_setServiceType_ExternalTrafficPolicy(t *testing.T) {
+	type args struct {
+		svc *srapi.StarRocksService
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantType   corev1.ServiceType
+		wantPolicy corev1.ServiceExternalTrafficPolicyType
+	}{
+		{
+			name: "LoadBalancer with Local policy",
+			args: args{
+				svc: &srapi.StarRocksService{
+					Type:                  corev1.ServiceTypeLoadBalancer,
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+			wantType:   corev1.ServiceTypeLoadBalancer,
+			wantPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+		},
+		{
+			name: "NodePort with Local policy",
+			args: args{
+				svc: &srapi.StarRocksService{
+					Type:                  corev1.ServiceTypeNodePort,
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+			wantType:   corev1.ServiceTypeNodePort,
+			wantPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+		},
+		{
+			name: "LoadBalancer with Cluster policy",
+			args: args{
+				svc: &srapi.StarRocksService{
+					Type:                  corev1.ServiceTypeLoadBalancer,
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+				},
+			},
+			wantType:   corev1.ServiceTypeLoadBalancer,
+			wantPolicy: corev1.ServiceExternalTrafficPolicyTypeCluster,
+		},
+		{
+			name: "explicit ClusterIP with policy does not set the field",
+			args: args{
+				svc: &srapi.StarRocksService{
+					Type:                  corev1.ServiceTypeClusterIP,
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+			wantType: corev1.ServiceTypeClusterIP,
+		},
+		{
+			name: "default ClusterIP with policy does not set the field",
+			args: args{
+				svc: &srapi.StarRocksService{
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+			wantType: corev1.ServiceTypeClusterIP,
+		},
+		{
+			name: "LoadBalancer without policy keeps it unset",
+			args: args{
+				svc: &srapi.StarRocksService{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			wantType: corev1.ServiceTypeLoadBalancer,
+		},
+		{
+			name:     "nil service defaults to ClusterIP",
+			args:     args{svc: nil},
+			wantType: corev1.ServiceTypeClusterIP,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &corev1.Service{}
+			setServiceType(tt.args.svc, service)
+			if service.Spec.Type != tt.wantType {
+				t.Errorf("setServiceType() type = %v, want %v", service.Spec.Type, tt.wantType)
+			}
+			if service.Spec.ExternalTrafficPolicy != tt.wantPolicy {
+				t.Errorf("setServiceType() externalTrafficPolicy = %v, want %v",
+					service.Spec.ExternalTrafficPolicy, tt.wantPolicy)
+			}
+		})
+	}
+}
+
+func Test_ServiceDeepEqual_ExternalTrafficPolicy(t *testing.T) {
+	buildService := func(policy corev1.ServiceExternalTrafficPolicyType) *corev1.Service {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-fe-service",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: corev1.ServiceSpec{
+				Type:                  corev1.ServiceTypeLoadBalancer,
+				ExternalTrafficPolicy: policy,
+			},
+		}
+		return svc
+	}
+
+	// changing externalTrafficPolicy must change the service hash so that the operator updates the service
+	local := buildService(corev1.ServiceExternalTrafficPolicyTypeLocal)
+	cluster := buildService(corev1.ServiceExternalTrafficPolicyTypeCluster)
+	if _, equal := ServiceDeepEqual(local, cluster); equal {
+		t.Errorf("ServiceDeepEqual() = true, want false when externalTrafficPolicy differs")
+	}
+
+	// the same externalTrafficPolicy must keep the hash stable so that no spurious update happens
+	if _, equal := ServiceDeepEqual(buildService(corev1.ServiceExternalTrafficPolicyTypeLocal), local); !equal {
+		t.Errorf("ServiceDeepEqual() = false, want true when services are identical")
 	}
 }

--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -262,5 +262,8 @@ func (be *BeController) validating(beSpec *srapi.StarRocksBeSpec) error {
 	if err := srapi.ValidUpdateStrategy(beSpec.UpdateStrategy); err != nil {
 		return err
 	}
+	if err := beSpec.GetService().Validate(); err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -529,6 +529,10 @@ func (cc *CnController) validating(cnSpec *srapi.StarRocksCnSpec) error {
 		return err
 	}
 
+	if err := cnSpec.GetService().Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/subcontrollers/fe/fe_controller.go
+++ b/pkg/subcontrollers/fe/fe_controller.go
@@ -227,6 +227,9 @@ func (fc *FeController) Validating(feSpec *srapi.StarRocksFeSpec) error {
 	if err := srapi.ValidUpdateStrategy(feSpec.UpdateStrategy); err != nil {
 		return err
 	}
+	if err := feSpec.GetService().Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/subcontrollers/feproxy/feproxy_controller.go
+++ b/pkg/subcontrollers/feproxy/feproxy_controller.go
@@ -90,6 +90,10 @@ func (controller *FeProxyController) SyncCluster(ctx context.Context, src *srapi
 		}
 	}()
 
+	if err = controller.validating(feProxySpec); err != nil {
+		return err
+	}
+
 	err = controller.SyncConfigMap(ctx, src)
 	if err != nil {
 		logger.Error(err, "sync fe proxy configmap failed", "StarRocksCluster", src)
@@ -112,6 +116,10 @@ func (controller *FeProxyController) SyncCluster(ctx context.Context, src *srapi
 	}
 
 	return nil
+}
+
+func (controller *FeProxyController) validating(feProxySpec *srapi.StarRocksFeProxySpec) error {
+	return feProxySpec.GetService().Validate()
 }
 
 // UpdateClusterStatus update the all resource status about fe.


### PR DESCRIPTION
# Description

The StarRocksService spec exposed type, loadBalancerIP,
loadBalancerSourceRanges, annotations, labels, and ports, but not
externalTrafficPolicy, so operator-managed FE/BE/CN/FE-proxy services
always used the Kubernetes default Cluster policy. Users who need
Local (to preserve the client source IP, or to make
loadBalancerSourceRanges filtering reliable on cloud LBs that depend
on it) had to manage the service object outside the operator.

- Add externalTrafficPolicy (enum Cluster/Local) to StarRocksService;
  the same struct serves FE/BE/CN/FE-proxy and warehouse CN services.
- Validate the service spec up front via a shared
  StarRocksService.Validate() (same pattern as StorageVolume.Validate),
  wired into every controller's validating step: FE Validating, BE/CN
  validating (the CN path covers warehouses via SyncCnSpec), and a new
  FE-proxy validating. Kubernetes rejects externalTrafficPolicy on
  service types other than NodePort/LoadBalancer, so an inconsistent
  spec fails the reconcile before any object is built and the message
  lands in the cluster status Reason field.
- Apply the field in BuildExternalService only for NodePort and
  LoadBalancer services (defensive guard; the spec is already
  validated).
- Include the field in the service hash so policy changes roll out.
  Note: the new hash field changes every service's hash once on
  operator upgrade, causing a one-time in-place service update (no
  recreate, no pod restart).
- Expose the field in the kube-starrocks and warehouse helm charts.

# Related Issue(s)

Please list any related issues and link them here.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `make lint` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
