### PR TITLE
[Feature] Support custom labels for operator Deployment and pod

### DIFF
--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ template "operator.namespace" . }}
   labels:
     app: {{ template "operator.name" . }}-operator
+    {{- with .Values.starrocksOperator.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- if .Values.starrocksOperator.annotations }}
   annotations:
     {{- toYaml .Values.starrocksOperator.annotations | nindent 4 }}
@@ -25,6 +28,9 @@ spec:
       labels:
         app: {{ template "operator.name" . }}-operator
         version: {{ $.Chart.Version }}
+        {{- with .Values.starrocksOperator.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       automountServiceAccountToken: true
       {{- if .Values.starrocksOperator.imagePullSecrets }}

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -1,8 +1,16 @@
 {{- if .Values.starrocksOperator.enabled }}
 {{- $operatorLabels := .Values.starrocksOperator.labels | default dict }}
-{{- range $reservedLabel := list "app" "version" }}
+{{- if not (kindIs "map" $operatorLabels) }}
+{{- fail "starrocksOperator.labels must be a map" }}
+{{- end }}
+{{- range $reservedLabel := list "app" "version" "app.kubernetes.io/managed-by" }}
 {{- if hasKey $operatorLabels $reservedLabel }}
 {{- fail (printf "starrocksOperator.labels cannot override reserved label %q" $reservedLabel) }}
+{{- end }}
+{{- end }}
+{{- range $key, $value := $operatorLabels }}
+{{- if or (kindIs "map" $value) (kindIs "slice" $value) (kindIs "invalid" $value) }}
+{{- fail (printf "starrocksOperator.labels value for %q must be a string, number, or boolean" $key) }}
 {{- end }}
 {{- end }}
 apiVersion: apps/v1
@@ -12,8 +20,8 @@ metadata:
   namespace: {{ template "operator.namespace" . }}
   labels:
     app: {{ template "operator.name" . }}-operator
-    {{- with $operatorLabels }}
-    {{- toYaml . | nindent 4 }}
+    {{- range $key, $value := $operatorLabels }}
+    {{ $key | quote }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.starrocksOperator.annotations }}
   annotations:
@@ -34,8 +42,8 @@ spec:
       labels:
         app: {{ template "operator.name" . }}-operator
         version: {{ $.Chart.Version }}
-        {{- with $operatorLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- range $key, $value := $operatorLabels }}
+        {{ $key | quote }}: {{ $value | quote }}
         {{- end }}
     spec:
       automountServiceAccountToken: true

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/deployment.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.starrocksOperator.enabled }}
+{{- $operatorLabels := .Values.starrocksOperator.labels | default dict }}
+{{- range $reservedLabel := list "app" "version" }}
+{{- if hasKey $operatorLabels $reservedLabel }}
+{{- fail (printf "starrocksOperator.labels cannot override reserved label %q" $reservedLabel) }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +12,7 @@ metadata:
   namespace: {{ template "operator.namespace" . }}
   labels:
     app: {{ template "operator.name" . }}-operator
-    {{- with .Values.starrocksOperator.labels }}
+    {{- with $operatorLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- if .Values.starrocksOperator.annotations }}
@@ -28,7 +34,7 @@ spec:
       labels:
         app: {{ template "operator.name" . }}-operator
         version: {{ $.Chart.Version }}
-        {{- with .Values.starrocksOperator.labels }}
+        {{- with $operatorLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:

--- a/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
@@ -30,7 +30,8 @@ starrocksOperator:
   # If enabled, the operator-related resources will be created, including the operator deployment, service account,
   # clusterrole, clusterrolebinding, and service account.
   enabled: true
-  # labels for the starrocks operator Deployment and pod. The "app" and "version" keys are reserved.
+  # labels for the starrocks operator Deployment and pod. Values must be strings, numbers, or booleans
+  # and are rendered as strings. The "app", "version", and "app.kubernetes.io/managed-by" keys are reserved.
   labels: {}
   # annotations for starrocks operator.
   annotations: {}

--- a/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
@@ -30,7 +30,7 @@ starrocksOperator:
   # If enabled, the operator-related resources will be created, including the operator deployment, service account,
   # clusterrole, clusterrolebinding, and service account.
   enabled: true
-  # labels for the starrocks operator Deployment and pod.
+  # labels for the starrocks operator Deployment and pod. The "app" and "version" keys are reserved.
   labels: {}
   # annotations for starrocks operator.
   annotations: {}

--- a/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/values.yaml
@@ -30,6 +30,8 @@ starrocksOperator:
   # If enabled, the operator-related resources will be created, including the operator deployment, service account,
   # clusterrole, clusterrolebinding, and service account.
   enabled: true
+  # labels for the starrocks operator Deployment and pod.
+  labels: {}
   # annotations for starrocks operator.
   annotations: {}
   namespaceOverride: ""

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -37,7 +37,7 @@ operator:
     # If enabled, the operator-related resources will be created, including the operator deployment, service account,
     # clusterrole, clusterrolebinding, and service account.
     enabled: true
-    # labels for the starrocks operator Deployment and pod.
+    # labels for the starrocks operator Deployment and pod. The "app" and "version" keys are reserved.
     labels: {}
     # annotations for starrocks operator.
     annotations: {}

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -37,6 +37,8 @@ operator:
     # If enabled, the operator-related resources will be created, including the operator deployment, service account,
     # clusterrole, clusterrolebinding, and service account.
     enabled: true
+    # labels for the starrocks operator Deployment and pod.
+    labels: {}
     # annotations for starrocks operator.
     annotations: {}
     namespaceOverride: ""

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -37,7 +37,8 @@ operator:
     # If enabled, the operator-related resources will be created, including the operator deployment, service account,
     # clusterrole, clusterrolebinding, and service account.
     enabled: true
-    # labels for the starrocks operator Deployment and pod. The "app" and "version" keys are reserved.
+    # labels for the starrocks operator Deployment and pod. Values must be strings, numbers, or booleans
+    # and are rendered as strings. The "app", "version", and "app.kubernetes.io/managed-by" keys are reserved.
     labels: {}
     # annotations for starrocks operator.
     annotations: {}


### PR DESCRIPTION
## Description

Add an optional `starrocksOperator.labels` value to the operator Helm chart and render it on the operator Deployment and pod template.

Custom labels are intentionally not added to `spec.selector`. This keeps the selector stable and allows organizational labels to change without requiring the Deployment to be recreated.

The parent `kube-starrocks` values file has been regenerated with `scripts/create-parent-chart-values.sh`.

## Related Issue(s)

Closes #790

## Validation

- `helm lint helm-charts/charts/kube-starrocks/charts/operator`
- `helm lint helm-charts/charts/kube-starrocks`
- Rendered the operator chart with default values and confirmed its output is unchanged.
- Rendered the operator and parent charts with custom labels and confirmed they appear on Deployment and pod metadata but not on `spec.selector`.

## Checklist

Operator code was not changed, so code generation, CRD generation, and Go unit tests are not applicable.

For the Helm chart:

- [x] Updated the operator child-chart `values.yaml`.
- [x] Ran `scripts/create-parent-chart-values.sh` to regenerate the parent `kube-starrocks` values.
- [x] Ran Helm lint and template validation for the operator and parent charts.
