### PR TITLE
Replace wildcard `*` permissions with specific verbs in RBAC policies

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -25,19 +25,37 @@ rules:
   - deployments
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - batch
   resources:
   - cronjobs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -45,7 +63,13 @@ rules:
   - serviceaccounts
   - services
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -62,7 +86,9 @@ rules:
   - starrocksclusters
   - starrockswarehouses
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
 # when deploying to OpenShift, the following permission is also necessary
 - apiGroups:
   - starrocks.com

--- a/doc/least_permission_to_deploy_starrocks_howto.md
+++ b/doc/least_permission_to_deploy_starrocks_howto.md
@@ -31,7 +31,13 @@ rules:
       - serviceaccounts
       - configmaps
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:
@@ -40,36 +46,72 @@ rules:
       - clusterroles
       - roles
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - apps
     resources:
       - deployments
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - monitoring.coreos.com
     resources:
       - servicemonitors
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - starrocks.com
     resources:
       - starrocksclusters
       - starrockswarehouses
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - batch
     resources:
       - jobs
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
 ```

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/clusterrole.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/clusterrole.yaml
@@ -13,19 +13,37 @@ rules:
   - deployments
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - batch
   resources:
   - cronjobs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -33,7 +51,13 @@ rules:
   - serviceaccounts
   - services
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -50,7 +74,9 @@ rules:
   - starrocksclusters
   - starrockswarehouses
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
 # when deploying to OpenShift, the following permission is also necessary
 - apiGroups:
   - starrocks.com

--- a/helm-charts/charts/kube-starrocks/charts/operator/templates/role.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/operator/templates/role.yaml
@@ -14,19 +14,37 @@ rules:
   - deployments
   - statefulsets
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - batch
   resources:
   - cronjobs
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -34,7 +52,13 @@ rules:
   - serviceaccounts
   - services
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -51,7 +75,9 @@ rules:
   - starrocksclusters
   - starrockswarehouses
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
 # when deploying to OpenShift, the following permission is also necessary
 - apiGroups:
   - starrocks.com


### PR DESCRIPTION
# Description
Replaces the wildcard `'*'` verb with explicit verb lists in every Role and ClusterRole
shipped by the operator chart.


Hi
Using '*' is not the best practice. It is not visible what really operator uses and adds not needed verbs like "bind", "escalate" or "deletecollection". 

In environments where we don't specify wildcards in any user roles it blocks possibility to install operator because they can't create role with "*". 


For example starrocks.com/{starrocksclusters,starrockswarehouses} had "*" too but I don't see a need for anything else than: 
  - get
  - list
  - watch


