### PR TITLE
[Feature] add seccompProfile

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -2720,6 +2720,31 @@ spec:
                     description: SchedulerName is the name of the kubernetes scheduler
                       that will be used to schedule the pods.
                     type: string
+                  seccompProfile:
+                    description: |-
+                      SeccompProfile defines a pod/container's seccomp profile settings.
+                      Only one profile source may be set.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile defined in a file on the node should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                          Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of seccomp profile will be applied.
+                          Valid options are:
+
+
+                          Localhost - a profile defined in a file on the node should be used.
+                          RuntimeDefault - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied.
+                        type: string
+                    required:
+                    - type
+                    type: object
                   secrets:
                     description: the reference for secrets.
                     items:
@@ -7832,6 +7857,31 @@ spec:
                     description: SchedulerName is the name of the kubernetes scheduler
                       that will be used to schedule the pods.
                     type: string
+                  seccompProfile:
+                    description: |-
+                      SeccompProfile defines a pod/container's seccomp profile settings.
+                      Only one profile source may be set.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile defined in a file on the node should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                          Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of seccomp profile will be applied.
+                          Valid options are:
+
+
+                          Localhost - a profile defined in a file on the node should be used.
+                          RuntimeDefault - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied.
+                        type: string
+                    required:
+                    - type
+                    type: object
                   secrets:
                     description: the reference for secrets.
                     items:
@@ -13904,6 +13954,31 @@ spec:
                     description: SchedulerName is the name of the kubernetes scheduler
                       that will be used to schedule the pods.
                     type: string
+                  seccompProfile:
+                    description: |-
+                      SeccompProfile defines a pod/container's seccomp profile settings.
+                      Only one profile source may be set.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile defined in a file on the node should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                          Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of seccomp profile will be applied.
+                          Valid options are:
+
+
+                          Localhost - a profile defined in a file on the node should be used.
+                          RuntimeDefault - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied.
+                        type: string
+                    required:
+                    - type
+                    type: object
                   secrets:
                     description: the reference for secrets.
                     items:

--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -3316,6 +3316,31 @@ spec:
                     description: SchedulerName is the name of the kubernetes scheduler
                       that will be used to schedule the pods.
                     type: string
+                  seccompProfile:
+                    description: |-
+                      SeccompProfile defines a pod/container's seccomp profile settings.
+                      Only one profile source may be set.
+                    properties:
+                      localhostProfile:
+                        description: |-
+                          localhostProfile indicates a profile defined in a file on the node should be used.
+                          The profile must be preconfigured on the node to work.
+                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                          Must only be set if type is "Localhost".
+                        type: string
+                      type:
+                        description: |-
+                          type indicates which kind of seccomp profile will be applied.
+                          Valid options are:
+
+
+                          Localhost - a profile defined in a file on the node should be used.
+                          RuntimeDefault - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied.
+                        type: string
+                    required:
+                    - type
+                    type: object
                   secrets:
                     description: the reference for secrets.
                     items:

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -1323,6 +1323,15 @@ spec:
                     type: boolean
                   schedulerName:
                     type: string
+                  seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   secrets:
                     items:
                       properties:
@@ -3737,6 +3746,15 @@ spec:
                     type: boolean
                   schedulerName:
                     type: string
+                  seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   secrets:
                     items:
                       properties:
@@ -6532,6 +6550,15 @@ spec:
                     type: boolean
                   schedulerName:
                     type: string
+                  seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   secrets:
                     items:
                       properties:

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -1637,6 +1637,15 @@ spec:
                     type: boolean
                   schedulerName:
                     type: string
+                  seccompProfile:
+                    properties:
+                      localhostProfile:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    type: object
                   secrets:
                     items:
                       properties:

--- a/doc/api.md
+++ b/doc/api.md
@@ -1452,6 +1452,18 @@ See <a href="https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
 </tr>
 <tr>
 <td>
+<code>seccompProfile</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#seccompprofile-v1-core">
+Kubernetes core/v1.SeccompProfile
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>persistentVolumeClaimRetentionPolicy</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps">

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -273,6 +273,8 @@ starrocksFESpec:
     # - name: "image-pull-secret"
   # serviceAccount for FE access cloud service.
   serviceAccount: ""
+  # seccompProfile defines a pod/container's seccomp profile settings
+  seccompProfile: {}
   # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
   # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector: {}
@@ -947,6 +949,8 @@ starrocksBeSpec:
     #   exec /opt/starrocks/be_entrypoint.sh $FE_SERVICE_NAME
   # serviceAccount for BE access cloud service.
   serviceAccount: ""
+  # seccompProfile defines a pod/container's seccomp profile settings
+  seccompProfile: {}
   # add annotations for BE pods. for example, if you want to config monitor for datadog, you can config the annotations.
   annotations: {}
   # If runAsNonRoot is true, the container is run as a non-root user.

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -412,6 +412,8 @@ starrocks:
       # - name: "image-pull-secret"
     # serviceAccount for FE access cloud service.
     serviceAccount: ""
+    # seccompProfile defines a pod/container's seccomp profile settings
+    seccompProfile: {}
     # If specified, the pod's nodeSelector，displayName="Map of nodeSelectors to match when scheduling pods on nodes"
     # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector: {}
@@ -1086,6 +1088,8 @@ starrocks:
       #   exec /opt/starrocks/be_entrypoint.sh $FE_SERVICE_NAME
     # serviceAccount for BE access cloud service.
     serviceAccount: ""
+    # seccompProfile defines a pod/container's seccomp profile settings
+    seccompProfile: {}
     # add annotations for BE pods. for example, if you want to config monitor for datadog, you can config the annotations.
     annotations: {}
     # If runAsNonRoot is true, the container is run as a non-root user.

--- a/pkg/apis/starrocks/v1/component_type.go
+++ b/pkg/apis/starrocks/v1/component_type.go
@@ -118,6 +118,8 @@ type StarRocksComponentSpec struct {
 	// See https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/ for more details.
 	Sysctls []corev1.Sysctl `json:"sysctls,omitempty"`
 
+	SeccompProfile *corev1.SeccompProfile `json:"seccompProfile,omitempty" protobuf:"bytes,10,opt,name=seccompProfile"`
+
 	// PersistentVolumeClaimRetentionPolicy specifies the retention policy for PersistentVolumeClaims associated with the component.
 	// The WhenDeleted field is supported for all components, and it determines whether to delete PVCs when the StatefulSet is deleted.
 	// The WhenScaled field is only supported for the CN component.
@@ -242,6 +244,10 @@ func (spec *StarRocksComponentSpec) GetArgs() []string {
 
 func (spec *StarRocksComponentSpec) GetSysctls() []corev1.Sysctl {
 	return spec.Sysctls
+}
+
+func (spec *StarRocksComponentSpec) GetSeccompProfile() *corev1.SeccompProfile {
+	return spec.SeccompProfile
 }
 
 func (spec *StarRocksComponentSpec) GetUpdateStrategy() *appsv1.StatefulSetUpdateStrategy {

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -70,6 +70,9 @@ type SpecInterface interface {
 	// Sysctls allow configuring kernel parameters at runtime.
 	GetSysctls() []corev1.Sysctl
 
+	// GetSeccompProfile returns the seccomp profile to set for the pod.
+	GetSeccompProfile() *corev1.SeccompProfile
+
 	// GetCommand returns the command to run in the container.
 	// This overrides the container image's default entrypoint.
 	GetCommand() []string
@@ -325,6 +328,8 @@ func (spec *StarRocksFeProxySpec) IsReadOnlyRootFilesystem() *bool {
 // fe proxy does not have field Sysctls, the reason why implementing this method is
 // that StarRocksFeProxySpec needs to implement SpecInterface interface
 func (spec *StarRocksFeProxySpec) GetSysctls() []corev1.Sysctl { return nil }
+
+func (spec *StarRocksFeProxySpec) GetSeccompProfile() *corev1.SeccompProfile { return nil }
 
 // GetMinReadySeconds
 // fe proxy does not have field MinReadySeconds, the reason why implementing this method is

--- a/pkg/apis/starrocks/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/starrocks/v1/zz_generated.deepcopy.go
@@ -482,6 +482,11 @@ func (in *StarRocksComponentSpec) DeepCopyInto(out *StarRocksComponentSpec) {
 		*out = make([]corev1.Sysctl, len(*in))
 		copy(*out, *in)
 	}
+	if in.SeccompProfile != nil {
+		in, out := &in.SeccompProfile, &out.SeccompProfile
+		*out = new(corev1.SeccompProfile)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PersistentVolumeClaimRetentionPolicy != nil {
 		in, out := &in.PersistentVolumeClaimRetentionPolicy, &out.PersistentVolumeClaimRetentionPolicy
 		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)

--- a/pkg/k8sutils/templates/pod/spec.go
+++ b/pkg/k8sutils/templates/pod/spec.go
@@ -308,6 +308,7 @@ func PodSecurityContext(spec v1.SpecInterface) *corev1.PodSecurityContext {
 		FSGroupChangePolicy: &onRootMismatch,
 		FSGroup:             fsGroup,
 		Sysctls:             spec.GetSysctls(),
+		SeccompProfile:      spec.GetSeccompProfile(),
 	}
 	return sc
 }

--- a/pkg/k8sutils/templates/pod/spec_test.go
+++ b/pkg/k8sutils/templates/pod/spec_test.go
@@ -419,6 +419,24 @@ func TestSecurityContext(t *testing.T) {
 				FSGroupChangePolicy: &onrootMismatch,
 			},
 		},
+		{
+			name: "test seccomp profile",
+			args: args{
+				spec: &v1.StarRocksFeSpec{
+					StarRocksComponentSpec: v1.StarRocksComponentSpec{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: "RuntimeDefault",
+						},
+					},
+				},
+			},
+			want: &corev1.PodSecurityContext{
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: "RuntimeDefault",
+				},
+				FSGroupChangePolicy: &onrootMismatch,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

The StarrocksCluster resource does not allows configuration of the `seccompProfile` of the pods. This makes deployment on hardened clusters difficult.

# Related Issue(s)

[#777](https://github.com/StarRocks/starrocks-kubernetes-operator/issues/777)
[#740](https://github.com/StarRocks/starrocks-kubernetes-operator/issues/740)

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `make lint` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
