### PR TITLE
fix: support OnDelete update strategy in statefulset rollout status

### DIFF
--- a/pkg/k8sutils/templates/statefulset/status.go
+++ b/pkg/k8sutils/templates/statefulset/status.go
@@ -25,8 +25,12 @@ import (
 // Status returns a message describing statefulset status, and a bool value indicating if the status is considered done.
 // Copy from kubelet
 func Status(sts *appsv1.StatefulSet) (string, bool, error) {
+	if sts.Spec.UpdateStrategy.Type == appsv1.OnDeleteStatefulSetStrategyType {
+		return onDeleteStatus(sts)
+	}
 	if sts.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
-		return "", true, fmt.Errorf("rollout status is only available for %s strategy type", appsv1.RollingUpdateStatefulSetStrategyType)
+		return "", true, fmt.Errorf("rollout status is only available for %s and %s strategy types",
+			appsv1.RollingUpdateStatefulSetStrategyType, appsv1.OnDeleteStatefulSetStrategyType)
 	}
 	if sts.Status.ObservedGeneration == 0 || sts.Generation > sts.Status.ObservedGeneration {
 		return "Waiting for statefulset spec update to be observed", false, nil
@@ -34,7 +38,7 @@ func Status(sts *appsv1.StatefulSet) (string, bool, error) {
 	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
 		return fmt.Sprintf("Waiting for %d pods to be ready", *sts.Spec.Replicas-sts.Status.ReadyReplicas), false, nil
 	}
-	if sts.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType && sts.Spec.UpdateStrategy.RollingUpdate != nil {
+	if sts.Spec.UpdateStrategy.RollingUpdate != nil {
 		if sts.Spec.Replicas != nil && sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
 			if sts.Status.UpdatedReplicas < (*sts.Spec.Replicas - *sts.Spec.UpdateStrategy.RollingUpdate.Partition) {
 				return fmt.Sprintf("Waiting for partitioned roll out to finish: %d out of %d new pods have been updated",
@@ -48,5 +52,25 @@ func Status(sts *appsv1.StatefulSet) (string, bool, error) {
 			sts.Status.UpdatedReplicas, sts.Status.UpdateRevision), false, nil
 	}
 	return fmt.Sprintf("statefulset rolling update complete %d pods at revision %s",
+		sts.Status.CurrentReplicas, sts.Status.CurrentRevision), true, nil
+}
+
+// onDeleteStatus reports status for the OnDelete update strategy.
+// Unlike RollingUpdate, OnDelete never auto-replaces pods, so CurrentRevision/UpdateRevision
+// staying out of sync is expected and must not be treated as "not done" indefinitely -
+// otherwise the owning StarRocksCluster/StarRocksWarehouse would be stuck "reconciling" forever.
+func onDeleteStatus(sts *appsv1.StatefulSet) (string, bool, error) {
+	if sts.Status.ObservedGeneration == 0 || sts.Generation > sts.Status.ObservedGeneration {
+		return "Waiting for statefulset spec update to be observed", false, nil
+	}
+	if sts.Spec.Replicas != nil && sts.Status.ReadyReplicas < *sts.Spec.Replicas {
+		return fmt.Sprintf("Waiting for %d pods to be ready", *sts.Spec.Replicas-sts.Status.ReadyReplicas), false, nil
+	}
+	if sts.Status.UpdateRevision != sts.Status.CurrentRevision {
+		return fmt.Sprintf("statefulset uses OnDelete strategy: %d pod(s) still run revision %s and"+
+			" require manual deletion to pick up revision %s",
+			sts.Status.Replicas-sts.Status.UpdatedReplicas, sts.Status.CurrentRevision, sts.Status.UpdateRevision), true, nil
+	}
+	return fmt.Sprintf("statefulset OnDelete rollout complete: %d pods at revision %s",
 		sts.Status.CurrentReplicas, sts.Status.CurrentRevision), true, nil
 }

--- a/pkg/k8sutils/templates/statefulset/status_test.go
+++ b/pkg/k8sutils/templates/statefulset/status_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021-present, StarRocks Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package statefulset
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestStatus_OnDelete(t *testing.T) {
+	replicas := int32(3)
+
+	tests := []struct {
+		name     string
+		sts      *appsv1.StatefulSet
+		wantDone bool
+		wantErr  bool
+	}{
+		{
+			name: "OnDelete: revisions differ but all replicas ready - should not error, done=true",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas:       &replicas,
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					ReadyReplicas:      3,
+					Replicas:           3,
+					UpdatedReplicas:    1,
+					CurrentRevision:    "v1",
+					UpdateRevision:     "v2",
+				},
+			},
+			wantDone: true,
+			wantErr:  false,
+		},
+		{
+			name: "OnDelete: not all replicas ready yet",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas:       &replicas,
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					ReadyReplicas:      2,
+				},
+			},
+			wantDone: false,
+			wantErr:  false,
+		},
+		{
+			name: "OnDelete: spec update not yet observed",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas:       &replicas,
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 0,
+				},
+			},
+			wantDone: false,
+			wantErr:  false,
+		},
+		{
+			name: "OnDelete: fully rolled out, revisions match",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas:       &replicas,
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 1,
+					ReadyReplicas:      3,
+					CurrentReplicas:    3,
+					UpdatedReplicas:    3,
+					CurrentRevision:    "v2",
+					UpdateRevision:     "v2",
+				},
+			},
+			wantDone: true,
+			wantErr:  false,
+		},
+		{
+			name: "unsupported strategy type still errors",
+			sts: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas:       &replicas,
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: "Unknown"},
+				},
+			},
+			wantDone: true,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, done, err := Status(tt.sts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Status() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if done != tt.wantDone {
+				t.Fatalf("Status() done = %v, want %v", done, tt.wantDone)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

The operator currently assumes that StatefulSets use the `RollingUpdate` strategy. When `updateStrategy.type` is set to `OnDelete`, the status handling returns an error because `CurrentRevision` and `UpdateRevision` may differ until pods are manually restarted. As a result, `UpdateClusterStatus` fails on every reconcile and the `StarRocksCluster` status can remain stuck at `Reconciling`.

This change adds support for the `OnDelete` update strategy in StatefulSet rollout status handling.

StarRocks supports rolling upgrades without stopping the service. According to the [StarRocks upgrade documentation](https://docs.starrocks.io/docs/deployment/manage_deployment/upgrade/), BEs and CNs are backward compatible with FEs, so BEs and CNs must be upgraded first, followed by the FEs. Upgrading them in the opposite order may create incompatibility between FEs and BEs/CNs and cause the service to crash. For FE nodes, all Follower FEs must be upgraded before the Leader FE.

The operator is not aware of the FE leader and follower roles. With an automatic StatefulSet rollout, it may restart or upgrade FE pods according to StatefulSet order rather than StarRocks role order. This can upgrade the Leader FE before the Follower FEs, violating the required upgrade sequence and potentially causing compatibility issues or a service crash.

Using `OnDelete` allows pod replacement to be controlled explicitly. This makes it possible to upgrade BEs and CNs first, then upgrade all Follower FEs, and upgrade the Leader FE last, while still allowing the operator to report the cluster status correctly.

The changes:

- Add `onDeleteStatus()` handling for FE, BE, and CN StatefulSets.
- Report pod readiness for `OnDelete` StatefulSets without treating revision mismatches as rollout failures.
- Preserve the existing rollout behavior for `RollingUpdate`.
- Prevent the cluster status from remaining stuck in `Reconciling` when `OnDelete` is intentionally used for ordered upgrades.

# Related Issue(s)

Not applicable.

# Checklist

For operator, please complete the following checklist:

run `make generate` to generate the code.
run `make lint` to check the code style.
run `make test` to run UT.
run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

make sure you have updated the [values.yaml](https://github.com/StarRocks/starrocks-kubernetes-operator/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml) file of starrocks chart.
In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parentchart (kube-starrocks chart).