### PR TITLE
[Enhancement] Support generic ephemeral volumes for cache and spill data

### DIFF
--- a/config/crd/bases/starrocks.com_starrocksclusters.yaml
+++ b/config/crd/bases/starrocks.com_starrocksclusters.yaml
@@ -4218,6 +4218,14 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          description: |-
+                            Ephemeral makes this volume a generic ephemeral volume: its PersistentVolumeClaim is declared
+                            in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions a new
+                            volume. StorageClassName and StorageSize still apply, but the data does not outlive the pod,
+                            so use it for a cache or a spill directory. It can not be set with emptyDir, hostPath or csi.
+                            More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+                          type: boolean
                         hostPath:
                           description: |-
                             HostPath Represents a host path mapped into a pod.
@@ -9330,6 +9338,14 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          description: |-
+                            Ephemeral makes this volume a generic ephemeral volume: its PersistentVolumeClaim is declared
+                            in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions a new
+                            volume. StorageClassName and StorageSize still apply, but the data does not outlive the pod,
+                            so use it for a cache or a spill directory. It can not be set with emptyDir, hostPath or csi.
+                            More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+                          type: boolean
                         hostPath:
                           description: |-
                             HostPath Represents a host path mapped into a pod.
@@ -10982,6 +10998,14 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          description: |-
+                            Ephemeral makes this volume a generic ephemeral volume: its PersistentVolumeClaim is declared
+                            in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions a new
+                            volume. StorageClassName and StorageSize still apply, but the data does not outlive the pod,
+                            so use it for a cache or a spill directory. It can not be set with emptyDir, hostPath or csi.
+                            More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+                          type: boolean
                         hostPath:
                           description: |-
                             HostPath Represents a host path mapped into a pod.
@@ -15402,6 +15426,14 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          description: |-
+                            Ephemeral makes this volume a generic ephemeral volume: its PersistentVolumeClaim is declared
+                            in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions a new
+                            volume. StorageClassName and StorageSize still apply, but the data does not outlive the pod,
+                            so use it for a cache or a spill directory. It can not be set with emptyDir, hostPath or csi.
+                            More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+                          type: boolean
                         hostPath:
                           description: |-
                             HostPath Represents a host path mapped into a pod.

--- a/config/crd/bases/starrocks.com_starrockswarehouses.yaml
+++ b/config/crd/bases/starrocks.com_starrockswarehouses.yaml
@@ -4814,6 +4814,14 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          description: |-
+                            Ephemeral makes this volume a generic ephemeral volume: its PersistentVolumeClaim is declared
+                            in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions a new
+                            volume. StorageClassName and StorageSize still apply, but the data does not outlive the pod,
+                            so use it for a cache or a spill directory. It can not be set with emptyDir, hostPath or csi.
+                            More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+                          type: boolean
                         hostPath:
                           description: |-
                             HostPath Represents a host path mapped into a pod.

--- a/deploy/starrocks.com_starrocksclusters.yaml
+++ b/deploy/starrocks.com_starrocksclusters.yaml
@@ -2010,6 +2010,8 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          type: boolean
                         hostPath:
                           properties:
                             path:
@@ -4424,6 +4426,8 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          type: boolean
                         hostPath:
                           properties:
                             path:
@@ -5167,6 +5171,8 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          type: boolean
                         hostPath:
                           properties:
                             path:
@@ -7219,6 +7225,8 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          type: boolean
                         hostPath:
                           properties:
                             path:

--- a/deploy/starrocks.com_starrockswarehouses.yaml
+++ b/deploy/starrocks.com_starrockswarehouses.yaml
@@ -2324,6 +2324,8 @@ spec:
                           required:
                           - driver
                           type: object
+                        ephemeral:
+                          type: boolean
                         hostPath:
                           properties:
                             path:

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,6 +14,7 @@ Table Of Content
     - [Mount Persistent Volume](./mount_persistent_volume_howto.md)
     - [Mount External ConfigMaps Or Secrets](./mount_external_configmaps_or_secrets_howto.md)
     - [Mount CSI Ephemeral Volumes](./mount_csi_volumes_howto.md)
+    - [Mount Generic Ephemeral Volumes](./mount_ephemeral_volumes_howto.md)
     - [Logging and Related Configurations](./logging_and_related_configurations_howto.md)
     - [HPA Automatic Scaling For CN Nodes](./hpa_dynamic_scaling_with_helm_howto.md)
     - [Load Data Using Stream Load](./load_data_using_stream_load_howto.md)

--- a/doc/mount_ephemeral_volumes_howto.md
+++ b/doc/mount_ephemeral_volumes_howto.md
@@ -1,0 +1,136 @@
+# Mount Generic Ephemeral Volumes
+
+A `storageVolumes` entry with a real storage class becomes a `volumeClaimTemplate` of the FE, BE or
+CN StatefulSet. Such a claim outlives its pod on purpose: when `cn-0` is recreated it binds to the
+same PersistentVolumeClaim, and therefore to the same PersistentVolume.
+
+For a volume that only holds a cache or spill data, that guarantee costs more than it gives:
+
+- A PersistentVolume backed by a local disk carries node affinity. Drain or replace the node it was
+  provisioned on and the replacement pod stays `Pending`, even though the cluster has capacity
+  elsewhere.
+- The claim is deleted only by a `persistentVolumeClaimRetentionPolicy` set to `Delete`, which
+  defaults to `Retain`, and even then only when the StatefulSet is deleted or scaled down. A
+  replacement pod never deletes it, so a volume holding nothing but a cache stays allocated for the
+  life of the StatefulSet.
+- An `emptyDir` avoids both, but it gives up the storage class and the size request, and it
+  competes for the node's ephemeral storage instead of getting a volume of its own.
+
+Setting `ephemeral: true` keeps the storage class and the size, and moves the claim into the pod
+spec as a
+[generic ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes).
+Kubernetes creates the PersistentVolumeClaim when the pod is created, names it
+`<pod-name>-<volume-name>`, sets its owner reference to the pod, and deletes it with the pod. The
+next pod gets a new volume of its own, provisioned where the scheduler places it when the storage
+class binds with `WaitForFirstConsumer`.
+
+Use it only where the data can be rebuilt: a CN data cache, which is refilled from object storage
+on the next read, or a spill directory, which belongs to a query that is already gone.
+
+> **Prerequisite:** generic ephemeral volumes are generally available since Kubernetes 1.23.
+
+## 1. By StarRocksCluster CRD
+
+Set `ephemeral: true` on an entry of `storageVolumes`.
+
+```yaml
+apiVersion: starrocks.com/v1
+kind: StarRocksCluster
+metadata:
+  name: starrockscluster-sample
+spec:
+  starRocksFeSpec:
+    replicas: 1
+    image: starrocks/fe-ubuntu:latest
+  starRocksCnSpec:
+    replicas: 3
+    image: starrocks/cn-ubuntu:latest
+    storageVolumes:
+      - name: cn-data
+        storageClassName: local-nvme
+        storageSize: 500Gi
+        mountPath: /opt/starrocks/cn/storage
+        ephemeral: true
+      - name: cn-log
+        storageClassName: gp3
+        storageSize: 20Gi
+        mountPath: /opt/starrocks/cn/log
+```
+
+Here `cn-log` stays in `volumeClaimTemplates` and `cn-data` does not.
+
+Supported on `starRocksFeSpec`, `starRocksBeSpec`, `starRocksCnSpec`, and `starRocksFeProxySpec`.
+FE metadata and, in a shared-nothing cluster, BE tablet replicas are not caches: making them
+ephemeral means every replacement pod starts from an empty disk.
+
+`emptyDir`, `hostPath` and `csi` volumes are not backed by a PersistentVolumeClaim, so `ephemeral`
+does not apply to them. Combining them, through `storageClassName` or through a `hostPath` or `csi`
+block, is rejected with `ephemeral can not be used together with emptyDir, hostPath or csi`.
+
+## 2. By Helm chart
+
+`storageSpec` exposes `storageEphemeral` for the data volumes and `spillEphemeral` for the spill
+volume, on `starrocksCnSpec` and `starrocksBeSpec`:
+
+```yaml
+starrocksCnSpec:
+  storageSpec:
+    name: cn
+    storageClassName: local-nvme
+    storageSize: 500Gi
+    storageEphemeral: true
+    spillStorageSize: 200Gi
+    spillEphemeral: true
+    logStorageClassName: gp3
+```
+
+`logStorageClassName` falls back to `storageClassName` when it is empty. Left on the local class,
+the log volume stays a `volumeClaimTemplate` with node affinity and keeps the pod bound to one
+node, so give it a class of its own, or set `logStorageSize: 0Gi` to mount an `emptyDir` and
+provision nothing.
+
+When using the parent `kube-starrocks` chart, nest this under the `starrocks:` key.
+
+## 3. Verifying
+
+Deploy the cluster, then look at where each claim came from:
+
+```bash
+kubectl get statefulset starrockscluster-sample-cn -o jsonpath='{.spec.volumeClaimTemplates[*].metadata.name}'
+```
+
+Expected: `cn-log` only.
+
+```bash
+kubectl get pvc -o custom-columns=NAME:.metadata.name,OWNER:.metadata.ownerReferences[*].kind
+```
+
+Expected, for `cn-0`, and the same pair for every other pod:
+
+```
+NAME                                   OWNER
+cn-log-starrockscluster-sample-cn-0    <none>
+starrockscluster-sample-cn-0-cn-data   Pod
+```
+
+The second claim is owned by the pod, so deleting the pod deletes it, while the `cn-log` claim
+stays. The replacement pod gets a new claim of its own.
+
+## 4. Changing a volume after it is deployed
+
+`storageSize` of an ephemeral volume can be changed. The claim template lives in the pod template,
+which the operator is free to update, so the change rolls the pods and every new pod gets a claim
+at the new size. The same change on a `volumeClaimTemplate` is rejected by Kubernetes, and the
+operator reports it in `status.reason`, which ends with:
+
+```
+Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
+```
+
+Turning `ephemeral` on or off for a volume that is already deployed hits that same error, because
+it adds or removes a `volumeClaimTemplate`. Apply the change to the StarRocksCluster first, then
+delete the StatefulSet with `--cascade=orphan`: the operator finds none on the next reconcile,
+creates it from the current spec, adopts the running pods and rolls them onto the new template.
+In the other order the operator recreates the StatefulSet from the old spec before there is
+anything new to apply. The PersistentVolumeClaims the old template created survive that delete,
+so remove them once the pods no longer use them.

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/templates/starrockscluster.yaml
@@ -553,17 +553,24 @@ spec:
     {{- $storageClassName := .Values.starrocksBeSpec.storageSpec.storageClassName -}}
     {{- $storageSize := .Values.starrocksBeSpec.storageSpec.storageSize -}}
     {{- $storageMountPath := include "starrockscluster.be.data.path" . -}}
+    {{- $storageEphemeral := .Values.starrocksBeSpec.storageSpec.storageEphemeral -}}
     {{- range $i, $e := until (int .Values.starrocksBeSpec.storageSpec.storageCount) }}
     - name: {{ $storageName }}{{ $i }}{{template "starrockscluster.be.data.suffix" . }}
       storageClassName: {{ $storageClassName }}
       storageSize: "{{ $storageSize }}"
       mountPath: {{ $storageMountPath }}{{ $i }}
+      {{- if $storageEphemeral }}
+      ephemeral: {{ $storageEphemeral }}
+      {{- end }}
     {{- end }}
     {{- else}}
     - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.data.suffix" . }}
       storageClassName: {{ .Values.starrocksBeSpec.storageSpec.storageClassName }}
       storageSize: "{{ .Values.starrocksBeSpec.storageSpec.storageSize }}"
       mountPath: {{template "starrockscluster.be.data.path" . }}
+      {{- if .Values.starrocksBeSpec.storageSpec.storageEphemeral }}
+      ephemeral: {{ .Values.starrocksBeSpec.storageSpec.storageEphemeral }}
+      {{- end }}
     {{- end }}
     - name: {{ .Values.starrocksBeSpec.storageSpec.name }}{{template "starrockscluster.be.log.suffix" . }}
       {{- if .Values.starrocksBeSpec.storageSpec.logStorageClassName }}
@@ -581,6 +588,9 @@ spec:
       {{- end }}
       storageSize: "{{ .Values.starrocksBeSpec.storageSpec.spillStorageSize}}"
       mountPath: {{template "starrockscluster.be.spill.path" . }}
+      {{- if .Values.starrocksBeSpec.storageSpec.spillEphemeral }}
+      ephemeral: {{ .Values.starrocksBeSpec.storageSpec.spillEphemeral }}
+      {{- end }}
     {{- end }}
     {{- if .Values.starrocksBeSpec.emptyDirs }}
     {{- range .Values.starrocksBeSpec.emptyDirs }}
@@ -878,17 +888,24 @@ spec:
     {{- $storageClassName := .Values.starrocksCnSpec.storageSpec.storageClassName -}}
     {{- $storageSize := .Values.starrocksCnSpec.storageSpec.storageSize -}}
     {{- $storageMountPath := include "starrockscluster.cn.data.path" . -}}
+    {{- $storageEphemeral := .Values.starrocksCnSpec.storageSpec.storageEphemeral -}}
     {{- range $i, $e := until (int .Values.starrocksCnSpec.storageSpec.storageCount) }}
     - name: {{ $storageName }}{{ $i }}{{template "starrockscluster.cn.data.suffix" . }}
       storageClassName: {{ $storageClassName }}
       storageSize: "{{ $storageSize }}"
       mountPath: {{ $storageMountPath }}{{ $i }}
+      {{- if $storageEphemeral }}
+      ephemeral: {{ $storageEphemeral }}
+      {{- end }}
     {{- end }}
     {{- else }}
     - name: {{ .Values.starrocksCnSpec.storageSpec.name }}{{template "starrockscluster.cn.data.suffix" . }}
       storageClassName: {{ .Values.starrocksCnSpec.storageSpec.storageClassName }}
       storageSize: "{{ .Values.starrocksCnSpec.storageSpec.storageSize }}"
       mountPath: {{template "starrockscluster.cn.data.path" . }}
+      {{- if .Values.starrocksCnSpec.storageSpec.storageEphemeral }}
+      ephemeral: {{ .Values.starrocksCnSpec.storageSpec.storageEphemeral }}
+      {{- end }}
     {{- end }}
     - name: {{ .Values.starrocksCnSpec.storageSpec.name }}{{template "starrockscluster.cn.log.suffix" . }}
       {{- if .Values.starrocksCnSpec.storageSpec.logStorageClassName }}
@@ -906,6 +923,9 @@ spec:
       {{- end }}
       storageSize: "{{ .Values.starrocksCnSpec.storageSpec.spillStorageSize}}"
       mountPath: {{template "starrockscluster.cn.spill.path" . }}
+      {{- if .Values.starrocksCnSpec.storageSpec.spillEphemeral }}
+      ephemeral: {{ .Values.starrocksCnSpec.storageSpec.spillEphemeral }}
+      {{- end }}
     {{- end }}
     {{- if .Values.starrocksCnSpec.emptyDirs }}
     {{- range .Values.starrocksCnSpec.emptyDirs }}

--- a/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml
@@ -749,6 +749,11 @@ starrocksCnSpec:
     storageCount: 1
     # see the comment of storageCount for the usage of storageMountPath.
     storageMountPath: ""
+    # If true, the volumes for data are mounted as generic ephemeral volumes: the PersistentVolumeClaim
+    # is declared in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions
+    # a new volume where it is scheduled.
+    # A CN keeps only cached data locally, so what is lost is rebuilt from object storage on the next read.
+    storageEphemeral: false
     # If not set will use the value of the storageClassName field.
     logStorageClassName: ""
     # The storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
@@ -766,6 +771,9 @@ starrocksCnSpec:
     # If spillMountPath is empty, the spillMountPath will be set to /opt/starrocks/cn/spill.
     # If spillMountPath is not /opt/starrocks/cn/spill, you must add in config the following configuration: spill_local_storage_dir = xxx.
     spillMountPath: ""
+    # If true, the volume for spill is mounted as a generic ephemeral volume. Spilled data belongs to a
+    # running query and is never read again once the pod is gone.
+    spillEphemeral: false
   # mount emptyDir volumes if necessary.
   # Note: please use storageSpec field for persistent storage data and log.
   emptyDirs: []
@@ -1103,6 +1111,13 @@ starrocksBeSpec:
     storageCount: 1
     # see the comment of storageCount for the usage of storageMountPath.
     storageMountPath: ""
+    # If true, the volumes for data are mounted as generic ephemeral volumes: the PersistentVolumeClaim
+    # is declared in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions
+    # a new volume where it is scheduled.
+    # In a shared-nothing cluster a BE holds tablet replicas locally, and enabling this makes every
+    # replacement pod start from an empty disk. It is meant for a shared-data cluster, where a BE only
+    # caches data that lives in object storage.
+    storageEphemeral: false
     # If not set will use the value of the storageClassName field.
     logStorageClassName: ""
     # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
@@ -1120,6 +1135,9 @@ starrocksBeSpec:
     # If spillMountPath is empty, the spillMountPath will be set to /opt/starrocks/be/spill.
     # If spillMountPath is not /opt/starrocks/be/spill, you must add in config the following configuration: spill_local_storage_dir = xxx.
     spillMountPath: ""
+    # If true, the volume for spill is mounted as a generic ephemeral volume. Spilled data belongs to a
+    # running query and is never read again once the pod is gone.
+    spillEphemeral: false
   # mount emptyDir volumes if necessary.
   # Note: please use storageSpec field for persistent storage data and log.
   emptyDirs: []

--- a/helm-charts/charts/kube-starrocks/values.yaml
+++ b/helm-charts/charts/kube-starrocks/values.yaml
@@ -888,6 +888,11 @@ starrocks:
       storageCount: 1
       # see the comment of storageCount for the usage of storageMountPath.
       storageMountPath: ""
+      # If true, the volumes for data are mounted as generic ephemeral volumes: the PersistentVolumeClaim
+      # is declared in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions
+      # a new volume where it is scheduled.
+      # A CN keeps only cached data locally, so what is lost is rebuilt from object storage on the next read.
+      storageEphemeral: false
       # If not set will use the value of the storageClassName field.
       logStorageClassName: ""
       # The storage size of persistent volume for log, and the mount path is /opt/starrocks/cn/log.
@@ -905,6 +910,9 @@ starrocks:
       # If spillMountPath is empty, the spillMountPath will be set to /opt/starrocks/cn/spill.
       # If spillMountPath is not /opt/starrocks/cn/spill, you must add in config the following configuration: spill_local_storage_dir = xxx.
       spillMountPath: ""
+      # If true, the volume for spill is mounted as a generic ephemeral volume. Spilled data belongs to a
+      # running query and is never read again once the pod is gone.
+      spillEphemeral: false
     # mount emptyDir volumes if necessary.
     # Note: please use storageSpec field for persistent storage data and log.
     emptyDirs: []
@@ -1242,6 +1250,13 @@ starrocks:
       storageCount: 1
       # see the comment of storageCount for the usage of storageMountPath.
       storageMountPath: ""
+      # If true, the volumes for data are mounted as generic ephemeral volumes: the PersistentVolumeClaim
+      # is declared in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions
+      # a new volume where it is scheduled.
+      # In a shared-nothing cluster a BE holds tablet replicas locally, and enabling this makes every
+      # replacement pod start from an empty disk. It is meant for a shared-data cluster, where a BE only
+      # caches data that lives in object storage.
+      storageEphemeral: false
       # If not set will use the value of the storageClassName field.
       logStorageClassName: ""
       # Setting this parameter can persist log storage, and the mount path is /opt/starrocks/be/log.
@@ -1259,6 +1274,9 @@ starrocks:
       # If spillMountPath is empty, the spillMountPath will be set to /opt/starrocks/be/spill.
       # If spillMountPath is not /opt/starrocks/be/spill, you must add in config the following configuration: spill_local_storage_dir = xxx.
       spillMountPath: ""
+      # If true, the volume for spill is mounted as a generic ephemeral volume. Spilled data belongs to a
+      # running query and is never read again once the pod is gone.
+      spillEphemeral: false
     # mount emptyDir volumes if necessary.
     # Note: please use storageSpec field for persistent storage data and log.
     emptyDirs: []

--- a/pkg/apis/starrocks/v1/starrockscluster_types.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types.go
@@ -453,6 +453,14 @@ type StorageVolume struct {
 	// +optional
 	CSI *corev1.CSIVolumeSource `json:"csi,omitempty"`
 
+	// Ephemeral makes this volume a generic ephemeral volume: its PersistentVolumeClaim is declared
+	// in the pod spec, owned by the pod and deleted with it, so a replacement pod provisions a new
+	// volume. StorageClassName and StorageSize still apply, but the data does not outlive the pod,
+	// so use it for a cache or a spill directory. It can not be set with emptyDir, hostPath or csi.
+	// More info: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+	// +optional
+	Ephemeral bool `json:"ephemeral,omitempty"`
+
 	// MountPath specify the path of volume mount.
 	MountPath string `json:"mountPath"`
 
@@ -478,7 +486,12 @@ var (
 	ErrCSIStorageClass = errors.New(`if csi is set, storageClassName must be empty or "csi"`)
 )
 
+var ErrEphemeralConflict = errors.New("ephemeral can not be used together with emptyDir, hostPath or csi")
+
 func (storageVolume *StorageVolume) Validate() error {
+	if err := storageVolume.validateEphemeral(); err != nil {
+		return err
+	}
 	if err := storageVolume.validateCSI(); err != nil {
 		return err
 	}
@@ -517,6 +530,26 @@ func (storageVolume *StorageVolume) validateCSI() error {
 	}
 	if storageVolume.CSI == nil || storageVolume.CSI.Driver == "" {
 		return ErrCSIRequired
+	}
+	return nil
+}
+
+// validateEphemeral rejects ephemeral together with emptyDir, hostPath or csi. Those render a volume
+// source that is not a PersistentVolumeClaim, so the flag would otherwise be dropped silently.
+func (storageVolume *StorageVolume) validateEphemeral() error {
+	if !storageVolume.Ephemeral {
+		return nil
+	}
+	if storageVolume.HostPath != nil || storageVolume.CSI != nil {
+		return ErrEphemeralConflict
+	}
+	if storageVolume.StorageClassName == nil {
+		return nil
+	}
+	for _, name := range []string{EmptyDir, HostPath, CSI} {
+		if strings.EqualFold(*storageVolume.StorageClassName, name) {
+			return ErrEphemeralConflict
+		}
 	}
 	return nil
 }

--- a/pkg/apis/starrocks/v1/starrockscluster_types_test.go
+++ b/pkg/apis/starrocks/v1/starrockscluster_types_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestStorageVolumeValidate(t *testing.T) {
 	hostPathClass := HostPath
+	hostPathClassUpper := "HostPath"
 	otherClass := "standard"
 	csiClass := CSI
 	csiClassUpper := "CSI"
@@ -118,6 +119,48 @@ func TestStorageVolumeValidate(t *testing.T) {
 				HostPath:         &corev1.HostPathVolumeSource{Path: "/data"},
 			},
 			wantErr: ErrCSIConflict,
+		},
+		{
+			name:    "ephemeral with a real storage class is valid",
+			volume:  StorageVolume{StorageClassName: &otherClass, Ephemeral: true},
+			wantErr: nil,
+		},
+		{
+			name:    "ephemeral without a storage class is valid",
+			volume:  StorageVolume{Ephemeral: true},
+			wantErr: nil,
+		},
+		{
+			name:    "ephemeral with emptyDir class is invalid",
+			volume:  StorageVolume{StorageClassName: &emptyDirClass, Ephemeral: true},
+			wantErr: ErrEphemeralConflict,
+		},
+		{
+			name:    "ephemeral with hostPath class is invalid, case insensitively",
+			volume:  StorageVolume{StorageClassName: &hostPathClassUpper, Ephemeral: true},
+			wantErr: ErrEphemeralConflict,
+		},
+		{
+			name:    "ephemeral with csi class is invalid",
+			volume:  StorageVolume{StorageClassName: &csiClass, Ephemeral: true},
+			wantErr: ErrEphemeralConflict,
+		},
+		{
+			name: "ephemeral with hostPath is invalid",
+			volume: StorageVolume{
+				HostPath:  &corev1.HostPathVolumeSource{Path: "/data"},
+				Ephemeral: true,
+			},
+			wantErr: ErrEphemeralConflict,
+		},
+		{
+			name: "ephemeral with csi is invalid",
+			volume: StorageVolume{
+				StorageClassName: &csiClass,
+				CSI:              &corev1.CSIVolumeSource{Driver: "csi.spiffe.io"},
+				Ephemeral:        true,
+			},
+			wantErr: ErrEphemeralConflict,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/k8sutils/templates/pod/mount.go
+++ b/pkg/k8sutils/templates/pod/mount.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/StarRocks/starrocks-kubernetes-operator/cmd/config"
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
@@ -39,6 +40,7 @@ func SpecialStorageClassName(sv v1.StorageVolume) string {
 
 // MountStorageVolumes parse StorageVolumes from spec and mount them to pod.
 // If StorageClassName is EmptyDir, mount an emptyDir volume to pod.
+// If Ephemeral is true, mount a generic ephemeral volume to pod.
 func MountStorageVolumes(spec v1.SpecInterface) ([]corev1.Volume, []corev1.VolumeMount) {
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
@@ -54,7 +56,12 @@ func MountStorageVolumes(spec v1.SpecInterface) ([]corev1.Volume, []corev1.Volum
 		case v1.CSI:
 			volumes, volumeMounts = MountCSIVolume(volumes, volumeMounts, sv.Name, sv.MountPath, sv.SubPath, sv.CSI)
 		default:
-			volumes, volumeMounts = MountPersistentVolumeClaim(volumes, volumeMounts, sv.Name, sv.MountPath, sv.SubPath)
+			if sv.Ephemeral {
+				volumes, volumeMounts = MountEphemeralVolume(volumes, volumeMounts, sv.Name, sv.MountPath, sv.SubPath,
+					PersistentVolumeClaimSpec(sv))
+			} else {
+				volumes, volumeMounts = MountPersistentVolumeClaim(volumes, volumeMounts, sv.Name, sv.MountPath, sv.SubPath)
+			}
 		}
 		// ReadOnly is applied here rather than inside each Mount* helper: those helpers are also
 		// called directly by the component pod builders to mount the log and meta directories,
@@ -74,6 +81,48 @@ func MountPersistentVolumeClaim(volumes []corev1.Volume, volumeMounts []corev1.V
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: volumeName,
+			},
+		},
+	})
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: mountPath,
+		SubPath:   subPath,
+	})
+	return volumes, volumeMounts
+}
+
+// PersistentVolumeClaimSpec builds the claim a storage volume asks for. The StatefulSet declares
+// it as a volumeClaimTemplate, and a generic ephemeral volume declares it in the pod spec.
+func PersistentVolumeClaimSpec(sv v1.StorageVolume) corev1.PersistentVolumeClaimSpec {
+	spec := corev1.PersistentVolumeClaimSpec{
+		AccessModes: []corev1.PersistentVolumeAccessMode{
+			corev1.ReadWriteOnce,
+		},
+		StorageClassName: sv.StorageClassName,
+	}
+	if sv.StorageSize != "" {
+		spec.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse(sv.StorageSize),
+			},
+		}
+	}
+	return spec
+}
+
+// MountEphemeralVolume mounts a generic ephemeral volume into the pod. The claim template is part of
+// the pod spec, so the PersistentVolumeClaim is created with the pod and deleted with it.
+func MountEphemeralVolume(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount,
+	volumeName string, mountPath string, subPath string,
+	claim corev1.PersistentVolumeClaimSpec) ([]corev1.Volume, []corev1.VolumeMount) {
+	volumes = append(volumes, corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			Ephemeral: &corev1.EphemeralVolumeSource{
+				VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+					Spec: claim,
+				},
 			},
 		},
 	})

--- a/pkg/k8sutils/templates/pod/mount_test.go
+++ b/pkg/k8sutils/templates/pod/mount_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/StarRocks/starrocks-kubernetes-operator/cmd/config"
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
@@ -329,6 +330,13 @@ func TestMountStorageVolumes(t *testing.T) {
 									ReadOnly:         true,
 								},
 								{
+									Name:             "ro-ephemeral",
+									MountPath:        "/ro-ephemeral",
+									StorageClassName: func() *string { s := "gp3"; return &s }(),
+									Ephemeral:        true,
+									ReadOnly:         true,
+								},
+								{
 									Name:      "rw-csi",
 									MountPath: "/rw-csi",
 									CSI:       &corev1.CSIVolumeSource{Driver: "csi.spiffe.io"},
@@ -358,6 +366,19 @@ func TestMountStorageVolumes(t *testing.T) {
 					},
 				},
 				{
+					Name: "ro-ephemeral",
+					VolumeSource: corev1.VolumeSource{
+						Ephemeral: &corev1.EphemeralVolumeSource{
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+									StorageClassName: func() *string { s := "gp3"; return &s }(),
+								},
+							},
+						},
+					},
+				},
+				{
 					Name:         "rw-csi",
 					VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{Driver: "csi.spiffe.io"}},
 				},
@@ -367,7 +388,72 @@ func TestMountStorageVolumes(t *testing.T) {
 				{Name: "ro-emptydir", MountPath: "/ro-emptydir", ReadOnly: true},
 				{Name: "ro-hostpath", MountPath: "/ro-hostpath", ReadOnly: true},
 				{Name: "ro-pvc", MountPath: "/ro-pvc", ReadOnly: true},
+				{Name: "ro-ephemeral", MountPath: "/ro-ephemeral", ReadOnly: true},
 				{Name: "rw-csi", MountPath: "/rw-csi"},
+			},
+		},
+		{
+			name: "storage volume with ephemeral",
+			args: args{
+				spec: &v1.StarRocksCnSpec{
+					StarRocksComponentSpec: v1.StarRocksComponentSpec{
+						StarRocksLoadSpec: v1.StarRocksLoadSpec{
+							StorageVolumes: []v1.StorageVolume{
+								{
+									Name:             "cache",
+									MountPath:        "/opt/starrocks/cn/storage",
+									StorageClassName: func() *string { s := "sc1"; return &s }(),
+									StorageSize:      "1Gi",
+									Ephemeral:        true,
+								},
+								{
+									Name:             "cache-no-size",
+									MountPath:        "/opt/starrocks/cn/spill",
+									SubPath:          "sub",
+									StorageClassName: func() *string { s := "sc1"; return &s }(),
+									Ephemeral:        true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []corev1.Volume{
+				{
+					Name: "cache",
+					VolumeSource: corev1.VolumeSource{
+						Ephemeral: &corev1.EphemeralVolumeSource{
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+									StorageClassName: func() *string { s := "sc1"; return &s }(),
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceStorage: resource.MustParse("1Gi"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "cache-no-size",
+					VolumeSource: corev1.VolumeSource{
+						Ephemeral: &corev1.EphemeralVolumeSource{
+							VolumeClaimTemplate: &corev1.PersistentVolumeClaimTemplate{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+									StorageClassName: func() *string { s := "sc1"; return &s }(),
+								},
+							},
+						},
+					},
+				},
+			},
+			want1: []corev1.VolumeMount{
+				{Name: "cache", MountPath: "/opt/starrocks/cn/storage"},
+				{Name: "cache-no-size", MountPath: "/opt/starrocks/cn/spill", SubPath: "sub"},
 			},
 		},
 	}

--- a/pkg/k8sutils/templates/statefulset/spec.go
+++ b/pkg/k8sutils/templates/statefulset/spec.go
@@ -19,7 +19,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/StarRocks/starrocks-kubernetes-operator/pkg/apis/starrocks/v1"
@@ -37,26 +36,17 @@ func PVCList(volumes []v1.StorageVolume) []corev1.PersistentVolumeClaim {
 		if name := pod.SpecialStorageClassName(vm); name != "" {
 			continue
 		}
+		// a generic ephemeral volume declares its claim in the pod spec, not here
+		if vm.Ephemeral {
+			continue
+		}
 		if strings.HasPrefix(vm.StorageSize, "0") {
 			continue
 		}
-		pvc := corev1.PersistentVolumeClaim{
+		pvcs = append(pvcs, corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{Name: vm.Name},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{
-					corev1.ReadWriteOnce,
-				},
-				StorageClassName: vm.StorageClassName,
-			},
-		}
-		if vm.StorageSize != "" {
-			pvc.Spec.Resources = corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(vm.StorageSize),
-				},
-			}
-		}
-		pvcs = append(pvcs, pvc)
+			Spec:       pod.PersistentVolumeClaimSpec(vm),
+		})
 	}
 	return pvcs
 }

--- a/pkg/k8sutils/templates/statefulset/spec_test.go
+++ b/pkg/k8sutils/templates/statefulset/spec_test.go
@@ -84,6 +84,42 @@ func TestMakePVCList(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "ephemeral volume is skipped, the rest of the list is not",
+			args: args{
+				volumes: []v1.StorageVolume{
+					{
+						Name:             "cache",
+						StorageClassName: func() *string { name := "test"; return &name }(),
+						StorageSize:      "1Gi",
+						MountPath:        "/opt/starrocks/cn/storage",
+						Ephemeral:        true,
+					},
+					{
+						Name:             "log",
+						StorageClassName: func() *string { name := "test"; return &name }(),
+						StorageSize:      "1Gi",
+						MountPath:        "/opt/starrocks/cn/log",
+					},
+				},
+			},
+			want: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "log"},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						StorageClassName: &[]string{"test"}[0],
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/subcontrollers/feproxy/feproxy_controller_validating_test.go
+++ b/pkg/subcontrollers/feproxy/feproxy_controller_validating_test.go
@@ -93,6 +93,24 @@ func TestFeProxyController_validating(t *testing.T) {
 			wantErrIs: srapi.ErrHostPathRequired,
 		},
 		{
+			name: "ephemeral on a hostPath volume returns ErrEphemeralConflict",
+			feProxySpec: &srapi.StarRocksFeProxySpec{
+				StarRocksLoadSpec: srapi.StarRocksLoadSpec{
+					StorageVolumes: []srapi.StorageVolume{
+						{
+							Name:             "cache",
+							StorageClassName: &hostPathStorageClass,
+							MountPath:        "/cache",
+							HostPath:         &corev1.HostPathVolumeSource{Path: "/cache"},
+							Ephemeral:        true,
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			wantErrIs: srapi.ErrEphemeralConflict,
+		},
+		{
 			name: "no storage volumes still validates the service as before",
 			feProxySpec: &srapi.StarRocksFeProxySpec{
 				StarRocksLoadSpec: srapi.StarRocksLoadSpec{


### PR DESCRIPTION
# Description

A CN in a shared-data cluster keeps its data cache on local disk, and BE and CN spill there. Both
want a dedicated disk of a declared size, one per pod, holding data that can be rebuilt. Today a
`storageVolumes` entry with a storage class becomes a `volumeClaimTemplate` of the StatefulSet,
and that claim outlives the pod on purpose. This PR adds one flag to `StorageVolume`:

```yaml
storageVolumes:
  - name: cn-data
    storageClassName: local-nvme
    storageSize: 500Gi
    mountPath: /opt/starrocks/cn/storage
    ephemeral: true
```

The volume keeps its storage class and size, but the claim is declared in the pod spec as a
[generic ephemeral volume](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes)
instead of in `volumeClaimTemplates`: Kubernetes creates the PersistentVolumeClaim with the pod,
names it `<pod>-<volume>`, deletes it with the pod, and a replacement pod provisions a new volume
where it is scheduled. A reserved `storageClassName` would not fit here: `emptyDir`, `hostPath`
and `csi` (#786) all do without a claim, while an ephemeral volume still needs a real storage
class to provision from.

Observed on a three-worker cluster (Kubernetes v1.30.4) running this branch, with two CRs that
differ only in `ephemeral`, on a local-path `WaitForFirstConsumer` class:

| Scenario | `volumeClaimTemplates` (today) | `ephemeral: true` |
| --- | --- | --- |
| The pod's node is cordoned and the pod deleted (#419) | stays `Pending` | `Running` on another node, on a new empty volume |
| `storageSize` is raised from 1Gi to 2Gi (#121, #617) | cluster `failed`, `Forbidden` | rolling update, the new pod claims 2Gi |

Row 1: a local PersistentVolume carries node affinity, so the replacement pod can only bind to
the node that is gone. `persistentVolumeClaimRetentionPolicy` does not help: it deletes claims
when the StatefulSet is deleted or scaled down, not when a pod is rescheduled.

Row 2: `volumeClaimTemplates` is immutable, so the update fails and `status.reason` reports:

```
error from CN controller: failed to apply merge patch: StatefulSet.apps "pinned-cn" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
```

An ephemeral claim sits in `spec.template`, which is mutable. This is not in-place expansion: the
change rolls the pods and each new pod claims the new size.

What this PR changes:

- `pod.MountStorageVolumes` renders an `ephemeral` volume through the new `MountEphemeralVolume`
  and `statefulset.PVCList` skips it, so the claim is declared once. Both build it with
  `pod.PersistentVolumeClaimSpec`, lifted out of `PVCList`.
- Validation rejects `ephemeral` together with `emptyDir`, `hostPath` or `csi`, given as
  `storageClassName` (case insensitive, like the reserved values themselves) or as a block:
  those render no claim, so the flag would be dropped silently.
- Helm: `storageSpec.storageEphemeral` for the data volumes and `storageSpec.spillEphemeral` for
  the spill volume, on `starrocksCnSpec` and `starrocksBeSpec`.
- Docs: `doc/mount_ephemeral_volumes_howto.md`, linked from `doc/README.md`.

The operator change is under a hundred lines; the rest is tests, chart values, the how-to and
generated CRD yaml.

`ephemeral` defaults to false, so no existing spec renders differently. Like `csi`, it reaches
all four component specs and `StarRocksWarehouse` through the shared `StorageVolume` type.
Generic ephemeral volumes are GA since Kubernetes 1.23, the chart's `kubeVersion` floor. Turning
`ephemeral` on or off on a deployed volume hits the same `Forbidden` as any other
`volumeClaimTemplates` change; the how-to gives the `--cascade=orphan` path out.

To see it on a cluster, apply the sample CR from the how-to and check where each claim comes from:

```bash
# expected: cn-log
kubectl get statefulset starrockscluster-sample-cn -o jsonpath='{.spec.volumeClaimTemplates[*].metadata.name}'
# expected: starrockscluster-sample-cn-0-cn-data owned by Pod, cn-log-starrockscluster-sample-cn-0 by <none>
kubectl get pvc -o custom-columns=NAME:.metadata.name,OWNER:.metadata.ownerReferences[*].kind
```

# Related Issue(s)

- #121 (open) and #617 (open): `storageSize` cannot be changed once the cluster exists. With
  `ephemeral` it can, for the volumes that carry the flag, by re-provisioning rather than
  expanding.
- #419: a CN cache on NVMe instance storage; the reporter fell back to a local volume provisioner,
  which "breaks auto-scaling". Closed by #451 with `hostPath`.

# Checklist

For operator, please complete the following checklist:

- [x] run `make generate` to generate the code.
- [x] run `make lint` to check the code style.
- [x] run `make test` to run UT.
- [x] run `make manifests` to update the yaml files of CRD.

For helm chart, please complete the following checklist:

- [x] make sure you have updated the [values.yaml](../helm-charts/charts/kube-starrocks/charts/starrocks/values.yaml)
  file of starrocks chart.
- [x] In `scripts` directory, run `bash create-parent-chart-values.sh` to update the values.yaml file of the parent
  chart( kube-starrocks chart).
