### PR TITLE
[Feature] Support exposedPorts in component service specs

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -2761,6 +2761,25 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      exposedPorts:
+                        description: |-
+                          ExposedPorts is an optional allowlist of port names exposed by the external Service.
+                          When omitted, all available ports for the component are exposed for backward compatibility.
+                          When specified, only ports whose names are listed are exposed.
+                          It does not affect the internal headless Service.
+
+
+                          Valid port names depend on the component.
+                          FE supports http, rpc, query, edit-log, and arrow-flight when configured.
+                          BE supports be, webserver, heartbeat, and brpc.
+                          CN supports thrift, webserver, heartbeat, and brpc.
+                          FE Proxy supports http-port.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         description: |-
                           ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
@@ -7873,6 +7892,25 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      exposedPorts:
+                        description: |-
+                          ExposedPorts is an optional allowlist of port names exposed by the external Service.
+                          When omitted, all available ports for the component are exposed for backward compatibility.
+                          When specified, only ports whose names are listed are exposed.
+                          It does not affect the internal headless Service.
+
+
+                          Valid port names depend on the component.
+                          FE supports http, rpc, query, edit-log, and arrow-flight when configured.
+                          BE supports be, webserver, heartbeat, and brpc.
+                          CN supports thrift, webserver, heartbeat, and brpc.
+                          FE Proxy supports http-port.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         description: |-
                           ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
@@ -10803,6 +10841,25 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      exposedPorts:
+                        description: |-
+                          ExposedPorts is an optional allowlist of port names exposed by the external Service.
+                          When omitted, all available ports for the component are exposed for backward compatibility.
+                          When specified, only ports whose names are listed are exposed.
+                          It does not affect the internal headless Service.
+
+
+                          Valid port names depend on the component.
+                          FE supports http, rpc, query, edit-log, and arrow-flight when configured.
+                          BE supports be, webserver, heartbeat, and brpc.
+                          CN supports thrift, webserver, heartbeat, and brpc.
+                          FE Proxy supports http-port.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         description: |-
                           ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the
@@ -13945,6 +14002,25 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      exposedPorts:
+                        description: |-
+                          ExposedPorts is an optional allowlist of port names exposed by the external Service.
+                          When omitted, all available ports for the component are exposed for backward compatibility.
+                          When specified, only ports whose names are listed are exposed.
+                          It does not affect the internal headless Service.
+
+
+                          Valid port names depend on the component.
+                          FE supports http, rpc, query, edit-log, and arrow-flight when configured.
+                          BE supports be, webserver, heartbeat, and brpc.
+                          CN supports thrift, webserver, heartbeat, and brpc.
+                          FE Proxy supports http-port.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         description: |-
                           ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the

--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -3357,6 +3357,25 @@ spec:
                           Annotations' store Kubernetes Service annotations. These will be added to the external service
                           only (not internal).
                         type: object
+                      exposedPorts:
+                        description: |-
+                          ExposedPorts is an optional allowlist of port names exposed by the external Service.
+                          When omitted, all available ports for the component are exposed for backward compatibility.
+                          When specified, only ports whose names are listed are exposed.
+                          It does not affect the internal headless Service.
+
+
+                          Valid port names depend on the component.
+                          FE supports http, rpc, query, edit-log, and arrow-flight when configured.
+                          BE supports be, webserver, heartbeat, and brpc.
+                          CN supports thrift, webserver, heartbeat, and brpc.
+                          FE Proxy supports http-port.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         description: |-
                           ExternalTrafficPolicy describes how nodes distribute service traffic they receive on one of the

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -1340,6 +1340,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      exposedPorts:
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         enum:
                         - Cluster
@@ -3754,6 +3761,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      exposedPorts:
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         enum:
                         - Cluster
@@ -5102,6 +5116,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      exposedPorts:
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         enum:
                         - Cluster
@@ -6549,6 +6570,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      exposedPorts:
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         enum:
                         - Cluster

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -1654,6 +1654,13 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      exposedPorts:
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                        uniqueItems: true
+                        x-kubernetes-list-type: set
                       externalTrafficPolicy:
                         enum:
                         - Cluster

--- a/doc/api.md
+++ b/doc/api.md
@@ -2236,6 +2236,26 @@ StarRocksServicePort.NodePort field.</p>
 </tr>
 <tr>
 <td>
+<code>exposedPorts</code><br/>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExposedPorts is an optional allowlist of port names exposed by the external Service.
+When omitted, all available ports for the component are exposed for backward compatibility.
+When specified, only ports whose names are listed are exposed.
+It does not affect the internal headless Service.</p>
+<p>Valid port names depend on the component.
+FE supports http, rpc, query, edit-log, and arrow-flight when configured.
+BE supports be, webserver, heartbeat, and brpc.
+CN supports thrift, webserver, heartbeat, and brpc.
+FE Proxy supports http-port.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>loadBalancerSourceRanges</code><br/>
 <em>
 []string
@@ -2701,5 +2721,5 @@ AutoScalingPolicy
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>7027f915</code>.
+on git commit <code>342e8e2</code>.
 </em></p>

--- a/doc/deploy_starrocks_with_operator_howto.md
+++ b/doc/deploy_starrocks_with_operator_howto.md
@@ -187,8 +187,11 @@ NodePort. This topic uses LoadBalancer as an example:
     ```YAML
     spec:
       starRocksFeSpec:
-        service:            
+        service:
           type: LoadBalancer # specified as LoadBalancer
+          exposedPorts:
+            - http
+            - query
     ```
 
 2. Obtain the IP address `EXTERNAL-IP` and port `PORT(S)` that the FE Service exposes to the outside.
@@ -199,7 +202,7 @@ NodePort. This topic uses LoadBalancer as an example:
     starrockscluster-sample-be-search    ClusterIP      None           <none>        9050/TCP                                                      6m39s
     starrockscluster-sample-be-service   ClusterIP      10.96.86.207   <none>        9060/TCP,8040/TCP,9050/TCP,8060/TCP                           6m39s
     starrockscluster-sample-fe-search    ClusterIP      None           <none>        9030/TCP                                                      8m
-    starrockscluster-sample-fe-service   LoadBalancer   10.96.26.146   a7509284bf3784983a596c6eec7fc212-618xxxxxx.us-west-2.elb.amazonaws.com     8030:30028/TCP,9020:32241/TCP,9030:32640/TCP,9010:32384/TCP   8m
+    starrockscluster-sample-fe-service   LoadBalancer   10.96.26.146   a7509284bf3784983a596c6eec7fc212-618xxxxxx.us-west-2.elb.amazonaws.com     8030:30028/TCP,9030:32640/TCP   8m
     ```
 
 3. Log in to your machine host and access the StarRocks cluster by using the MySQL client.

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -60,6 +60,10 @@ spec:
       {{- if and (or (eq "LoadBalancer" .Values.starrocksFESpec.service.type) (eq "NodePort" .Values.starrocksFESpec.service.type)) .Values.starrocksFESpec.service.externalTrafficPolicy }}
       externalTrafficPolicy: {{ .Values.starrocksFESpec.service.externalTrafficPolicy }}
       {{- end }}
+      {{- if .Values.starrocksFESpec.service.exposedPorts }}
+      exposedPorts:
+        {{- toYaml .Values.starrocksFESpec.service.exposedPorts | nindent 8 }}
+      {{- end }}
       {{- if .Values.starrocksFESpec.service.ports }}
       ports:
         {{- toYaml .Values.starrocksFESpec.service.ports | nindent 8 }}
@@ -346,6 +350,10 @@ spec:
       {{- end }}
       {{- if and (or (eq "LoadBalancer" .Values.starrocksBeSpec.service.type) (eq "NodePort" .Values.starrocksBeSpec.service.type)) .Values.starrocksBeSpec.service.externalTrafficPolicy }}
       externalTrafficPolicy: {{ .Values.starrocksBeSpec.service.externalTrafficPolicy }}
+      {{- end }}
+      {{- if .Values.starrocksBeSpec.service.exposedPorts }}
+      exposedPorts:
+        {{- toYaml .Values.starrocksBeSpec.service.exposedPorts | nindent 8 }}
       {{- end }}
       {{- if .Values.starrocksBeSpec.service.ports }}
       ports:
@@ -809,6 +817,10 @@ spec:
       {{- if and (or (eq "LoadBalancer" .Values.starrocksCnSpec.service.type) (eq "NodePort" .Values.starrocksCnSpec.service.type)) .Values.starrocksCnSpec.service.externalTrafficPolicy }}
       externalTrafficPolicy: {{ .Values.starrocksCnSpec.service.externalTrafficPolicy }}
       {{- end }}
+      {{- if .Values.starrocksCnSpec.service.exposedPorts }}
+      exposedPorts:
+        {{- toYaml .Values.starrocksCnSpec.service.exposedPorts | nindent 8 }}
+      {{- end }}
       {{- if .Values.starrocksCnSpec.service.ports }}
       ports:
         {{- toYaml .Values.starrocksCnSpec.service.ports | nindent 8 }}
@@ -983,6 +995,10 @@ spec:
       {{- end }}
       {{- if and (or (eq "LoadBalancer" .Values.starrocksFeProxySpec.service.type) (eq "NodePort" .Values.starrocksFeProxySpec.service.type)) .Values.starrocksFeProxySpec.service.externalTrafficPolicy }}
       externalTrafficPolicy: {{ .Values.starrocksFeProxySpec.service.externalTrafficPolicy }}
+      {{- end }}
+      {{- if .Values.starrocksFeProxySpec.service.exposedPorts }}
+      exposedPorts:
+        {{- toYaml .Values.starrocksFeProxySpec.service.exposedPorts | nindent 8 }}
       {{- end }}
       {{- if .Values.starrocksFeProxySpec.service.ports }}
       ports:

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -262,6 +262,15 @@ starrocksFESpec:
       # e.g., specify a dedicated node port for FE service by containerPort.
       # - nodePort: 30030 # The range of valid ports is 30000-32767
       #   containerPort: 8030 # The port exported on the container
+    # Select the FE ports exposed by the external Service.
+    # Leave empty to omit exposedPorts and preserve the existing behavior.
+    # Valid values include http, rpc, query, edit-log, and arrow-flight when configured.
+    exposedPorts: []
+      # - http
+      # - rpc
+      # - query
+      # - edit-log
+      # - arrow-flight
     # specifies the source IP ranges for the load balancer when the type=LoadBalancer.
     loadBalancerSourceRanges: []
       # - 10.0.0.0/8
@@ -608,6 +617,14 @@ starrocksCnSpec:
       # e.g., specify a dedicated node port for CN service by containerPort.
       # - nodePort: 30040 # The range of valid ports is 30000-32767
       #   containerPort: 8040 # The port on the container to expose.
+    # Select the CN ports exposed by the external Service.
+    # Leave empty to omit exposedPorts and preserve the existing behavior.
+    # Valid values include thrift, webserver, heartbeat, and brpc.
+    exposedPorts: []
+      # - thrift
+      # - webserver
+      # - heartbeat
+      # - brpc
     # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
     loadBalancerSourceRanges: []
       # - 10.0.0.0/8
@@ -990,6 +1007,14 @@ starrocksBeSpec:
       # e.g., specify a dedicated node port for BE service by containerPort.
       # - nodePort: 30040 # The range of valid ports is 30000-32767
       #   containerPort: 8040 # The port on the container to expose.
+    # Select the BE ports exposed by the external Service.
+    # Leave empty to omit exposedPorts and preserve the existing behavior.
+    # Valid values include be, webserver, heartbeat, and brpc.
+    exposedPorts: []
+      # - be
+      # - webserver
+      # - heartbeat
+      # - brpc
     # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
     loadBalancerSourceRanges: []
       # - 10.0.0.0/8
@@ -1336,6 +1361,11 @@ starrocksFeProxySpec:
       # e.g., specify a dedicated node port for FE proxy service by containerPort.
       # - nodePort: 30080 # The range of valid ports is 30000-32767
       #   containerPort: 8080 # The port on the container to expose.
+    # Select the FE Proxy ports exposed by the external Service.
+    # Leave empty to omit exposedPorts and preserve the existing behavior.
+    # The valid value is http-port.
+    exposedPorts: []
+      # - http-port
     # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
     loadBalancerSourceRanges: []
       # - 10.0.0.0/8

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -401,6 +401,15 @@ starrocks:
         # e.g., specify a dedicated node port for FE service by containerPort.
         # - nodePort: 30030 # The range of valid ports is 30000-32767
         #   containerPort: 8030 # The port exported on the container
+      # Select the FE ports exposed by the external Service.
+      # Leave empty to omit exposedPorts and preserve the existing behavior.
+      # Valid values include http, rpc, query, edit-log, and arrow-flight when configured.
+      exposedPorts: []
+        # - http
+        # - rpc
+        # - query
+        # - edit-log
+        # - arrow-flight
       # specifies the source IP ranges for the load balancer when the type=LoadBalancer.
       loadBalancerSourceRanges: []
         # - 10.0.0.0/8
@@ -747,6 +756,14 @@ starrocks:
         # e.g., specify a dedicated node port for CN service by containerPort.
         # - nodePort: 30040 # The range of valid ports is 30000-32767
         #   containerPort: 8040 # The port on the container to expose.
+      # Select the CN ports exposed by the external Service.
+      # Leave empty to omit exposedPorts and preserve the existing behavior.
+      # Valid values include thrift, webserver, heartbeat, and brpc.
+      exposedPorts: []
+        # - thrift
+        # - webserver
+        # - heartbeat
+        # - brpc
       # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
       loadBalancerSourceRanges: []
         # - 10.0.0.0/8
@@ -1129,6 +1146,14 @@ starrocks:
         # e.g., specify a dedicated node port for BE service by containerPort.
         # - nodePort: 30040 # The range of valid ports is 30000-32767
         #   containerPort: 8040 # The port on the container to expose.
+      # Select the BE ports exposed by the external Service.
+      # Leave empty to omit exposedPorts and preserve the existing behavior.
+      # Valid values include be, webserver, heartbeat, and brpc.
+      exposedPorts: []
+        # - be
+        # - webserver
+        # - heartbeat
+        # - brpc
       # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
       loadBalancerSourceRanges: []
         # - 10.0.0.0/8
@@ -1475,6 +1500,11 @@ starrocks:
         # e.g., specify a dedicated node port for FE proxy service by containerPort.
         # - nodePort: 30080 # The range of valid ports is 30000-32767
         #   containerPort: 8080 # The port on the container to expose.
+      # Select the FE Proxy ports exposed by the external Service.
+      # Leave empty to omit exposedPorts and preserve the existing behavior.
+      # The valid value is http-port.
+      exposedPorts: []
+        # - http-port
       # Specify the source IP ranges for the load balancer when the type=LoadBalancer.
       loadBalancerSourceRanges: []
         # - 10.0.0.0/8

--- a/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
+++ b/helm-charts/charts/warehouse/templates/starrockswarehouse.yaml
@@ -67,6 +67,10 @@ spec:
       {{- if and (or (eq "LoadBalancer" .Values.spec.service.type) (eq "NodePort" .Values.spec.service.type)) .Values.spec.service.externalTrafficPolicy }}
       externalTrafficPolicy: {{ .Values.spec.service.externalTrafficPolicy }}
       {{- end }}
+      {{- if .Values.spec.service.exposedPorts }}
+      exposedPorts:
+        {{- toYaml .Values.spec.service.exposedPorts | nindent 8 }}
+      {{- end }}
       {{- if .Values.spec.service.ports }}
       ports:
         {{- toYaml .Values.spec.service.ports | nindent 8 }}

--- a/helm-charts/charts/warehouse/values.yaml
+++ b/helm-charts/charts/warehouse/values.yaml
@@ -63,6 +63,14 @@ spec:
       #   nodePort: 30040 # The range of valid ports is 30000-32767
       #   containerPort: 8040 # The port on the container to expose
       #   port: 8040 # The port to expose on the service
+    # Select the CN ports exposed by the external Service.
+    # Leave empty to omit exposedPorts and preserve the existing behavior.
+    # Valid values include thrift, webserver, heartbeat, and brpc.
+    exposedPorts: []
+      # - thrift
+      # - webserver
+      # - heartbeat
+      # - brpc
     # Specify how nodes distribute service traffic. Possible values: Cluster, Local.
     # Only applies when the type is NodePort or LoadBalancer. Local preserves the client source IP.
     externalTrafficPolicy: ""

--- a/pkg/apis/starrocks/v1/load_type.go
+++ b/pkg/apis/starrocks/v1/load_type.go
@@ -246,6 +246,22 @@ type StarRocksService struct {
 	// +optional
 	Ports []StarRocksServicePort `json:"ports,omitempty"`
 
+	// ExposedPorts is an optional allowlist of port names exposed by the external Service.
+	// When omitted, all available ports for the component are exposed for backward compatibility.
+	// When specified, only ports whose names are listed are exposed.
+	// It does not affect the internal headless Service.
+	//
+	// Valid port names depend on the component.
+	// FE supports http, rpc, query, edit-log, and arrow-flight when configured.
+	// BE supports be, webserver, heartbeat, and brpc.
+	// CN supports thrift, webserver, heartbeat, and brpc.
+	// FE Proxy supports http-port.
+	// +optional
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:UniqueItems=true
+	// +listType=set
+	ExposedPorts []string `json:"exposedPorts,omitempty"`
+
 	// If specified and supported by the platform, this will restrict traffic through the cloud-provider
 	// load-balancer will be restricted to the specified client IPs. This field will be ignored if the
 	// cloud-provider does not support the feature.

--- a/pkg/apis/starrocks/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/starrocks/v1/zz_generated.deepcopy.go
@@ -761,6 +761,11 @@ func (in *StarRocksService) DeepCopyInto(out *StarRocksService) {
 		*out = make([]StarRocksServicePort, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExposedPorts != nil {
+		in, out := &in.ExposedPorts, &out.ExposedPorts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.LoadBalancerSourceRanges != nil {
 		in, out := &in.LoadBalancerSourceRanges, &out.LoadBalancerSourceRanges
 		*out = make([]string, len(*in))

--- a/pkg/common/resource_utils/service.go
+++ b/pkg/common/resource_utils/service.go
@@ -15,6 +15,8 @@
 package resource_utils
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -61,7 +63,7 @@ type hashService struct {
 
 // BuildExternalService build the external service. not have selector
 func BuildExternalService(object object.StarRocksObject, spec srapi.SpecInterface,
-	config map[string]interface{}, selector map[string]string, labels map[string]string) corev1.Service {
+	config map[string]interface{}, selector map[string]string, labels map[string]string) (corev1.Service, error) {
 	// the k8s service type.
 	var srPorts []srapi.StarRocksServicePort
 	svc := corev1.Service{
@@ -104,6 +106,14 @@ func BuildExternalService(object object.StarRocksObject, spec srapi.SpecInterfac
 		}
 	}
 
+	if starRocksService != nil {
+		filteredPorts, err := filterServicePorts(srPorts, starRocksService.ExposedPorts)
+		if err != nil {
+			return corev1.Service{}, err
+		}
+		srPorts = filteredPorts
+	}
+
 	ref := metav1.NewControllerRef(object, object.GroupVersionKind())
 	svc.OwnerReferences = []metav1.OwnerReference{*ref}
 
@@ -135,7 +145,39 @@ func BuildExternalService(object object.StarRocksObject, spec srapi.SpecInterfac
 
 	anno[srapi.ComponentResourceHash] = hash.HashObject(serviceHashObject(&svc))
 	svc.Annotations = anno
-	return svc
+	return svc, nil
+}
+
+func filterServicePorts(
+	ports []srapi.StarRocksServicePort,
+	exposedPorts []string,
+) ([]srapi.StarRocksServicePort, error) {
+	if len(exposedPorts) == 0 {
+		return ports, nil
+	}
+
+	requestedPorts := make(map[string]struct{}, len(exposedPorts))
+	for _, name := range exposedPorts {
+		requestedPorts[name] = struct{}{}
+	}
+
+	filteredPorts := make([]srapi.StarRocksServicePort, 0, len(ports))
+	for _, port := range ports {
+		if _, ok := requestedPorts[port.Name]; ok {
+			filteredPorts = append(filteredPorts, port)
+			delete(requestedPorts, port.Name)
+		}
+	}
+
+	if len(requestedPorts) != 0 {
+		for _, name := range exposedPorts {
+			if _, ok := requestedPorts[name]; ok {
+				return nil, fmt.Errorf("service: exposed port %q is not available", name)
+			}
+		}
+	}
+
+	return filteredPorts, nil
 }
 
 func getFeServicePorts(config map[string]interface{}, service *srapi.StarRocksService) (srPorts []srapi.StarRocksServicePort) {

--- a/pkg/common/resource_utils/service_test.go
+++ b/pkg/common/resource_utils/service_test.go
@@ -187,9 +187,12 @@ func TestBuildExternalService_ForStarRocksWarehouse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(_ *testing.T) {
-			gotCnService := BuildExternalService(object.NewFromWarehouse(warehouse),
+		t.Run(tt.name, func(t *testing.T) {
+			gotCnService, err := BuildExternalService(object.NewFromWarehouse(warehouse),
 				warehouse.Spec.Template.ToCnSpec(), map[string]interface{}{}, map[string]string{}, map[string]string{})
+			if err != nil {
+				t.Fatalf("BuildExternalService() error = %v", err)
+			}
 			equal(gotCnService, tt.wantCnService)
 		})
 	}
@@ -395,18 +398,212 @@ func TestBuildExternalService_ForStarRocksCluster(t *testing.T) {
 		"starrocks_default_label": "test",
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(_ *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			object := object.NewFromCluster(src)
-			gotFeService := BuildExternalService(object, src.Spec.StarRocksFeSpec,
+			gotFeService, err := BuildExternalService(object, src.Spec.StarRocksFeSpec,
 				map[string]interface{}{}, map[string]string{}, starrocksDefaultLabels)
+			if err != nil {
+				t.Fatalf("BuildExternalService() FE error = %v", err)
+			}
 			equal(gotFeService, tt.wantFeService)
-			gotBeService := BuildExternalService(object, src.Spec.StarRocksBeSpec,
+
+			gotBeService, err := BuildExternalService(object, src.Spec.StarRocksBeSpec,
 				map[string]interface{}{}, map[string]string{}, starrocksDefaultLabels)
+			if err != nil {
+				t.Fatalf("BuildExternalService() BE error = %v", err)
+			}
 			equal(gotBeService, tt.wantBeService)
-			gotCnService := BuildExternalService(object, src.Spec.StarRocksCnSpec,
+
+			gotCnService, err := BuildExternalService(object, src.Spec.StarRocksCnSpec,
 				map[string]interface{}{}, map[string]string{}, starrocksDefaultLabels)
+			if err != nil {
+				t.Fatalf("BuildExternalService() CN error = %v", err)
+			}
 			equal(gotCnService, tt.wantCnService)
 		})
+	}
+}
+
+func TestBuildExternalService_ExposedPorts(t *testing.T) {
+	src := &srapi.StarRocksCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+
+	newService := func(exposedPorts []string) *srapi.StarRocksService {
+		return &srapi.StarRocksService{
+			Type:         corev1.ServiceTypeLoadBalancer,
+			ExposedPorts: exposedPorts,
+		}
+	}
+
+	newComponentSpec := func(exposedPorts []string) srapi.StarRocksComponentSpec {
+		return srapi.StarRocksComponentSpec{
+			StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+				Service: newService(exposedPorts),
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		spec          srapi.SpecInterface
+		config        map[string]interface{}
+		wantPortNames []string
+		wantErr       string
+	}{
+		{
+			name: "all FE ports when exposedPorts is omitted",
+			spec: &srapi.StarRocksFeSpec{
+				StarRocksComponentSpec: newComponentSpec(nil),
+			},
+			wantPortNames: []string{"http", "rpc", "query", "edit-log"},
+		},
+		{
+			name: "expose only FE query port",
+			spec: &srapi.StarRocksFeSpec{
+				StarRocksComponentSpec: newComponentSpec([]string{"query"}),
+			},
+			wantPortNames: []string{"query"},
+		},
+		{
+			name: "expose only BE webserver port",
+			spec: &srapi.StarRocksBeSpec{
+				StarRocksComponentSpec: newComponentSpec([]string{"webserver"}),
+			},
+			wantPortNames: []string{"webserver"},
+		},
+		{
+			name: "expose selected CN ports in component order",
+			spec: &srapi.StarRocksCnSpec{
+				StarRocksComponentSpec: newComponentSpec([]string{"heartbeat", "thrift"}),
+			},
+			wantPortNames: []string{"thrift", "heartbeat"},
+		},
+		{
+			name: "expose FE Proxy HTTP port",
+			spec: &srapi.StarRocksFeProxySpec{
+				StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+					Service: newService([]string{"http-port"}),
+				},
+			},
+			wantPortNames: []string{"http-port"},
+		},
+		{
+			name: "reject unavailable FE port",
+			spec: &srapi.StarRocksFeSpec{
+				StarRocksComponentSpec: newComponentSpec([]string{"qeury"}),
+			},
+			wantErr: `service: exposed port "qeury" is not available`,
+		},
+		{
+			name: "expose configured FE arrow flight port",
+			spec: &srapi.StarRocksFeSpec{
+				StarRocksComponentSpec: newComponentSpec([]string{"arrow-flight"}),
+			},
+			config: map[string]interface{}{
+				ARROW_FLIGHT_PORT: "8070",
+			},
+			wantPortNames: []string{"arrow-flight"},
+		},
+		{
+			name: "reject unconfigured FE arrow flight port",
+			spec: &srapi.StarRocksFeSpec{
+				StarRocksComponentSpec: newComponentSpec([]string{"arrow-flight"}),
+			},
+			wantErr: `service: exposed port "arrow-flight" is not available`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotService, err := BuildExternalService(
+				object.NewFromCluster(src),
+				tt.spec,
+				tt.config,
+				nil,
+				nil,
+			)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("BuildExternalService() error = nil, want %q", tt.wantErr)
+				}
+				if err.Error() != tt.wantErr {
+					t.Errorf("BuildExternalService() error = %q, want %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("BuildExternalService() error = %v", err)
+			}
+
+			gotPortNames := make([]string, 0, len(gotService.Spec.Ports))
+			for _, port := range gotService.Spec.Ports {
+				gotPortNames = append(gotPortNames, port.Name)
+			}
+
+			if !reflect.DeepEqual(gotPortNames, tt.wantPortNames) {
+				t.Errorf("BuildExternalService() port names = %v, want %v", gotPortNames, tt.wantPortNames)
+			}
+		})
+	}
+}
+
+func TestBuildExternalService_ExposedPortsWithPortOverride(t *testing.T) {
+	src := &srapi.StarRocksCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+
+	spec := &srapi.StarRocksFeSpec{
+		StarRocksComponentSpec: srapi.StarRocksComponentSpec{
+			StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+				Service: &srapi.StarRocksService{
+					Type:         corev1.ServiceTypeLoadBalancer,
+					ExposedPorts: []string{"query"},
+					Ports: []srapi.StarRocksServicePort{
+						{
+							Name: "query",
+							Port: 3306,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	gotService, err := BuildExternalService(
+		object.NewFromCluster(src),
+		spec,
+		map[string]interface{}{},
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("BuildExternalService() error = %v", err)
+	}
+
+	if len(gotService.Spec.Ports) != 1 {
+		t.Fatalf("BuildExternalService() ports = %v, want one port", gotService.Spec.Ports)
+	}
+
+	gotPort := gotService.Spec.Ports[0]
+	if gotPort.Name != "query" {
+		t.Errorf("port name = %q, want %q", gotPort.Name, "query")
+	}
+	if gotPort.Port != 3306 {
+		t.Errorf("port = %d, want %d", gotPort.Port, 3306)
+	}
+
+	wantTargetPort := intstr.FromInt(int(DefMap[QUERY_PORT]))
+	if gotPort.TargetPort != wantTargetPort {
+		t.Errorf("targetPort = %v, want %v", gotPort.TargetPort, wantTargetPort)
 	}
 }
 

--- a/pkg/subcontrollers/be/be_controller.go
+++ b/pkg/subcontrollers/be/be_controller.go
@@ -116,8 +116,11 @@ func (be *BeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 	beConfig[rutils.QUERY_PORT] = strconv.FormatInt(int64(rutils.GetPort(feConfig, rutils.QUERY_PORT)), 10)
 	// generate new be external service.
 	defaultLabels := load.Labels(src.Name, beSpec)
-	externalsvc := rutils.BuildExternalService(object.NewFromCluster(src),
+	externalsvc, err := rutils.BuildExternalService(object.NewFromCluster(src),
 		beSpec, beConfig, load.Selector(src.Name, beSpec), defaultLabels)
+	if err != nil {
+		return err
+	}
 	// generate internal fe service, update the status of cn on src.
 	internalService := GenerateInternalService(src, &externalsvc, beConfig, defaultLabels)
 

--- a/pkg/subcontrollers/cn/cn_controller.go
+++ b/pkg/subcontrollers/cn/cn_controller.go
@@ -195,8 +195,11 @@ func (cc *CnController) SyncCnSpec(ctx context.Context, object object.StarRocksO
 
 	// build and deploy service
 	defaultLabels := load.Labels(object.SubResourcePrefixName, cnSpec)
-	externalsvc := rutils.BuildExternalService(object, cnSpec, cnConfig,
+	externalsvc, err := rutils.BuildExternalService(object, cnSpec, cnConfig,
 		load.Selector(object.SubResourcePrefixName, cnSpec), defaultLabels)
+	if err != nil {
+		return err
+	}
 	internalService := generateInternalService(object, cnSpec, &externalsvc, cnConfig, defaultLabels)
 
 	if err := k8sutils.ApplyService(ctx, cc.k8sClient, &externalsvc, rutils.ServiceDeepEqual); err != nil {

--- a/pkg/subcontrollers/fe/fe_controller.go
+++ b/pkg/subcontrollers/fe/fe_controller.go
@@ -92,7 +92,10 @@ func (fc *FeController) SyncCluster(ctx context.Context, src *srapi.StarRocksClu
 	logger.V(log.DebugLevel).Info("build fe service", "StarRocksCluster", src)
 	object := object.NewFromCluster(src)
 	defaultLabels := load.Labels(src.Name, feSpec)
-	svc := rutils.BuildExternalService(object, feSpec, feConfig, load.Selector(src.Name, feSpec), defaultLabels)
+	svc, err := rutils.BuildExternalService(object, feSpec, feConfig, load.Selector(src.Name, feSpec), defaultLabels)
+	if err != nil {
+		return err
+	}
 	searchServiceName := service.SearchServiceName(src.Name, feSpec)
 	internalService := service.MakeSearchService(searchServiceName, &svc, []corev1.ServicePort{
 		{

--- a/pkg/subcontrollers/feproxy/feproxy_controller.go
+++ b/pkg/subcontrollers/feproxy/feproxy_controller.go
@@ -109,8 +109,11 @@ func (controller *FeProxyController) SyncCluster(ctx context.Context, src *srapi
 	}
 
 	object := object.NewFromCluster(src)
-	externalsvc := rutils.BuildExternalService(object, feProxySpec, nil,
+	externalsvc, err := rutils.BuildExternalService(object, feProxySpec, nil,
 		load.Selector(src.Name, feProxySpec), load.Labels(src.Name, feProxySpec))
+	if err != nil {
+		return err
+	}
 	if err := k8sutils.ApplyService(ctx, controller.k8sClient, &externalsvc, rutils.ServiceDeepEqual); err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

This PR adds an optional `exposedPorts` field to the component Service configuration.

Currently, an external Service exposes all available ports for the component. For example, an FE LoadBalancer exposes `rpc` and `edit-log` even when users only need `http` and `query`.

When `exposedPorts` is set, the Operator adds only the listed ports to the external Service.

```yaml
service:
  type: LoadBalancer
  exposedPorts:
    - http
    - query
```

When the field is not set, the Operator keeps the current behavior and exposes all available ports. This keeps backward compatibility for existing users.

The field only affects the external Service. The internal headless Service is not changed.
Invalid port names are reported during reconciliation.

This feature supports FE, BE, CN, FE Proxy, and Warehouse. This PR also updates the Helm charts, generated CRDs, API documentation, and the LoadBalancer usage example.

The affected Go packages and both Helm charts were tested with `go test` and `helm lint`.

# Related Issue(s)

Closes #793

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [ ] run `make lint` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
