### PR TITLE
[BugFix] Support TLS on the operator's MySQL connection to FE

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -8,6 +8,12 @@ var (
 
 	// VolumeNameWithHash decides whether adding a hash to the volume name
 	VolumeNameWithHash bool
+
+	// FeSslMode decides whether the operator's MySQL connection to FE negotiates TLS. Valid values
+	// are DISABLED, PREFERRED and REQUIRED — the MySQL client's --ssl-mode vocabulary, matched
+	// case-insensitively. It is validated once at startup (see cn.ValidateSSLMode), applies to the
+	// whole operator process, and requires an operator restart to change.
+	FeSslMode string
 )
 
 func GetServiceDomainSuffix() string {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	srapi "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/controllers"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils"
+	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/subcontrollers/cn"
 )
 
 var (
@@ -50,6 +51,11 @@ func main() {
 	flag.StringVar(&config.DNSDomainSuffix, "dns-domain-suffix", "cluster.local", "The suffix of the dns domain in k8s")
 	flag.BoolVar(&config.VolumeNameWithHash, "volume-name-with-hash", true, "Add a hash to the volume name")
 	flag.StringVar(&_denyList, "deny-list", "", "Comma-separated list of namespaces to exclude from reconciliation")
+	flag.StringVar(&config.FeSslMode, "fe-ssl-mode", cn.SSLModePreferred,
+		"How the operator's MySQL connection to FE negotiates TLS. DISABLED keeps it plaintext; "+
+			"PREFERRED encrypts when FE advertises SSL support and stays plaintext otherwise; "+
+			"REQUIRED always encrypts and fails when FE does not support SSL. Case-insensitive. "+
+			"The server certificate is never verified. Requires an operator restart to change.")
 
 	// Set up logger.
 	opts := zap.Options{}
@@ -57,6 +63,12 @@ func main() {
 	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	logger := ctrl.Log.WithName("main")
+
+	// Fail fast: an unusable ssl mode would otherwise stay silent until the first FE connection.
+	if err := cn.ValidateSSLMode(config.FeSslMode); err != nil {
+		logger.Error(err, "invalid --fe-ssl-mode")
+		os.Exit(1)
+	}
 
 	// Register CRD to SchemeBuilder
 	srapi.Register()

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -179,6 +179,7 @@ spec:
         - --zap-time-encoding=iso8601
         - --zap-encoder=console
         - --volume-name-with-hash=true
+        - --fe-ssl-mode=PREFERRED
         env:
         - name: TZ
           value: Asia/Shanghai

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,6 +17,7 @@ Table Of Content
     - [HPA Automatic Scaling For CN Nodes](./hpa_dynamic_scaling_with_helm_howto.md)
     - [Load Data Using Stream Load](./load_data_using_stream_load_howto.md)
     - [Build Your Own Container Image](./build_your_own_container_image_howto.md)
+    - [Connect the Operator to an SSL-Enabled FE](./connect_to_ssl_enabled_fe_howto.md)
 - Integration
     - [Prometheus And Grafana](./integration/integration-prometheus-grafana.md)
     - [Datadog](./integration/integration-with-datadog.md)

--- a/doc/connect_to_ssl_enabled_fe_howto.md
+++ b/doc/connect_to_ssl_enabled_fe_howto.md
@@ -1,0 +1,132 @@
+# Connect the Operator to an SSL-Enabled FE HOWTO
+
+The operator talks to FE over the MySQL protocol to run maintenance statements such as
+`SHOW COMPUTE NODES`, `ALTER SYSTEM DROP COMPUTE NODE`, and `DROP WAREHOUSE`. Before this feature the
+operator could only open a **plaintext** connection. If FE was configured with
+`ssl_force_secure_transport = true` in `fe.conf`, it rejected every one of these connections with
+error 5205 (`Connections using insecure transport are prohibited`) and logged a warning each time.
+
+This document describes the `--fe-ssl-mode` flag (Helm value `starrocksOperator.feSslMode`) that lets
+the operator negotiate TLS for this connection, and how to choose the right value for your cluster.
+
+## 1. How It Works
+
+`--fe-ssl-mode` accepts three values, matched case-insensitively:
+
+| Value | Behavior |
+|---|---|
+| `DISABLED` | Always plaintext. An FE with `ssl_force_secure_transport = true` rejects the connection with error 5205. |
+| `PREFERRED` (default) | Encrypt when FE advertises SSL support; stay plaintext when it does not. A cluster without SSL configured on FE behaves exactly as before this feature. |
+| `REQUIRED` | Always encrypt; fail the connection when FE does not support SSL. |
+
+`VERIFY_CA` and `VERIFY_IDENTITY` are recognized names — they exist in the MySQL client's
+`--ssl-mode` vocabulary that this flag mirrors — but the operator refuses to start if either is
+configured; see [Certificate Verification](#2-certificate-verification) for why. An unrecognized or
+empty value also stops the operator at startup: a typo in this flag should be loud, not silently
+fall back to plaintext.
+
+## 2. Certificate Verification
+
+**The server certificate is never verified, in any mode**, including `REQUIRED`. FE's own
+documentation for enabling SSL has you generate a self-signed keystore, for example:
+
+```bash
+keytool -genkeypair -alias starrocks -keyalg RSA -keysize 1024 -validity 365
+```
+
+A self-signed certificate has no CA to chain to, and its certificate name never matches the
+in-cluster service DNS name the operator dials to reach FE. Verifying either one would fail
+against the exact keystore FE's documentation tells you to create.
+
+Because of this, `PREFERRED` and `REQUIRED` protect the connection from **passive eavesdropping
+only**. They do not protect against an **active man-in-the-middle**, since the operator never
+confirms it is actually talking to your FE. Do not treat `REQUIRED` as a strong security guarantee;
+treat it as "always encrypted, certificate unchecked."
+
+## 3. Choosing a Mode
+
+- **Most users should change nothing.** The default, `PREFERRED`, already handles both cases: it
+  encrypts against an FE with SSL enabled and stays plaintext against an FE without it.
+- **Use `REQUIRED`** if you need a guarantee that the operator never talks to FE in plaintext — for
+  example, a compliance posture that does not accept `PREFERRED`'s silent fallback to plaintext when
+  FE does not advertise SSL.
+- **Fall back to `DISABLED`** if FE advertises SSL but the TLS handshake cannot be negotiated (for
+  example, a TLS version or cipher mismatch between the operator's MySQL driver and FE's keystore).
+  `PREFERRED` does **not** fall back to plaintext in that situation — it only falls back when FE does
+  not advertise SSL at all, so a handshake failure with `PREFERRED` still fails the connection.
+  `DISABLED` is the escape hatch while you fix the handshake, or if you decide not to run FE with SSL.
+
+## 4. FE-Side Settings
+
+These `fe.conf` settings on the FE side determine whether FE advertises and accepts SSL, and are
+what `--fe-ssl-mode` reacts to:
+
+- `ssl_keystore_location` — path to the keystore file.
+- `ssl_keystore_password` — password for the keystore.
+- `ssl_key_password` — password for the private key inside the keystore.
+- `ssl_force_secure_transport` — when `true`, FE rejects plaintext connections outright (error 5205).
+
+Refer to FE's own documentation for how to generate the keystore and set these values. Two traps to
+watch for while doing so:
+
+- **`ssl_key_password` must equal `ssl_keystore_password`.** JDK 9+ defaults `keytool` to the PKCS12
+  keystore format, which does not support a separate per-key password: `-storepass A -keypass B`
+  silently keeps the private key's password as `A` and only prints a warning. FE still starts and
+  logs the three `ssl_*` settings as if healthy, but cannot read its private key, and the operator in
+  `REQUIRED` mode fails with no obvious cause.
+- **Verify enforcement through the FE Service DNS name, not loopback.** FE exempts `127.0.0.1`
+  connections from `ssl_force_secure_transport`, so `kubectl exec ... -- mysql -h127.0.0.1` still
+  succeeds in plaintext even with enforcement on. Test from the FE's Service DNS name or another pod.
+
+## 5. Configure via Helm
+
+Set `starrocksOperator.feSslMode` when installing or upgrading the operator (or the `kube-starrocks`
+umbrella chart, where the same key lives under `operator.starrocksOperator.feSslMode`):
+
+```bash
+helm upgrade starrocks-operator starrocks/operator \
+  --reuse-values \
+  --set starrocksOperator.feSslMode=REQUIRED
+```
+
+Or set it in `values.yaml`:
+
+```yaml
+starrocksOperator:
+  feSslMode: REQUIRED
+```
+
+If you installed the `kube-starrocks` umbrella chart instead of the standalone `operator` chart, the
+same value lives one level deeper, under the `operator` subchart:
+
+```bash
+helm upgrade starrocks starrocks/kube-starrocks \
+  --reuse-values \
+  --set operator.starrocksOperator.feSslMode=REQUIRED
+```
+
+## 6. Configure via Raw Manifest
+
+If you deploy the operator from `deploy/operator.yaml` instead of Helm, edit the `--fe-ssl-mode`
+argument that already ships in the manager container's `args`:
+
+```yaml
+        args:
+        - --leader-elect
+        - --zap-time-encoding=iso8601
+        - --zap-encoder=console
+        - --volume-name-with-hash=true
+        - --fe-ssl-mode=REQUIRED
+```
+
+Then re-apply the manifest:
+
+```bash
+kubectl apply -f deploy/operator.yaml
+```
+
+## 7. Restart Behavior
+
+`--fe-ssl-mode` is read once at process start, so changing it (through either path above) **restarts
+the operator pod**. It does **not** restart FE, BE, or CN pods — those keep running unaffected, and
+the new mode only takes effect for the operator's own FE connections after its pod comes back up.

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         {{- if .Values.starrocksOperator.denyList }}
         - --deny-list={{ .Values.starrocksOperator.denyList }}
         {{- end }}
+        {{- if .Values.starrocksOperator.feSslMode }}
+        - --fe-ssl-mode={{ .Values.starrocksOperator.feSslMode }}
+        {{- end }}
         env:
         - name: TZ
           value: {{ .Values.timeZone }}

--- a/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
@@ -95,6 +95,19 @@ starrocksOperator:
   # any resources in it. Avoid configuring conflicting values between these two settings.
   # Example: "kube-system,kube-public,monitoring"
   denyList: ""
+  # How the operator's MySQL connection to FE negotiates TLS. Mirrors the MySQL client's
+  # --ssl-mode option:
+  #   DISABLED  - always plaintext. An FE with ssl_force_secure_transport=true rejects the
+  #               connection with error 5205 and logs a warning for every attempt.
+  #   PREFERRED - (default) encrypt when FE advertises SSL support, stay plaintext when it does
+  #               not, so a cluster without SSL configured behaves exactly as before.
+  #   REQUIRED  - always encrypt, and fail the connection when FE does not support SSL. Use this
+  #               to guarantee the operator never talks to FE in plaintext.
+  # The server certificate is never verified: the keystore FE's documentation generates is
+  # self-signed, so there is no CA to chain to and its name does not match FE's in-cluster
+  # service DNS name. Leave empty to use the operator's built-in default. Changing this value
+  # restarts the operator pod.
+  feSslMode: PREFERRED
   # Additional operator container environment variables
   # You specify this manually like you would a raw deployment manifest.
   # Ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -102,6 +102,19 @@ operator:
     # any resources in it. Avoid configuring conflicting values between these two settings.
     # Example: "kube-system,kube-public,monitoring"
     denyList: ""
+    # How the operator's MySQL connection to FE negotiates TLS. Mirrors the MySQL client's
+    # --ssl-mode option:
+    #   DISABLED  - always plaintext. An FE with ssl_force_secure_transport=true rejects the
+    #               connection with error 5205 and logs a warning for every attempt.
+    #   PREFERRED - (default) encrypt when FE advertises SSL support, stay plaintext when it does
+    #               not, so a cluster without SSL configured behaves exactly as before.
+    #   REQUIRED  - always encrypt, and fail the connection when FE does not support SSL. Use this
+    #               to guarantee the operator never talks to FE in plaintext.
+    # The server certificate is never verified: the keystore FE's documentation generates is
+    # self-signed, so there is no CA to chain to and its name does not match FE's in-cluster
+    # service DNS name. Leave empty to use the operator's built-in default. Changing this value
+    # restarts the operator pod.
+    feSslMode: PREFERRED
     # Additional operator container environment variables
     # You specify this manually like you would a raw deployment manifest.
     # Ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/

--- a/pkg/subcontrollers/cn/cn_mysql.go
+++ b/pkg/subcontrollers/cn/cn_mysql.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/StarRocks/starrocks-kubernetes-operator/cmd/config"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils/templates/object"
 )
@@ -29,6 +30,11 @@ type SQLExecutor struct {
 	FeServiceName      string
 	FeServiceNamespace string
 	FeServicePort      string
+
+	// SSLMode decides whether the connection to FE negotiates TLS; see the SSLMode* constants.
+	// It is captured per executor rather than read from the flag at connect time so that tests can
+	// exercise each mode without mutating process-wide state.
+	SSLMode string
 }
 
 // NewSQLExecutor creates a SQLExecutor instance. It will get the root password, fe service name, and fe service port
@@ -77,7 +83,16 @@ func NewSQLExecutor(ctx context.Context, k8sClient client.Client, namespace, cnS
 		FeServiceName:      feServiceName,
 		FeServiceNamespace: namespace,
 		FeServicePort:      feServicePort,
+		SSLMode:            config.FeSslMode,
 	}, nil
+}
+
+// dsn builds the go-sql-driver DSN for the FE connection. Both ExecuteContext and QueryContext go
+// through it so the SSL mode can never be honored by one path and skipped by the other.
+func (executor *SQLExecutor) dsn() string {
+	return fmt.Sprintf("root:%s@tcp(%s.%s:%s)/%s",
+		executor.RootPassword, executor.FeServiceName, executor.FeServiceNamespace,
+		executor.FeServicePort, sslModeDSNSuffix(executor.SSLMode))
 }
 
 // ExecuteContext sql statements. Every time a SQL statement needs to be executed, a new sql.DB instance will be created.
@@ -85,8 +100,7 @@ func NewSQLExecutor(ctx context.Context, k8sClient client.Client, namespace, cnS
 func (executor *SQLExecutor) ExecuteContext(ctx context.Context, db *sql.DB, statement string) error {
 	var err error
 	if db == nil {
-		db, err = sql.Open("mysql", fmt.Sprintf("root:%s@tcp(%s.%s:%s)/",
-			executor.RootPassword, executor.FeServiceName, executor.FeServiceNamespace, executor.FeServicePort))
+		db, err = sql.Open("mysql", executor.dsn())
 		if err != nil {
 			return err
 		}
@@ -104,8 +118,7 @@ func (executor *SQLExecutor) ExecuteContext(ctx context.Context, db *sql.DB, sta
 func (executor *SQLExecutor) QueryContext(ctx context.Context, db *sql.DB, statements string) (*sql.Rows, error) {
 	var err error
 	if db == nil {
-		db, err = sql.Open("mysql", fmt.Sprintf("root:%s@tcp(%s.%s:%s)/",
-			executor.RootPassword, executor.FeServiceName, executor.FeServiceNamespace, executor.FeServicePort))
+		db, err = sql.Open("mysql", executor.dsn())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/subcontrollers/cn/cn_mysql_ssl.go
+++ b/pkg/subcontrollers/cn/cn_mysql_ssl.go
@@ -1,0 +1,69 @@
+package cn
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SSL modes for the operator's MySQL connection to FE. The names mirror the MySQL client's
+// --ssl-mode option so that the vocabulary in the FE SSL documentation carries over unchanged.
+const (
+	// SSLModeDisabled never negotiates TLS. An FE configured with ssl_force_secure_transport=true
+	// rejects such a connection with error 5205.
+	SSLModeDisabled = "DISABLED"
+
+	// SSLModePreferred negotiates TLS when FE advertises the CLIENT_SSL capability and falls back
+	// to plaintext when it does not. The server certificate is not verified.
+	SSLModePreferred = "PREFERRED"
+
+	// SSLModeRequired always negotiates TLS and fails the connection when FE does not advertise
+	// CLIENT_SSL. The server certificate is not verified.
+	SSLModeRequired = "REQUIRED"
+
+	// SSLModeVerifyCA and SSLModeVerifyIdentity are recognized but rejected. The keystore FE's
+	// documentation tells users to generate is self-signed, so there is no CA to chain to, and its
+	// certificate name never matches the in-cluster service DNS name the operator dials.
+	SSLModeVerifyCA       = "VERIFY_CA"
+	SSLModeVerifyIdentity = "VERIFY_IDENTITY"
+)
+
+// normalizeSSLMode makes a user-supplied mode comparable to the SSLMode* constants: matching is
+// case-insensitive, and surrounding whitespace (easy to introduce through Helm values) is ignored.
+func normalizeSSLMode(mode string) string {
+	return strings.ToUpper(strings.TrimSpace(mode))
+}
+
+// ValidateSSLMode reports whether mode is a value the operator can act on. main calls it right
+// after flag.Parse so that a typo stops the operator at startup, instead of surfacing much later
+// as a failed FE connection during reconcile.
+func ValidateSSLMode(mode string) error {
+	switch normalizeSSLMode(mode) {
+	case SSLModeDisabled, SSLModePreferred, SSLModeRequired:
+		return nil
+	case SSLModeVerifyCA, SSLModeVerifyIdentity:
+		return fmt.Errorf("ssl mode %q is not supported: the keystore FE's documentation generates is "+
+			"self-signed, so neither its certificate chain nor its certificate name can be verified; "+
+			"use %s to require encryption without certificate verification", mode, SSLModeRequired)
+	default:
+		return fmt.Errorf("invalid ssl mode %q, must be one of %s, %s, %s",
+			mode, SSLModeDisabled, SSLModePreferred, SSLModeRequired)
+	}
+}
+
+// sslModeDSNSuffix returns the query string to append to the FE DSN for mode, including the leading
+// "?" when non-empty. The values map onto go-sql-driver's tls= parameter: "preferred" negotiates TLS
+// but falls back to plaintext when the server does not advertise CLIENT_SSL, while "skip-verify"
+// insists on TLS. Neither verifies the server certificate.
+//
+// Unrecognized values yield "" — the plaintext behavior that predates this feature — rather than a
+// panic. Production never reaches that branch because main rejects such values via ValidateSSLMode.
+func sslModeDSNSuffix(mode string) string {
+	switch normalizeSSLMode(mode) {
+	case SSLModePreferred:
+		return "?tls=preferred"
+	case SSLModeRequired:
+		return "?tls=skip-verify"
+	default:
+		return ""
+	}
+}

--- a/pkg/subcontrollers/cn/cn_mysql_ssl_test.go
+++ b/pkg/subcontrollers/cn/cn_mysql_ssl_test.go
@@ -1,0 +1,59 @@
+package cn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSLModeDSNSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{name: "disabled adds nothing", mode: SSLModeDisabled, want: ""},
+		{name: "preferred negotiates with plaintext fallback", mode: SSLModePreferred, want: "?tls=preferred"},
+		{name: "required always negotiates", mode: SSLModeRequired, want: "?tls=skip-verify"},
+		{name: "lower case is accepted", mode: "preferred", want: "?tls=preferred"},
+		{name: "mixed case is accepted", mode: "ReQuIrEd", want: "?tls=skip-verify"},
+		{name: "surrounding spaces are trimmed", mode: "  PREFERRED  ", want: "?tls=preferred"},
+		{name: "verify_ca falls back to plaintext", mode: SSLModeVerifyCA, want: ""},
+		{name: "verify_identity falls back to plaintext", mode: SSLModeVerifyIdentity, want: ""},
+		{name: "unrecognized value falls back to plaintext", mode: "banana", want: ""},
+		{name: "empty value falls back to plaintext", mode: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sslModeDSNSuffix(tt.mode))
+		})
+	}
+}
+
+func TestValidateSSLMode(t *testing.T) {
+	for _, mode := range []string{SSLModeDisabled, SSLModePreferred, SSLModeRequired, "preferred", "  REQUIRED "} {
+		t.Run("accepts "+mode, func(t *testing.T) {
+			assert.NoError(t, ValidateSSLMode(mode))
+		})
+	}
+
+	// VERIFY_CA / VERIFY_IDENTITY are recognized names, so the error must explain why they are
+	// unusable and point at REQUIRED instead of just listing valid values.
+	for _, mode := range []string{SSLModeVerifyCA, SSLModeVerifyIdentity} {
+		t.Run("rejects "+mode, func(t *testing.T) {
+			err := ValidateSSLMode(mode)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "self-signed")
+			assert.Contains(t, err.Error(), SSLModeRequired)
+		})
+	}
+
+	for _, mode := range []string{"", "banana", "true"} {
+		t.Run("rejects unrecognized "+mode, func(t *testing.T) {
+			err := ValidateSSLMode(mode)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), SSLModePreferred)
+		})
+	}
+}

--- a/pkg/subcontrollers/cn/cn_mysql_test.go
+++ b/pkg/subcontrollers/cn/cn_mysql_test.go
@@ -17,6 +17,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/StarRocks/starrocks-kubernetes-operator/cmd/config"
 	"github.com/StarRocks/starrocks-kubernetes-operator/pkg/k8sutils/fake"
 )
 
@@ -27,6 +28,12 @@ func TestNewSQLExecutor(t *testing.T) {
 		namespace string
 		name      string
 	}
+
+	// NewSQLExecutor copies the process-wide flag value onto the executor, so pin it for this test.
+	originalSslMode := config.FeSslMode
+	config.FeSslMode = SSLModeRequired
+	t.Cleanup(func() { config.FeSslMode = originalSslMode })
+
 	tests := []struct {
 		name    string
 		args    args
@@ -89,6 +96,7 @@ func TestNewSQLExecutor(t *testing.T) {
 				FeServiceName:      "fe",
 				FeServiceNamespace: "default",
 				FeServicePort:      "9030",
+				SSLMode:            SSLModeRequired,
 			},
 			wantErr: assert.NoError,
 		},
@@ -353,6 +361,42 @@ func TestSQLExecutor_ExecuteDropWarehouse(t *testing.T) {
 				FeServicePort:      tt.fields.FeServicePort,
 			}
 			tt.wantErr(t, executor.ExecuteDropWarehouse(tt.args.ctx, tt.args.db, tt.args.warehouseName), fmt.Sprintf("ExecuteDropWarehouse(%v, %v, %v)", tt.args.ctx, tt.args.db, tt.args.warehouseName))
+		})
+	}
+}
+
+func TestSQLExecutorDSN(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{
+			name: "disabled keeps the plaintext DSN unchanged",
+			mode: SSLModeDisabled,
+			want: "root:123456@tcp(fe.default:9030)/",
+		},
+		{
+			name: "preferred appends the opportunistic tls parameter",
+			mode: SSLModePreferred,
+			want: "root:123456@tcp(fe.default:9030)/?tls=preferred",
+		},
+		{
+			name: "required appends the mandatory tls parameter",
+			mode: SSLModeRequired,
+			want: "root:123456@tcp(fe.default:9030)/?tls=skip-verify",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &SQLExecutor{
+				RootPassword:       "123456",
+				FeServiceName:      "fe",
+				FeServiceNamespace: "default",
+				FeServicePort:      "9030",
+				SSLMode:            tt.mode,
+			}
+			assert.Equal(t, tt.want, executor.dsn())
 		})
 	}
 }


### PR DESCRIPTION
# Description

The operator opens its MySQL connection to FE (used for `SHOW COMPUTE NODES`,
`ALTER SYSTEM DROP COMPUTE NODE`, `DROP WAREHOUSE`) in **plaintext only**, with no switch to enable
TLS. When a user sets `ssl_force_secure_transport = true` in `fe.conf`, FE rejects every operator
connection with `Error 5205 (HY000): Connections using insecure transport are prohibited` and logs
a WARN for each attempt — roughly 10–14 failures per FE per minute in a real deployment, burying
real errors in log noise. There is exactly one MySQL connection site in the repo
(`pkg/subcontrollers/cn/cn_mysql.go`, two `sql.Open` call sites) and its DSN ends in a bare `/`.

**Fix:** append a `tls=` parameter to that DSN, controlled by one new global operator flag
`--fe-ssl-mode` (Helm value `starrocksOperator.feSslMode`), with values `DISABLED` / `PREFERRED` /
`REQUIRED`, default `PREFERRED`.

| `--fe-ssl-mode` | DSN suffix | Semantics |
|---|---|---|
| `DISABLED` | none | plaintext; byte-for-byte the behavior that predates this change |
| `PREFERRED` (**default**) | `?tls=preferred` | encrypt when FE advertises `CLIENT_SSL`, stay plaintext otherwise |
| `REQUIRED` | `?tls=skip-verify` | always encrypt; fail when FE does not support SSL |
| `VERIFY_CA` / `VERIFY_IDENTITY` | — | recognized but **rejected at startup**, with an error explaining why |

Values are matched case-insensitively; an unrecognized or empty value makes the operator **fail to
start** rather than silently fall back to plaintext. The server certificate is never verified in
any mode — FE's own documentation generates a self-signed keystore whose certificate name cannot
match the Kubernetes service DNS name, so `VERIFY_CA` / `VERIFY_IDENTITY` would be unusable in the
documented deployment; the two names are reserved so certificate verification can be added later
without changing the parameter.

**Why `PREFERRED` is a safe default:** an FE without a keystore does not advertise `CLIENT_SSL`, so
the driver takes its `AllowFallbackToPlaintext` branch and behaves exactly like today. This was
measured against a live FE before fixing the default (no `tls` param → success, `?tls=preferred` →
success, `?tls=skip-verify` → `TLS requested but server does not support TLS`).

**No new dependency, no CRD change, no RBAC change, no certificate mounting.**
`go-sql-driver/mysql` is already vendored and `preferred` / `skip-verify` are its native values.

Changes:

- `pkg/subcontrollers/cn/cn_mysql_ssl.go` (new) — the mode constants, `ValidateSSLMode`,
  `sslModeDSNSuffix`.
- `pkg/subcontrollers/cn/cn_mysql.go` — the two duplicated DSN literals collapsed into one `dsn()`
  method, so a future change cannot make one query path negotiate TLS while the other stays
  plaintext.
- `cmd/config/config.go`, `cmd/main.go` — the flag, validated immediately after `flag.Parse()` so a
  bad value fails at startup instead of at the first reconcile.
- Operator subchart — `starrocksOperator.feSslMode: PREFERRED` plus a `{{- if }}`-gated
  `--fe-ssl-mode` arg (following the `--dns-domain-suffix` precedent): setting the value to `""` or
  `null` omits the whole arg and falls back to the binary default, instead of rendering
  `--fe-ssl-mode=` and killing the operator on start.
- `deploy/operator.yaml` and the parent `kube-starrocks/values.yaml` — regenerated
  (`scripts/operator.sh`, `scripts/create-parent-chart-values.sh`).
- `doc/connect_to_ssl_enabled_fe_howto.md` (new) — how the flag works, why certificates are not
  verified, how to choose a mode, FE-side keystore traps (PKCS12 `-keypass` silently ignored;
  loopback connections exempt from `ssl_force_secure_transport`), and both Helm and raw-manifest
  configuration. Indexed in `doc/README.md`.

**Upgrade behavior:** nothing in the StatefulSet / Pod rendering path is touched, so FE / BE / CN
pods are not restarted — only the operator's own Deployment rolls. The only behavioral change is
that an FE which already advertises SSL will get an encrypted operator connection; set
`feSslMode: DISABLED` to return to the exact previous behavior.

Verification on this branch:

- 24 new/extended unit subtests across `TestSSLModeDSNSuffix`, `TestValidateSSLMode`,
  `TestSQLExecutorDSN`, `TestNewSQLExecutor`; `go test ./pkg/...` green.
- `helm lint` clean; render checked end to end through the parent chart: default renders
  `--fe-ssl-mode=PREFERRED`, `--set operator.starrocksOperator.feSslMode=DISABLED` passes through,
  an empty value omits the arg.
- `make generate` / `make manifests` produce no diff; `golangci-lint run` (v2.2.2, the CI-pinned
  version): 0 issues.
- End-to-end behavior was verified on a kind cluster against FE 4.x with a real SSL keystore:
  with SSL enforced and mode `DISABLED` the operator logs error 5205 matching FE-side WARNs
  one-to-one; with the default `PREFERRED` on the same FE, `SHOW COMPUTE NODES` and
  `ALTER SYSTEM DROP COMPUTE NODE` succeed (which on a plaintext-rejecting FE can only mean the
  connection was upgraded to TLS); `VERIFY_CA` and an invalid value each put the new operator pod
  into CrashLoopBackOff with the intended message while the old pod keeps running. A `helm upgrade`
  across this change left FE/CN StatefulSets untouched (same UID / restartCount /
  `controller-revision-hash` / `resourceVersion`).

# Related Issue(s)

N/A — reported by an enterprise customer running the operator against an FE with
`ssl_force_secure_transport = true` (operator v1.11.x has the defect).

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code. — no diff (no API-type change).
- [x] run `make lint` to check the code style. — golangci-lint v2.2.2: 0 issues.
- [x] run `make test` to run UT. — all packages ok, including the 24 new subtests in
  `pkg/subcontrollers/cn`.
- [x] run `make manifests` to update the yaml files of CRD. — no CRD diff (this is a global
  operator flag by design, not a CRD field).

For helm chart, please complete the following checklist:

- [x] make sure you have updated the `values.yaml` file of starrocks chart. — the value belongs to
  the **operator** subchart (`kube-starrocks/charts/operator/values.yaml`,
  `starrocksOperator.feSslMode: PREFERRED`); the `starrocks` subchart is deliberately untouched —
  this flag configures the operator process, not the data plane.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml
  file of the parent chart (kube-starrocks chart). — regenerated, committed.